### PR TITLE
feat(docs): add markdown checks to `pre-commit` using `rumdl`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,15 @@
 # Description
+
 The description of the main changes of your pull request
 
-# Related Issue(s)
+## Related Issue(s)
 <!---
 For example:
 
 - closes #106
 --->
 
-# Documentation
+## Documentation
 
 <!---
 Share links to useful documentation

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
 # rivers Contributor License Agreement
 
-**Version 1.0**
+## Version 1.0
 
 Thank you for your interest in contributing to rivers (the "Project"), maintained by Ion Koutsouris (the "Project Owner"). This Contributor License Agreement ("Agreement") clarifies the intellectual property rights granted with Contributions from any person or entity to the Project. It protects You, the Project Owner, and users of the Project; it does not change Your rights to use Your own Contributions for any other purpose.
 
@@ -78,7 +78,7 @@ git commit -s -m "your message"
 
 This appends a trailer to Your commit message of the form:
 
-```
+```text
 Signed-off-by: Your Name <you@example.com>
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ just demo 1k               # same, but with a 1000-node synthetic graph
 
 ## Project layout
 
-```
+```text
 rust/
   rivers-core/      Pure Rust core: graph, execution plan, storage (SurrealDB + RocksDB)
   rivers-api/       gRPC proto + generated code (shared between Python server and UI)
@@ -125,7 +125,7 @@ git commit -s -m "your message"
 
 That appends a trailer like:
 
-```
+```text
 Signed-off-by: Your Name <you@example.com>
 ```
 

--- a/docs/api-reference/daemon.md
+++ b/docs/api-reference/daemon.md
@@ -121,9 +121,9 @@ At daemon startup, each eval function is classified:
 
 - **`inspect.iscoroutinefunction`** detects async functions
 - Combined with the user's `eval_mode` setting, this determines the dispatch:
-  - **Async in-process**: the coroutine runs automatically on the Python event loop managed from Rust. The GIL is released during `await` points, allowing true I/O concurrency.
-  - **Sync in-process**: the function runs on a dedicated tokio blocking thread, holding the GIL for the duration of the call.
-  - **Subprocess**: the eval function and context data are submitted to a loky process pool. The subprocess reconstructs the context from primitives and calls the function (no resources / config injection available across the boundary).
+    - **Async in-process**: the coroutine runs automatically on the Python event loop managed from Rust. The GIL is released during `await` points, allowing true I/O concurrency.
+    - **Sync in-process**: the function runs on a dedicated tokio blocking thread, holding the GIL for the duration of the call.
+    - **Subprocess**: the eval function and context data are submitted to a loky process pool. The subprocess reconstructs the context from primitives and calls the function (no resources / config injection available across the boundary).
 
 ## API
 

--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -298,10 +298,9 @@ A run/step currently holding pool slots — surfaced by `get_pool_slot_holders()
 | `set_run_outcome(run_id, status, completed_steps, total_steps, message=None)` | `None` | Persist the terminal status of a run (`"Success" \| "Failure" \| "Cancelled"`). |
 | `get_run_progress(run_id)` | `tuple[int, int]` | `(completed_steps, total_steps)` for an in-flight run. |
 
-
 The claim/release methods (`_claim_concurrency_slots`, `_free_concurrency_slots`, `_free_concurrency_slots_for_run`) and the lease management methods (`_renew_slot_lease`, `_free_expired_leases`) are internal — called by the executor during step scheduling and background lease management, not by user code.
 
-#### Executor Integration
+### Executor Integration
 
 Pool limits are enforced during execution. When a step with `pool` configuration runs, the executor:
 

--- a/docs/architecture/concurrency-flow.md
+++ b/docs/architecture/concurrency-flow.md
@@ -15,7 +15,7 @@ The first two are **run-level** gates (before execution starts). The other two a
 
 ## Flow Diagram
 
-```
+```text
                          USER / SCHEDULER / SENSOR
                                    │
                     ┌──────────────┴──────────────┐

--- a/docs/comparisons/dagster.md
+++ b/docs/comparisons/dagster.md
@@ -1,6 +1,6 @@
 # Comparison with Dagster
 
-rivers takes the asset-graph orchestration model that Dagster pioneered and brings it to the compiled world. 
+rivers takes the asset-graph orchestration model that Dagster pioneered and brings it to the compiled world.
 
 This page is intentionally **not** a feature-parity matrix. It only lists what rivers does *differently or better*; for everything else (assets, partitions, IO handlers, schedules, sensors, automation conditions, backfills, jobs) assume the surface area is comparable.
 
@@ -396,7 +396,6 @@ The Python pymethods intentionally skip the queue — they are the "I want to ru
 ## Run lifecycle controls
 
 - **Sensors can yield `BackfillRequest`** — one `SensorResult` can carry `run_requests=[...]` (mixed `RunRequest` / `BackfillRequest`), a `cursor`, and a `skip_reason` from the same tick.
-
 
 ## Observability
 

--- a/docs/concepts/io-handlers.md
+++ b/docs/concepts/io-handlers.md
@@ -116,8 +116,7 @@ class JsonIOHandler(BaseIOHandler):
 
 ### Register data version during handle_output
 
-IO handlers can register a data version while materialing, by using `output_context.register_data_version()`. This takes precedence over the auto created UUID version. 
-
+IO handlers can register a data version while materialing, by using `output_context.register_data_version()`. This takes precedence over the auto created UUID version.
 
 All IO handlers **must** inherit from `BaseIOHandler`. Duck-typing (objects that merely have `handle_output`/`load_input` methods) is not supported.
 

--- a/docs/concepts/resources.md
+++ b/docs/concepts/resources.md
@@ -73,7 +73,7 @@ def my_schedule(context: rs.ScheduleEvaluationContext, db: DatabaseResource):
 
 ## Lifecycle
 
-```
+```text
 CodeRepository.__init__()
   └─ stores raw resource instances
 

--- a/docs/deferred/lineage-since-last-deploy.md
+++ b/docs/deferred/lineage-since-last-deploy.md
@@ -73,6 +73,6 @@ about surfacing the toggle and feeding real data into it.
 
 - `rust/rivers-ui/src/pages/graph.rs` (deploy_view signal + toggle removed here)
 - `rust/rivers-ui/src/components/dag/render.rs` (`changed_keys` prop + NEW chip
-  + accent ring rendering — preserved)
+    - accent ring rendering — preserved)
 - Rivers reference: `/tmp/design/rivers-v2/project/components/rivers-screens.jsx`
   `LineageGraphScreen` deploy-diff banner + node NEW chip

--- a/docs/deferred/run-detail-ghost-overlay.md
+++ b/docs/deferred/run-detail-ghost-overlay.md
@@ -82,6 +82,7 @@ The following classes were removed. Recreate them when the overlay returns:
   `.gantt-legend-swatch--ghost`, `.gantt-legend-sep`, `.gantt-legend-spacer`
 
 Keyframes to keep:
+
 - `river-flow` — already used by the running-bar stripes animation.
 
 ## Related

--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -14,7 +14,7 @@ The `rivers` Helm chart wires all three together; the `rivers-crds` Helm chart s
 
 ## How it fits together
 
-```
+```text
    ┌────────────────┐                                ┌─────────────┐
    │  User Browser  │                                │   kubectl   │
    └────────┬───────┘                                └──────┬──────┘
@@ -58,7 +58,7 @@ The UI, on every page load, queries that registry over gRPC `:50052` to discover
 
 A `CodeLocation` going from `kubectl apply` to `Ready`:
 
-```
+```text
    kubectl     k8s API      operator      img registry    Pod      SurrealDB
       │           │             │              │            │            │
       │           │             │              │            │            │
@@ -98,7 +98,7 @@ The mutating admission webhook stamps `spec.identity` (UUID) on create; the vali
 
 A user opens the UI and triggers an asset materialization:
 
-```
+```text
    Browser     rivers-ui      operator       Pod       SurrealDB
       │            │             │            │             │
       │            │             │            │             │

--- a/justfile
+++ b/justfile
@@ -73,12 +73,14 @@ wasm-test browser="chrome":
 
 # Run linter, formatter, static type checker
 pre-commit:
+    uv run --no-sync rumdl check . --fix --flavor mkdocs --fail-on never --disable MD013,MD033,MD041
     uv run --no-sync ruff check python/
     uv run --no-sync ruff format python/
     cd python && uv run --no-sync pyright .
 
 # Run linter, formatter, static type checker in CI
 pre-commit-check:
+    uv run --no-sync rumdl check . --fix --flavor mkdocs --fail-on never --disable MD013,MD033,MD041
     uv run --no-sync ruff check python/
     uv run --no-sync ruff format --check --diff python/
     uv run --no-sync typos python/

--- a/justfile
+++ b/justfile
@@ -80,7 +80,7 @@ pre-commit:
 
 # Run linter, formatter, static type checker in CI
 pre-commit-check:
-    uv run --no-sync rumdl check . --fix --flavor mkdocs --fail-on never --disable MD013,MD033,MD041
+    uv run --no-sync rumdl check . --flavor mkdocs --fail-on never --disable MD013,MD033,MD041
     uv run --no-sync ruff check python/
     uv run --no-sync ruff format --check --diff python/
     uv run --no-sync typos python/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ dev = [
     "grpcio>=1.60.0",
     "grpcio-tools>=1.60.0",
     "kr8s>=0.20",
+    "rumdl>=0.2.7",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1604,6 +1604,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
     { name = "ruff" },
+    { name = "rumdl" },
     { name = "typos" },
 ]
 
@@ -1620,6 +1621,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "ruff", specifier = ">=0.15.12" },
+    { name = "rumdl", specifier = ">=0.2.7" },
     { name = "typos", specifier = ">=1.46.0" },
 ]
 
@@ -1646,6 +1648,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
     { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
     { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+]
+
+[[package]]
+name = "rumdl"
+version = "0.2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/e5/cedeae3e7dfe8f02f8698f9093d77730de6695d94bcee3cbef0053556653/rumdl-0.2.7.tar.gz", hash = "sha256:22af425c9774ad28775e1f81fc74b459cea6c9b6ec130455c6c28f1e88870a9f", size = 2655582, upload-time = "2026-06-03T21:15:24.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/c0/759bc55a265346d870b899a86c3ba98b7d57d99e1fe722613db25c1859e1/rumdl-0.2.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:31300053a6c10572d6da952f4c2250d15972766488717385d0693a389f762780", size = 5554161, upload-time = "2026-06-03T21:15:18.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c1/0e3b6a9c512f408a8eefc2d9595333e0b9eb0132fb9d4b0be8678aeb512a/rumdl-0.2.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2c6d047754ca5532f103a2d8a27633cd5ac33525b41e694f7f1952f4be8a9d80", size = 5152298, upload-time = "2026-06-03T21:15:12.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/90/1fb9d0ec50596d7217cdea05f5d03917a97fc590ad3f9b0de08da4d4cdcf/rumdl-0.2.7-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:c7ef18fd700913d6b9a9807e0b3b80116f116d7df4b15e66d91c97ac6c4291d3", size = 5376124, upload-time = "2026-06-03T21:15:15.176Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/9b0c130df2fe98d487d72d566ebd29dc37dfe4ad366ca5386e1af70c6d56/rumdl-0.2.7-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:3816fb51eab817744938205b3de2bc7caef9c16112fd0d62f2ba95edfa5cf909", size = 5777002, upload-time = "2026-06-03T21:15:21.655Z" },
+    { url = "https://files.pythonhosted.org/packages/61/57/fcb56cb52c07ebdaaf13f714a3acf898afda410e759ec81b72b7715e4972/rumdl-0.2.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bc64a3c87f12e416bf5ee66042e76ac40ee8c2ab4c9107647759088613abe665", size = 5381252, upload-time = "2026-06-03T21:15:16.805Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fd/1449c2c9a9f0f51d9e0bbe3b62171f5df7d2ed4269aa7ec43b9f6a270052/rumdl-0.2.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d24ce1f4e71506a7ceb0ada057d9d517bb8f8d8bd321bba00630c322a104b28f", size = 5774616, upload-time = "2026-06-03T21:15:23.361Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b1/757dce97a9bb2fb2c1936d4c230cd85e38dc89630e4c8879886495ea5614/rumdl-0.2.7-py3-none-win_amd64.whl", hash = "sha256:6680abe5b367e0e594600898f40414bd86aa03fcda1f29891eb2594c687c52d2", size = 5857483, upload-time = "2026-06-03T21:15:20.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Add [`rumdl`](https://github.com/rvben/rumdl) for automatic markdown lint and formatting to `pre-commit` and `pre-commit-check` in the `justfile`.

Not so sure about some of the changes to the following files:

- `.github/pull_request_template.md`
- `CLA.md`

I can add an `--exclude`-flag for these files if you agree.

Since it runs with `--fail-on never`, it will never fail the command execution. Instead, it'll always run with `exit 0` as the end result, even if it detects `markdown` files that does not follow the rules defined by `rumdl`. This is to avoid `markdown` problems from being a blocker in `pre-commit-check` run of the CI pipeline.

# Documentation

- [Rumdl documentation](https://rumdl.dev/)
