### PR TITLE
fix: remove wasm-opt from build step

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -18,7 +18,7 @@ inputs:
     default: "true"
 
   cross_compile:
-    description: "Install the cross-compile toolchain (cargo-zigbuild + zig as the cross linker). Release workflows that produce linux/amd64 + linux/arm64 artifacts from a single runner set this to 'true'. binaryen for wasm-opt is installed unconditionally — it's needed by `just wasm` whenever the SSR rivers-ui binary is built, and the apt install is cheap."
+    description: "Install the cross-compile toolchain (cargo-zigbuild + zig as the cross linker). Release workflows that produce linux/amd64 + linux/arm64 artifacts from a single runner set this to 'true'."
     required: false
     default: "false"
 
@@ -66,16 +66,12 @@ runs:
         # Save partial compilation
         cache-on-failure: "true"
 
-    - name: Install protoc + binaryen
+    - name: Install protoc
       shell: bash
       run: |
         set -euo pipefail
         sudo apt-get update -qq
-        # binaryen ships `wasm-opt`, used by `just wasm` to optimize the
-        # rivers-ui hydration WASM. Cheap (~5s) so we install it on every
-        # run rather than gating on a flag — gating proved fragile.
-        sudo apt-get install -y -qq protobuf-compiler binaryen
-        wasm-opt --version
+        sudo apt-get install -y -qq protobuf-compiler
 
     # wasm-bindgen-cli is used by `just wasm` / `just wasm-dev` (driven directly
     # so we can pass a custom cargo profile — wasm-pack can't)

--- a/.github/workflows/python_build.yaml
+++ b/.github/workflows/python_build.yaml
@@ -113,8 +113,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Build and install rivers
-        # Python tests don't need the optimized UI bundle; develop-fast
-        # skips wasm-opt to save a few seconds in CI.
+        # Python tests don't need the release UI bundle; develop-fast
+        # builds the WASM dev-profile to save a few seconds in CI.
         run: just develop-fast
 
       - name: Run tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ For larger changes, please open an [issue](https://github.com/ion-elgreco/rivers
 
 Optional, only for specific recipes:
 
-- `wasm-pack`, `wasm-bindgen`, `binaryen` (`wasm-opt`) — for `just develop` (release WASM)
+- `wasm-pack`, `wasm-bindgen` — for `just develop` (release WASM)
 - `helm` + the [`helm-unittest`](https://github.com/helm-unittest/helm-unittest) plugin — for `just test-helm`
 - `cargo-zigbuild` — for cross-compiling K8s images on macOS
 
@@ -28,7 +28,7 @@ cd rivers
 just develop-fast
 ```
 
-`just develop-fast` is the default for day-to-day work — it skips `wasm-opt` and embeds an unoptimized WASM blob (~187 MB). It is **not** suitable for shipping or for K8s images. For UI release builds or anything you'd publish, use `just develop` instead (requires `binaryen`).
+`just develop-fast` is the default for day-to-day work — it builds the WASM with the dev cargo profile (preserves panic symbols, larger blob, much faster rebuilds). It is **not** suitable for shipping or for K8s images. For UI release builds or anything you'd publish, use `just develop` instead.
 
 After the first build, the editable wheel is installed into `.venv`. Re-run `just develop-fast` whenever you change Rust code; pure-Python edits don't need a rebuild.
 

--- a/justfile
+++ b/justfile
@@ -18,14 +18,12 @@ _default:
 venv:
     uv sync --no-install-workspace --all-extras
 
-# Build the UI's hydration WASM (release) and shrink it in-place with wasm-opt -Oz (requires binaryen)
+# Build the UI's hydration WASM (release).
 wasm:
     cargo build -p rivers-ui --target wasm32-unknown-unknown --release --no-default-features --features hydrate
     wasm-bindgen target/wasm32-unknown-unknown/release/rivers_ui.wasm --out-dir rust/rivers-ui/pkg --target web --no-typescript
-    # --all-features: rustc emits bulk-memory / sign-ext / nontrapping-float-to-int ops that wasm-opt rejects by default
-    wasm-opt -Oz --all-features -o rust/rivers-ui/pkg/rivers_ui_bg.wasm rust/rivers-ui/pkg/rivers_ui_bg.wasm
 
-# Build WASM in dev mode — preserves panic messages/symbols for debugging (no wasm-opt).
+# Build WASM in dev mode — preserves panic messages/symbols for debugging.
 # Honors $PROFILE so host build-deps (proc-macros, build.rs deps) land in the same
 # `target/<profile>/` dir as the follow-up `maturin develop --profile $PROFILE`,
 # letting the two steps share artifacts. wasm-pack hardcodes `dev`/`release` and
@@ -35,11 +33,11 @@ wasm-dev:
     cargo build -p rivers-ui --target wasm32-unknown-unknown --profile {{ profile }} --no-default-features --features hydrate
     wasm-bindgen target/wasm32-unknown-unknown/{{ profile_dir }}/rivers_ui.wasm --out-dir rust/rivers-ui/pkg --target web --no-typescript
 
-# Build and install rivers as editable (release WASM, shrunk via wasm-opt — use for UI work or shipping)
+# Build and install rivers as editable (release WASM — use for UI work or shipping)
 develop: venv wasm
     cd python && VIRTUAL_ENV={{ justfile_directory() }}/.venv uvx --from 'maturin[zig]' maturin develop --profile {{ profile }}
 
-# Faster develop for non-UI work — skips wasm-opt; embeds ~187 MB unoptimized blob (don't use for k8s/release)
+# Faster develop for non-UI work — dev-profile WASM build (preserves panic symbols, larger blob; don't use for k8s/release)
 develop-fast: venv wasm-dev
     cd python && VIRTUAL_ENV={{ justfile_directory() }}/.venv uvx --from 'maturin[zig]' maturin develop --profile {{ profile }}
 
@@ -53,7 +51,7 @@ test:
 
 # Run all Rust workspace tests.
 # - `wasm-dev` is a prerequisite so rivers-ui's `include_bytes!("../pkg/...")`
-#   can resolve when the crate is built with `ssr` (no wasm-opt = faster).
+#   can resolve when the crate is built with `ssr`.
 # - `rivers` (PyO3 cdylib) is excluded; its Rust unit tests need a libpython
 #   link step bare `cargo test` doesn't provide and are exercised indirectly
 #   by the Python test suite.

--- a/rust/rivers-ui/src/lib.rs
+++ b/rust/rivers-ui/src/lib.rs
@@ -251,10 +251,11 @@ mod server {
             )
             .fallback(|| async { (StatusCode::NOT_FOUND, "Not found") })
             .with_state(leptos_options)
-            // application/wasm is already heavily compressed by wasm-opt and
-            // is large; brotli on every fetch pins the runtime worker for
-            // multiple seconds (~2s for the 5 MB optimized blob, even worse
-            // for dev builds). The browser-side gain is minimal — skip it.
+            // application/wasm is large; brotli on every fetch pins the runtime
+            // worker for multiple seconds (~2s for the 5 MB blob, even worse for
+            // dev builds). Release builds precompress to .wasm.br in build.rs and
+            // serve_wasm_bg returns that directly — runtime compression here would
+            // re-do that work for nothing.
             .layer(CompressionLayer::new().br(true).gzip(true).compress_when(
                 DefaultPredicate::new().and(NotForContentType::const_new("application/wasm")),
             ));


### PR DESCRIPTION
# Description
Wasm-opt was generating some types that were not supported, missed that since I was developing mostly with `just develop-fast`
