### PR TITLE
fix: pin SERVER_FN_OVERRIDE_KEY so /api URL hashes match across CI hosts

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,9 @@
 # maxLength assertion with the legacy mangling scheme.
 [build]
 rustflags = ["-C", "symbol-mangling-version=v0"]
+
+# Leptos `#[server]` hashes CARGO_MANIFEST_DIR into each /api/<fn> URL.
+# CI builds WASM and the wheel on different runners (different absolute
+# paths) → client/server hashes mismatch → 404. Pin a stable key.
+[env]
+SERVER_FN_OVERRIDE_KEY = "rivers"


### PR DESCRIPTION
# Description
Leptos `#[server]` hashes CARGO_MANIFEST_DIR into each URL; build-wasm and per-platform wheel jobs run on different runners, so there was a client server mismatch on the url causing 404s :(

So we set a hashing key that will be used across different runners, could also disable the hash but that would potentially cause collision across pages

# Related Issue(s)
- closes https://github.com/ion-elgreco/rivers/issues/19