### PR TITLE
fix: bunch of partitioning correctness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5600,6 +5600,7 @@ dependencies = [
  "pyo3",
  "pyo3-arrow",
  "pyo3-async-runtimes",
+ "pyo3-build-config",
  "pyo3-pylogger",
  "rivers-api",
  "rivers-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5640,6 +5640,7 @@ dependencies = [
  "chrono",
  "croner",
  "futures-util",
+ "ordermap",
  "petgraph",
  "serde",
  "serde_json",

--- a/docs/api-reference/automation.md
+++ b/docs/api-reference/automation.md
@@ -45,7 +45,7 @@ Fine-grained conditions for building custom rules. All are static methods on `Au
 | `.code_version_changed()` | Code version differs from the last materialized version. |
 | `.data_version_changed()` | Data version differs from the previous tick. |
 | `.cron_tick_passed(cron_schedule, timezone=None)` | A cron tick has passed since the last evaluation. `cron_schedule` accepts 5 or 6 fields (seconds optional). |
-| `.in_latest_time_window(lookback_delta=None)` | Partition falls within the latest time window (`lookback_delta` in seconds; must be positive and finite or `ValueError` is raised). |
+| `.in_latest_time_window(lookback_delta=None)` | Partition falls within the latest time window (`lookback_delta` in seconds, measured back from the latest window's start; must be positive and finite or `ValueError` is raised). |
 | `.initial_evaluation()` | First evaluation tick after daemon startup or a condition tree change. |
 | `.backfill_in_progress()` | Asset is part of an active backfill. |
 | `.will_be_requested()` | Asset's condition already fired earlier this tick (same-tick cascading). |

--- a/docs/api-reference/automation.md
+++ b/docs/api-reference/automation.md
@@ -45,7 +45,7 @@ Fine-grained conditions for building custom rules. All are static methods on `Au
 | `.code_version_changed()` | Code version differs from the last materialized version. |
 | `.data_version_changed()` | Data version differs from the previous tick. |
 | `.cron_tick_passed(cron_schedule, timezone=None)` | A cron tick has passed since the last evaluation. `cron_schedule` accepts 5 or 6 fields (seconds optional). |
-| `.in_latest_time_window(lookback_delta=None)` | Partition falls within the latest time window (`lookback_delta` in seconds). |
+| `.in_latest_time_window(lookback_delta=None)` | Partition falls within the latest time window (`lookback_delta` in seconds; must be positive and finite or `ValueError` is raised). |
 | `.initial_evaluation()` | First evaluation tick after daemon startup or a condition tree change. |
 | `.backfill_in_progress()` | Asset is part of an active backfill. |
 | `.will_be_requested()` | Asset's condition already fired earlier this tick (same-tick cascading). |

--- a/docs/api-reference/partitions.md
+++ b/docs/api-reference/partitions.md
@@ -195,6 +195,12 @@ Returns the half-open `(start, end)` time window for the current key, or `None` 
 
 An inclusive range of partition keys for backfills and lookups.
 
+Range endpoints follow the **partition definition's ordering**, resolved when
+the range is used: positional order for static keys (which need not be
+alphabetical) and chronological order for time windows (so custom formats
+like `%m/%d/%Y` work). Unknown endpoints and inverted ranges are rejected
+with a precise error at backfill submission.
+
 ### `PartitionKeyRange.single()`
 
 ```python
@@ -241,7 +247,10 @@ Explicit key-to-key mapping.
 PartitionMapping.time_window(offset: int) -> PartitionMapping.TimeWindow
 ```
 
-Offset by N time periods (e.g., `-1` for previous day).
+Offset by N time periods (e.g., `-1` for previous day): materializing
+`2024-01-05` with `offset=-1` loads the upstream's `2024-01-04` partition.
+Works for cron and interval windows alike; a key that shifts outside the
+upstream's `[start, end)` range fails the run with a precise error.
 
 ### `PartitionMapping.specific_partitions(partition_keys)`
 

--- a/docs/api-reference/partitions.md
+++ b/docs/api-reference/partitions.md
@@ -52,6 +52,8 @@ Defines how an asset is partitioned.
 
 Partition key values may not contain `|` or `,` — those characters are reserved by the canonical display form (`dim=value|dim=value`, values joined with `,`) used everywhere keys appear as strings. Dimension names in `multi()` additionally may not contain `=`. Constructors, `fmt` rendering, and `storage.add_dynamic_partitions()` reject violations.
 
+Every definition is re-validated when the repository resolves: values built without the factory staticmethods (e.g. the raw `PartitionsDefinition.TimeWindow(...)` variant constructor) are held to the same rules before any partition keys are minted.
+
 ### `PartitionsDefinition.static_()`
 
 ```python

--- a/docs/api-reference/partitions.md
+++ b/docs/api-reference/partitions.md
@@ -106,7 +106,7 @@ PartitionsDefinition.time_window(
 ) -> PartitionsDefinition.TimeWindow
 ```
 
-Custom time-window partitions. Exactly one of `cron_schedule` or `interval_seconds` is required. `cron_schedule` accepts 5 fields (`min hour dom mon dow`) or 6 fields (`sec min hour dom mon dow`) — seconds are optional.
+Custom time-window partitions. Exactly one of `cron_schedule` or `interval_seconds` is required. `cron_schedule` accepts 5 fields (`min hour dom mon dow`) or 6 fields (`sec min hour dom mon dow`) — seconds are optional. Cron grids are second-granular, so `start` must fall on a whole second (sub-second intervals remain supported via `interval_seconds`).
 
 `fmt` must be at least as fine as the grid: every window start has to format to a key that parses back to exactly that start (e.g. an hourly grid with `fmt="%Y-%m-%d"` is rejected, because 24 windows would collapse into one key). Coarse fmts like `%Y-%m` or `%Y` are fine on equally coarse grids — missing calendar fields parse back as the window start. The round-trip is checked across the grid's first four years (capped at 1024 windows), so calendar drift that spares the earliest ticks — e.g. a 31-day interval under `fmt="%Y-%m"`, whose first ticks happen to land on month starts — is still rejected at construction. This applies to `daily(fmt=...)` and `hourly(fmt=...)` overrides too.
 

--- a/docs/api-reference/partitions.md
+++ b/docs/api-reference/partitions.md
@@ -50,6 +50,8 @@ rs.PartitionKey.multi({"date": "2024-01-15", "region": ["us", "eu"]})
 
 Defines how an asset is partitioned.
 
+Partition key values may not contain `|` or `,` — those characters are reserved by the canonical display form (`dim=value|dim=value`, values joined with `,`) used everywhere keys appear as strings. Dimension names in `multi()` additionally may not contain `=`. Constructors, `fmt` rendering, and `storage.add_dynamic_partitions()` reject violations.
+
 ### `PartitionsDefinition.static_()`
 
 ```python

--- a/docs/api-reference/partitions.md
+++ b/docs/api-reference/partitions.md
@@ -102,6 +102,8 @@ PartitionsDefinition.time_window(
 
 Custom time-window partitions. Exactly one of `cron_schedule` or `interval_seconds` is required. `cron_schedule` accepts 5 fields (`min hour dom mon dow`) or 6 fields (`sec min hour dom mon dow`) — seconds are optional.
 
+`fmt` must be at least as fine as the grid: every window start has to format to a key that parses back to exactly that start (e.g. an hourly grid with `fmt="%Y-%m-%d"` is rejected, because 24 windows would collapse into one key). Coarse fmts like `%Y-%m` or `%Y` are fine on equally coarse grids — missing calendar fields parse back as the window start. This applies to `daily(fmt=...)` and `hourly(fmt=...)` overrides too.
+
 **`TimeWindow` attributes:**
 
 | Attribute | Type |

--- a/docs/api-reference/partitions.md
+++ b/docs/api-reference/partitions.md
@@ -86,7 +86,7 @@ PartitionsDefinition.hourly(
 ) -> PartitionsDefinition.TimeWindow
 ```
 
-Hourly partitions. Default format: `"%Y-%m-%d-%H:%M"`.
+Hourly partitions. Default format: `"%Y-%m-%dT%H:00"`.
 
 ### `PartitionsDefinition.time_window()`
 

--- a/docs/api-reference/partitions.md
+++ b/docs/api-reference/partitions.md
@@ -108,7 +108,7 @@ PartitionsDefinition.time_window(
 
 Custom time-window partitions. Exactly one of `cron_schedule` or `interval_seconds` is required. `cron_schedule` accepts 5 fields (`min hour dom mon dow`) or 6 fields (`sec min hour dom mon dow`) — seconds are optional.
 
-`fmt` must be at least as fine as the grid: every window start has to format to a key that parses back to exactly that start (e.g. an hourly grid with `fmt="%Y-%m-%d"` is rejected, because 24 windows would collapse into one key). Coarse fmts like `%Y-%m` or `%Y` are fine on equally coarse grids — missing calendar fields parse back as the window start. This applies to `daily(fmt=...)` and `hourly(fmt=...)` overrides too.
+`fmt` must be at least as fine as the grid: every window start has to format to a key that parses back to exactly that start (e.g. an hourly grid with `fmt="%Y-%m-%d"` is rejected, because 24 windows would collapse into one key). Coarse fmts like `%Y-%m` or `%Y` are fine on equally coarse grids — missing calendar fields parse back as the window start. The round-trip is checked across the grid's first four years (capped at 1024 windows), so calendar drift that spares the earliest ticks — e.g. a 31-day interval under `fmt="%Y-%m"`, whose first ticks happen to land on month starts — is still rejected at construction. This applies to `daily(fmt=...)` and `hourly(fmt=...)` overrides too.
 
 **`TimeWindow` attributes:**
 

--- a/docs/api-reference/partitions.md
+++ b/docs/api-reference/partitions.md
@@ -78,6 +78,8 @@ PartitionsDefinition.daily(
 
 Daily partitions. Default format: `"%Y-%m-%d"`.
 
+Raises `PartitionDefinitionError` if a `fmt` override cannot round-trip the daily grid — e.g. `daily(fmt="%Y-%m")` collapses ~30 windows into one key (see [`time_window()`](#partitionsdefinitiontime_window) for the round-trip rule).
+
 ### `PartitionsDefinition.hourly()`
 
 ```python
@@ -89,6 +91,8 @@ PartitionsDefinition.hourly(
 ```
 
 Hourly partitions. Default format: `"%Y-%m-%dT%H:00"`.
+
+Raises `PartitionDefinitionError` if a `fmt` override cannot round-trip the hourly grid, e.g. `hourly(fmt="%Y-%m-%d")`.
 
 ### `PartitionsDefinition.time_window()`
 

--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -70,6 +70,8 @@ All query methods block the calling thread until the result is ready.
 | `has_dynamic_partition(name, key)` | `bool` |
 | `get_materialized_partitions(asset_key)` | `list[PartitionKey]` |
 
+Dynamic keys registered before the reserved-character guard existed (`|`/`,`) still classify, but cannot round-trip display-string paths (UI, gRPC). The storage migration records any such keys under the `reserved_dynamic_keys` entry in the `kv` table and logs a warning at startup — delete each offending key and re-register it under a clean name.
+
 ### `compute_staleness()`
 
 ```python

--- a/docs/concepts/partitions.md
+++ b/docs/concepts/partitions.md
@@ -58,7 +58,7 @@ rs.PartitionsDefinition.time_window(
 )
 ```
 
-`cron_schedule` accepts 5 fields (`min hour dom mon dow`) or 6 fields with leading seconds (`sec min hour dom mon dow`). The `fmt` parameter controls the partition key format string (default: `"%Y-%m-%d"` for daily, `"%Y-%m-%d-%H:%M"` for hourly).
+`cron_schedule` accepts 5 fields (`min hour dom mon dow`) or 6 fields with leading seconds (`sec min hour dom mon dow`). The `fmt` parameter controls the partition key format string (default: `"%Y-%m-%d"` for daily, `"%Y-%m-%dT%H:00"` for hourly).
 
 `start`/`end` are tz-naive: keys are wall-clock labels on the naive timeline,
 so the grid is identical on every host timezone and DST transitions neither

--- a/docs/concepts/partitions.md
+++ b/docs/concepts/partitions.md
@@ -60,6 +60,10 @@ rs.PartitionsDefinition.time_window(
 
 `cron_schedule` accepts 5 fields (`min hour dom mon dow`) or 6 fields with leading seconds (`sec min hour dom mon dow`). The `fmt` parameter controls the partition key format string (default: `"%Y-%m-%d"` for daily, `"%Y-%m-%d-%H:%M"` for hourly).
 
+`start`/`end` are tz-naive: keys are wall-clock labels on the naive timeline,
+so the grid is identical on every host timezone and DST transitions neither
+drop nor duplicate keys.
+
 ### Multi-dimensional partitions
 
 Cartesian product of any number of named dimensions. Each dimension can be `static_`, `daily`/`hourly`/`time_window`, or `dynamic` — mix and match freely:
@@ -92,6 +96,11 @@ repo.storage.add_dynamic_partitions("customers", ["acme", "globex"])
 ```
 
 Dynamic partitions are useful when the key set is discovered at runtime (new tenants, new files, new symbols).
+
+Keys must be registered **before** they can be materialized or backfilled —
+submitting a key that isn't in storage (a typo, or one deleted via
+`delete_dynamic_partition`) is rejected at the boundary with a precise error
+instead of recording a materialization for a partition that doesn't exist.
 
 ## Partition keys
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -53,3 +53,6 @@ k8s-openapi.workspace = true
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 mimalloc = { version = "0.1", features = ["local_dynamic_tls"] }
+
+[build-dependencies]
+pyo3-build-config = "0.28"

--- a/python/build.rs
+++ b/python/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}

--- a/python/rivers/_core/automation/__init__.pyi
+++ b/python/rivers/_core/automation/__init__.pyi
@@ -105,7 +105,9 @@ class AutomationCondition:
         """True when the partition falls within the latest time window.
 
         Args:
-            lookback_delta: Optional lookback in seconds from the current window.
+            lookback_delta: Optional lookback in seconds, measured back from
+                the latest window's start — one period reaches exactly one
+                window back, regardless of the time of day.
 
         Raises:
             ValueError: If ``lookback_delta`` is not a positive finite number.

--- a/python/rivers/_core/automation/__init__.pyi
+++ b/python/rivers/_core/automation/__init__.pyi
@@ -106,6 +106,9 @@ class AutomationCondition:
 
         Args:
             lookback_delta: Optional lookback in seconds from the current window.
+
+        Raises:
+            ValueError: If ``lookback_delta`` is not a positive finite number.
         """
         ...
     @staticmethod

--- a/python/rivers/_core/partitions/__init__.pyi
+++ b/python/rivers/_core/partitions/__init__.pyi
@@ -140,9 +140,9 @@ class PartitionsDefinition:
         """Define a static partitions set from a list of keys.
 
         Raises:
-            PartitionDefinitionError: If ``keys`` is empty, or a key contains
-                a character reserved by the canonical display form
-                (``|`` or ``,``).
+            PartitionDefinitionError: If ``keys`` is empty, a key is the
+                empty string, or a key contains a character reserved by the
+                canonical display form (``|`` or ``,``).
         """
         ...
 

--- a/python/rivers/_core/partitions/__init__.pyi
+++ b/python/rivers/_core/partitions/__init__.pyi
@@ -188,8 +188,9 @@ class PartitionsDefinition:
 
         Raises:
             PartitionDefinitionError: If ``interval_seconds`` is not positive
-                or is below one nanosecond; if ``fmt`` cannot round-trip the
-                grid (coarser than the window spacing); or if ``fmt`` renders
+                or is below one nanosecond; if a cron-gridded ``start`` is not
+                on a whole second; if ``fmt`` cannot round-trip the grid
+                (coarser than the window spacing); or if ``fmt`` renders
                 keys containing a character reserved by the canonical display
                 form (``|`` or ``,``).
         """

--- a/python/rivers/_core/partitions/__init__.pyi
+++ b/python/rivers/_core/partitions/__init__.pyi
@@ -152,7 +152,12 @@ class PartitionsDefinition:
         end: datetime.datetime | None = None,
         fmt: str | None = None,
     ) -> PartitionsDefinition.TimeWindow:
-        """Daily time-window partitions starting at ``start``."""
+        """Daily time-window partitions starting at ``start``.
+
+        Raises:
+            PartitionDefinitionError: If a ``fmt`` override cannot round-trip
+                the daily grid (e.g. ``fmt="%Y-%m"``).
+        """
         ...
 
     @staticmethod
@@ -161,7 +166,12 @@ class PartitionsDefinition:
         end: datetime.datetime | None = None,
         fmt: str | None = None,
     ) -> PartitionsDefinition.TimeWindow:
-        """Hourly time-window partitions starting at ``start``."""
+        """Hourly time-window partitions starting at ``start``.
+
+        Raises:
+            PartitionDefinitionError: If a ``fmt`` override cannot round-trip
+                the hourly grid (e.g. ``fmt="%Y-%m-%d"``).
+        """
         ...
 
     @staticmethod
@@ -178,8 +188,9 @@ class PartitionsDefinition:
 
         Raises:
             PartitionDefinitionError: If ``interval_seconds`` is not positive
-                or is below one nanosecond, or if ``fmt`` renders keys
-                containing a character reserved by the canonical display
+                or is below one nanosecond; if ``fmt`` cannot round-trip the
+                grid (coarser than the window spacing); or if ``fmt`` renders
+                keys containing a character reserved by the canonical display
                 form (``|`` or ``,``).
         """
         ...

--- a/python/rivers/_core/partitions/__init__.pyi
+++ b/python/rivers/_core/partitions/__init__.pyi
@@ -137,7 +137,13 @@ class PartitionsDefinition:
 
     @staticmethod
     def static_(keys: list[str]) -> PartitionsDefinition.Static:
-        """Define a static partitions set from a list of keys."""
+        """Define a static partitions set from a list of keys.
+
+        Raises:
+            PartitionDefinitionError: If ``keys`` is empty, or a key contains
+                a character reserved by the canonical display form
+                (``|`` or ``,``).
+        """
         ...
 
     @staticmethod
@@ -172,7 +178,9 @@ class PartitionsDefinition:
 
         Raises:
             PartitionDefinitionError: If ``interval_seconds`` is not positive
-                or is below one nanosecond.
+                or is below one nanosecond, or if ``fmt`` renders keys
+                containing a character reserved by the canonical display
+                form (``|`` or ``,``).
         """
         ...
 
@@ -180,7 +188,14 @@ class PartitionsDefinition:
     def multi(
         dimensions: dict[str, PartitionsDefinition],
     ) -> PartitionsDefinition.Multi:
-        """Combine multiple definitions into a multi-dimensional partition space."""
+        """Combine multiple definitions into a multi-dimensional partition space.
+
+        Raises:
+            PartitionDefinitionError: If ``dimensions`` is empty, a dimension
+                is itself Multi, or a dimension name is empty or contains a
+                character reserved by the canonical display form
+                (``|``, ``,`` or ``=``).
+        """
         ...
 
     @staticmethod

--- a/python/rivers/_core/partitions/__init__.pyi
+++ b/python/rivers/_core/partitions/__init__.pyi
@@ -21,6 +21,12 @@ class PartitionKey:
 
         keys: dict[str, list[str]]
 
+    class Set(PartitionKey):
+        """Explicit key set bundling a sparse backfill group — internal /
+        transport form, returned by :meth:`from_json`."""
+
+        keys: list[PartitionKey]
+
     @staticmethod
     def single(key: str | list[str]) -> PartitionKey.Single:
         """Build a single-dimension key from a value or list of values."""
@@ -87,7 +93,8 @@ class PartitionKeyRange:
 
     @staticmethod
     def single(from_key: str, to_key: str) -> PartitionKeyRange:
-        """Single-dimension range from ``from_key`` to ``to_key`` (inclusive)."""
+        """Single-dimension range from ``from_key`` to ``to_key`` (inclusive),
+        ordered by the partition definition at resolve time."""
         ...
 
     @staticmethod
@@ -162,6 +169,10 @@ class PartitionsDefinition:
         """Custom time-window partitions defined by a cron schedule or interval.
 
         Provide exactly one of ``cron_schedule`` or ``interval_seconds``.
+
+        Raises:
+            PartitionDefinitionError: If ``interval_seconds`` is not positive
+                or is below one nanosecond.
         """
         ...
 
@@ -197,7 +208,11 @@ class PartitionContext:
     def __init__(
         self, keys: list[PartitionKey], definition: PartitionsDefinition
     ) -> None:
-        """Construct a context (typically only the executor calls this)."""
+        """Construct a context (typically only the executor calls this).
+
+        Raises:
+            ValueError: If ``keys`` is empty.
+        """
         ...
 
     def time_window(self) -> tuple[datetime.datetime, datetime.datetime] | None:
@@ -263,7 +278,8 @@ class PartitionMapping:
 
     @staticmethod
     def time_window(offset: int) -> PartitionMapping.TimeWindow:
-        """Offset the downstream by ``offset`` upstream windows (negative = lag)."""
+        """Offset the downstream by ``offset`` upstream windows (negative = lag);
+        shifts outside the upstream's ``[start, end)`` range fail the run."""
         ...
 
     @staticmethod

--- a/python/rivers/_core/storage/__init__.pyi
+++ b/python/rivers/_core/storage/__init__.pyi
@@ -307,7 +307,12 @@ class Storage:
     def add_dynamic_partitions(
         self, partitions_def_name: str, partition_keys: list[str]
     ) -> None:
-        """Add keys to a :class:`PartitionsDefinition.Dynamic` instance."""
+        """Add keys to a :class:`PartitionsDefinition.Dynamic` instance.
+
+        Raises:
+            StorageError: If a key is empty or contains a character reserved
+                by the canonical display form (``|`` or ``,``).
+        """
         ...
 
     def delete_dynamic_partition(

--- a/python/src/automation/condition.rs
+++ b/python/src/automation/condition.rs
@@ -217,8 +217,19 @@ impl PyAutomationCondition {
     /// True when the partition is in the latest time window.
     #[staticmethod]
     #[pyo3(signature = (lookback_delta=None))]
-    fn in_latest_time_window(lookback_delta: Option<f64>) -> Self {
-        Self::new_node(ConditionNode::InLatestTimeWindow { lookback_delta })
+    fn in_latest_time_window(lookback_delta: Option<f64>) -> PyResult<Self> {
+        if let Some(delta) = lookback_delta
+            && (!delta.is_finite() || delta <= 0.0)
+        {
+            // NaN/negative silently select no windows; inf overflows the
+            // cutoff arithmetic.
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "lookback_delta must be a positive number of seconds, got {delta}"
+            )));
+        }
+        Ok(Self::new_node(ConditionNode::InLatestTimeWindow {
+            lookback_delta,
+        }))
     }
 
     /// True on the first evaluation tick after daemon startup or condition tree change.

--- a/python/src/daemon/automation_condition/engine.rs
+++ b/python/src/daemon/automation_condition/engine.rs
@@ -54,6 +54,29 @@ impl ConditionTickEngine {
             }
         };
 
+        // Advance partition universes: open time grids gain newly started
+        // windows; dynamic namespaces mirror storage (incl. retirements).
+        let mut dynamic_keys = std::collections::HashMap::new();
+        for ns in self.pass.dynamic_universe_namespaces() {
+            match self.storage.scoped().get_dynamic_partitions(&ns).await {
+                Ok(keys) => {
+                    dynamic_keys.insert(ns, keys.into_iter().collect());
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "rivers::daemon",
+                        namespace = %ns,
+                        error = %e,
+                        "dynamic partition universe refresh failed"
+                    );
+                }
+            }
+        }
+        let universe_changed = self
+            .pass
+            .refresh_partition_universes(chrono::Local::now().naive_local(), &dynamic_keys);
+        let has_changes = has_changes || universe_changed;
+
         tracing::trace!(
             target: "rivers::dbg::cond",
             has_changes,

--- a/python/src/daemon/automation_condition/mod.rs
+++ b/python/src/daemon/automation_condition/mod.rs
@@ -107,7 +107,11 @@ fn partition_universe_for(
             dims: dimensions
                 .iter()
                 .map(|(dim_name, dim_def)| {
-                    let keys = dim_def.enumerate_single_dim_keys().unwrap_or_default();
+                    let keys = dim_def
+                        .enumerate_single_dim_keys()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .collect();
                     let kind = match dim_def {
                         PartitionsDefinition::TimeWindow { .. } => match dim_def.time_grid() {
                             Some(grid) => DimensionKind::TimeWindow {

--- a/python/src/daemon/automation_condition/mod.rs
+++ b/python/src/daemon/automation_condition/mod.rs
@@ -35,7 +35,13 @@ mod persist;
 use engine::ConditionTickEngine;
 
 /// Build a [`PartitionInfo`] from a graph node. Returns `None` if unpartitioned.
-fn partition_info_from_node(asset_name: &str, node: &ResolvedNode) -> Option<PartitionInfo> {
+/// `node_map` supplies upstream definitions so time-window mappings carry
+/// their grid into core eval.
+fn partition_info_from_node(
+    asset_name: &str,
+    node: &ResolvedNode,
+    node_map: &HashMap<String, ResolvedNode>,
+) -> Option<PartitionInfo> {
     let def = node.partitions_def()?;
     let all_keys = def
         .get_partition_keys()
@@ -50,7 +56,7 @@ fn partition_info_from_node(asset_name: &str, node: &ResolvedNode) -> Option<Par
         PartitionsDefinition::TimeWindow { fmt, .. } => Some(fmt.clone()),
         _ => None,
     };
-    let mappings = extract_partition_mappings(asset_name, node);
+    let mappings = extract_partition_mappings(asset_name, node, node_map);
     Some(PartitionInfo {
         all_keys,
         mappings,
@@ -75,7 +81,7 @@ impl PyCodeRepository {
             if let ResolvedNode::Asset(asset_node) = node
                 && let Some(ref cond) = asset_node.automation_condition
             {
-                let partition_info = partition_info_from_node(name, node);
+                let partition_info = partition_info_from_node(name, node, &state.node_map);
                 let backfill_strategy = node.backfill_strategy().map(|s| s.to_core());
                 by_key.insert(
                     name.clone(),
@@ -130,16 +136,23 @@ impl PyCodeRepository {
     }
 }
 
-fn mapping_to_kind(m: &PartitionMapping) -> PartitionMappingKind {
+/// `upstream_def` is the definition of the side the mapping shifts within —
+/// it supplies the time grid for `TimeWindow` and per-dimension defs for
+/// nested mappings.
+fn mapping_to_kind(
+    m: &PartitionMapping,
+    upstream_def: Option<&PartitionsDefinition>,
+) -> PartitionMappingKind {
     match m {
         PartitionMapping::Identity {} => PartitionMappingKind::Identity,
         PartitionMapping::AllPartitions {} => PartitionMappingKind::AllPartitions,
         PartitionMapping::Static { mapping } => PartitionMappingKind::Static {
             mapping: mapping.clone(),
         },
-        PartitionMapping::TimeWindow { offset } => {
-            PartitionMappingKind::TimeWindow { offset: *offset }
-        }
+        PartitionMapping::TimeWindow { offset } => PartitionMappingKind::TimeWindow {
+            offset: *offset,
+            grid: upstream_def.and_then(|d| d.time_grid()),
+        },
         PartitionMapping::SpecificPartitions { partition_keys } => {
             PartitionMappingKind::SpecificPartitions {
                 keys: partition_keys.clone(),
@@ -149,9 +162,16 @@ fn mapping_to_kind(m: &PartitionMapping) -> PartitionMappingKind {
             dimension_mappings: dimension_mappings
                 .iter()
                 .map(|(up_dim, (down_dim, per_dim))| {
+                    let dim_def = upstream_def.and_then(|d| match d {
+                        PartitionsDefinition::Multi { dimensions } => dimensions
+                            .iter()
+                            .find(|(n, _)| n == up_dim)
+                            .map(|(_, dd)| dd),
+                        _ => None,
+                    });
                     (
                         up_dim.clone(),
-                        (down_dim.clone(), Box::new(mapping_to_kind(per_dim))),
+                        (down_dim.clone(), Box::new(mapping_to_kind(per_dim, dim_def))),
                     )
                 })
                 .collect(),
@@ -159,10 +179,21 @@ fn mapping_to_kind(m: &PartitionMapping) -> PartitionMappingKind {
         PartitionMapping::MultiToSingle {
             dimension_name,
             partition_mapping,
-        } => PartitionMappingKind::MultiToSingle {
-            dimension_name: dimension_name.clone(),
-            inner: Box::new(mapping_to_kind(&partition_mapping.0)),
-        },
+        } => {
+            // The inner mapping shifts within the named dimension when the
+            // upstream is Multi, else within the upstream itself.
+            let inner_def = upstream_def.and_then(|d| match d {
+                PartitionsDefinition::Multi { dimensions } => dimensions
+                    .iter()
+                    .find(|(n, _)| n == dimension_name)
+                    .map(|(_, dd)| dd),
+                _ => upstream_def,
+            });
+            PartitionMappingKind::MultiToSingle {
+                dimension_name: dimension_name.clone(),
+                inner: Box::new(mapping_to_kind(&partition_mapping.0, inner_def)),
+            }
+        }
         PartitionMapping::ForKeys { .. } => PartitionMappingKind::ForKeys,
         PartitionMapping::Subset {} => PartitionMappingKind::Subset,
     }
@@ -171,11 +202,15 @@ fn mapping_to_kind(m: &PartitionMapping) -> PartitionMappingKind {
 fn extract_partition_mappings(
     asset_name: &str,
     node: &crate::repository::resolved_node::ResolvedNode,
+    node_map: &HashMap<String, ResolvedNode>,
 ) -> HashMap<(String, String), PartitionMappingKind> {
     let mut result = HashMap::new();
     if let Some(mappings) = node.partition_mapping() {
         for (upstream_name, mapping) in &mappings {
-            let kind = mapping_to_kind(mapping);
+            let upstream_def = node_map
+                .get(upstream_name)
+                .and_then(|n| n.partitions_def());
+            let kind = mapping_to_kind(mapping, upstream_def);
             result.insert((asset_name.to_string(), upstream_name.clone()), kind);
         }
     }

--- a/python/src/daemon/automation_condition/mod.rs
+++ b/python/src/daemon/automation_condition/mod.rs
@@ -15,8 +15,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use rivers_core::condition::{
-    AssetConditionCache, AssetConditionInfo, ConditionEvalState, ConditionPass, PartitionInfo,
-    PartitionMappingKind,
+    AssetConditionCache, AssetConditionInfo, ConditionEvalState, ConditionPass, DimensionKind,
+    DimensionUniverse, PartitionInfo, PartitionMappingKind, PartitionUniverse,
 };
 use rivers_core::storage::surrealdb_backend::SurrealStorage;
 use rivers_core::storage::{PartitionKey as CorePartitionKey, ScopedStorageHandle};
@@ -43,6 +43,11 @@ fn partition_info_from_node(
     node_map: &HashMap<String, ResolvedNode>,
 ) -> Option<PartitionInfo> {
     let def = node.partitions_def()?;
+    // Captured before enumeration: a window starting between this and the
+    // enumerate call is re-added by the first refresh (extend is idempotent)
+    // rather than skipped.
+    let now = chrono::Local::now().naive_local();
+    let universe = partition_universe_for(def, now);
     let all_keys = def
         .get_partition_keys()
         .ok()
@@ -61,7 +66,51 @@ fn partition_info_from_node(
         all_keys,
         mappings,
         time_window_fmt,
+        universe,
     })
+}
+
+/// How `def`'s key universe evolves after extraction. `now` is the
+/// enumeration high-water mark for open time grids.
+fn partition_universe_for(
+    def: &PartitionsDefinition,
+    now: chrono::NaiveDateTime,
+) -> PartitionUniverse {
+    match def {
+        PartitionsDefinition::Static { .. } => PartitionUniverse::Frozen,
+        PartitionsDefinition::TimeWindow { .. } => match def.time_grid() {
+            Some(grid) => PartitionUniverse::TimeWindow {
+                grid,
+                enumerated_to: now,
+            },
+            None => PartitionUniverse::Frozen,
+        },
+        PartitionsDefinition::Dynamic { name } => PartitionUniverse::Dynamic {
+            namespace: name.clone(),
+        },
+        PartitionsDefinition::Multi { dimensions } => PartitionUniverse::Multi {
+            dims: dimensions
+                .iter()
+                .map(|(dim_name, dim_def)| {
+                    let keys = dim_def.enumerate_single_dim_keys().unwrap_or_default();
+                    let kind = match dim_def {
+                        PartitionsDefinition::TimeWindow { .. } => match dim_def.time_grid() {
+                            Some(grid) => DimensionKind::TimeWindow {
+                                grid,
+                                enumerated_to: now,
+                            },
+                            None => DimensionKind::Frozen,
+                        },
+                        PartitionsDefinition::Dynamic { name } => DimensionKind::Dynamic {
+                            namespace: name.clone(),
+                        },
+                        _ => DimensionKind::Frozen,
+                    };
+                    (dim_name.clone(), DimensionUniverse { keys, kind })
+                })
+                .collect(),
+        },
+    }
 }
 
 impl PyCodeRepository {
@@ -108,26 +157,33 @@ impl PyCodeRepository {
     pub(in crate::daemon) fn extract_upstream_partition_keys(
         &self,
         conditions: &[AssetConditionInfo],
-    ) -> HashMap<String, HashSet<CorePartitionKey>> {
+    ) -> HashMap<String, (HashSet<CorePartitionKey>, PartitionUniverse)> {
         let guard = self.state.read().unwrap();
         let Some(state) = guard.as_ref() else {
             return HashMap::new();
         };
 
-        let mut map: HashMap<String, HashSet<CorePartitionKey>> = HashMap::new();
+        let mut map: HashMap<String, (HashSet<CorePartitionKey>, PartitionUniverse)> =
+            HashMap::new();
         for cond in conditions {
             if let Some(ref pi) = cond.partition_info {
+                // Conditioned assets re-sync from their refreshed
+                // PartitionInfo each tick, so Frozen here is fine.
                 map.entry(cond.asset_key.clone())
-                    .or_insert_with(|| pi.all_keys.clone());
+                    .or_insert_with(|| (pi.all_keys.clone(), PartitionUniverse::Frozen));
                 for (_, upstream_key) in pi.mappings.keys() {
                     if !map.contains_key(upstream_key)
                         && let Some(node) = state.node_map.get(upstream_key)
                         && let Some(def) = node.partitions_def()
-                        && let Ok(keys) = def.get_partition_keys()
                     {
-                        let core_keys: HashSet<CorePartitionKey> =
-                            keys.iter().map(CorePartitionKey::from).collect();
-                        map.insert(upstream_key.clone(), core_keys);
+                        let now = chrono::Local::now().naive_local();
+                        let universe = partition_universe_for(def, now);
+                        let core_keys: HashSet<CorePartitionKey> = def
+                            .get_partition_keys()
+                            .ok()
+                            .map(|keys| keys.iter().map(CorePartitionKey::from).collect())
+                            .unwrap_or_default();
+                        map.insert(upstream_key.clone(), (core_keys, universe));
                     }
                 }
             }
@@ -234,8 +290,9 @@ pub(super) struct ConditionEvalLoopConfig {
     pub max_ticks_retained: Option<usize>,
     pub eval_tx: tokio::sync::mpsc::UnboundedSender<ConditionEvalWriteMsg>,
     pub max_evals_retained: Option<usize>,
-    /// Upstream partition keys, pre-extracted with GIL at daemon start.
-    pub upstream_partition_keys: HashMap<String, HashSet<CorePartitionKey>>,
+    /// Upstream partition keys (+ how each set evolves), pre-extracted with
+    /// GIL at daemon start.
+    pub upstream_partition_keys: HashMap<String, (HashSet<CorePartitionKey>, PartitionUniverse)>,
 }
 
 /// Background loop that periodically evaluates automation conditions on assets.

--- a/python/src/daemon/automation_condition/mod.rs
+++ b/python/src/daemon/automation_condition/mod.rs
@@ -14,6 +14,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use rivers_core::assets::graph::NodeRef;
 use rivers_core::condition::{
     AssetConditionCache, AssetConditionInfo, ConditionEvalState, ConditionPass, DimensionKind,
     DimensionUniverse, PartitionInfo, PartitionMappingKind, PartitionUniverse,
@@ -36,11 +37,13 @@ use engine::ConditionTickEngine;
 
 /// Build a [`PartitionInfo`] from a graph node. Returns `None` if unpartitioned.
 /// `node_map` supplies upstream definitions so time-window mappings carry
-/// their grid into core eval.
+/// their grid into core eval; `deps` supplies the asset's dependency edges so
+/// unmapped partitioned deps get their default Identity mapping.
 fn partition_info_from_node(
     asset_name: &str,
     node: &ResolvedNode,
     node_map: &HashMap<String, ResolvedNode>,
+    deps: &[NodeRef],
 ) -> Option<PartitionInfo> {
     let def = node.partitions_def()?;
     // Captured before enumeration: a window starting between this and the
@@ -61,7 +64,7 @@ fn partition_info_from_node(
         PartitionsDefinition::TimeWindow { fmt, .. } => Some(fmt.clone()),
         _ => None,
     };
-    let mappings = extract_partition_mappings(asset_name, node, node_map);
+    let mappings = extract_partition_mappings(asset_name, node, node_map, deps);
     Some(PartitionInfo {
         all_keys,
         mappings,
@@ -130,7 +133,13 @@ impl PyCodeRepository {
             if let ResolvedNode::Asset(asset_node) = node
                 && let Some(ref cond) = asset_node.automation_condition
             {
-                let partition_info = partition_info_from_node(name, node, &state.node_map);
+                let deps = state
+                    .inner_repo
+                    .assets()
+                    .get(name)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[]);
+                let partition_info = partition_info_from_node(name, node, &state.node_map, deps);
                 let backfill_strategy = node.backfill_strategy().map(|s| s.to_core());
                 by_key.insert(
                     name.clone(),
@@ -262,6 +271,7 @@ fn extract_partition_mappings(
     asset_name: &str,
     node: &crate::repository::resolved_node::ResolvedNode,
     node_map: &HashMap<String, ResolvedNode>,
+    deps: &[NodeRef],
 ) -> HashMap<(String, String), PartitionMappingKind> {
     let mut result = HashMap::new();
     if let Some(mappings) = node.partition_mapping() {
@@ -269,6 +279,25 @@ fn extract_partition_mappings(
             let upstream_def = node_map.get(upstream_name).and_then(|n| n.partitions_def());
             let kind = mapping_to_kind(mapping, upstream_def);
             result.insert((asset_name.to_string(), upstream_name.clone()), kind);
+        }
+    }
+    // An unmapped partitioned dep defaults to Identity at resolve time; the
+    // eval context must carry that default or the dep is treated as
+    // unpartitioned and its condition truth broadcasts across the universe.
+    for dep in deps {
+        let NodeRef::ByName(upstream_name) = dep else {
+            continue;
+        };
+        let key = (asset_name.to_string(), upstream_name.clone());
+        if result.contains_key(&key) {
+            continue;
+        }
+        if node_map
+            .get(upstream_name)
+            .and_then(|n| n.partitions_def())
+            .is_some()
+        {
+            result.insert(key, PartitionMappingKind::Identity);
         }
     }
     result

--- a/python/src/daemon/automation_condition/mod.rs
+++ b/python/src/daemon/automation_condition/mod.rs
@@ -73,6 +73,18 @@ fn partition_info_from_node(
     })
 }
 
+/// Seeding enumerates through an explicit end — future windows included — so
+/// the watermark starts past whatever the seed covered, not at `now`.
+fn seeded_watermark(
+    def: &PartitionsDefinition,
+    now: chrono::NaiveDateTime,
+) -> chrono::NaiveDateTime {
+    match def {
+        PartitionsDefinition::TimeWindow { end: Some(e), .. } => (*e).max(now),
+        _ => now,
+    }
+}
+
 /// How `def`'s key universe evolves after extraction. `now` is the
 /// enumeration high-water mark for open time grids.
 fn partition_universe_for(
@@ -84,7 +96,7 @@ fn partition_universe_for(
         PartitionsDefinition::TimeWindow { .. } => match def.time_grid() {
             Some(grid) => PartitionUniverse::TimeWindow {
                 grid,
-                enumerated_to: now,
+                enumerated_to: seeded_watermark(def, now),
             },
             None => PartitionUniverse::Frozen,
         },
@@ -100,7 +112,7 @@ fn partition_universe_for(
                         PartitionsDefinition::TimeWindow { .. } => match dim_def.time_grid() {
                             Some(grid) => DimensionKind::TimeWindow {
                                 grid,
-                                enumerated_to: now,
+                                enumerated_to: seeded_watermark(dim_def, now),
                             },
                             None => DimensionKind::Frozen,
                         },

--- a/python/src/daemon/automation_condition/mod.rs
+++ b/python/src/daemon/automation_condition/mod.rs
@@ -171,7 +171,10 @@ fn mapping_to_kind(
                     });
                     (
                         up_dim.clone(),
-                        (down_dim.clone(), Box::new(mapping_to_kind(per_dim, dim_def))),
+                        (
+                            down_dim.clone(),
+                            Box::new(mapping_to_kind(per_dim, dim_def)),
+                        ),
                     )
                 })
                 .collect(),
@@ -207,9 +210,7 @@ fn extract_partition_mappings(
     let mut result = HashMap::new();
     if let Some(mappings) = node.partition_mapping() {
         for (upstream_name, mapping) in &mappings {
-            let upstream_def = node_map
-                .get(upstream_name)
-                .and_then(|n| n.partitions_def());
+            let upstream_def = node_map.get(upstream_name).and_then(|n| n.partitions_def());
             let kind = mapping_to_kind(mapping, upstream_def);
             result.insert((asset_name.to_string(), upstream_name.clone()), kind);
         }

--- a/python/src/daemon/mod.rs
+++ b/python/src/daemon/mod.rs
@@ -337,7 +337,13 @@ struct DaemonLoopConfig {
     schedule_infos: Vec<ScheduleInfo>,
     sensor_infos: Vec<SensorInfo>,
     asset_conditions: Vec<rivers_core::condition::AssetConditionInfo>,
-    upstream_partition_keys: HashMap<String, HashSet<rivers_core::storage::PartitionKey>>,
+    upstream_partition_keys: HashMap<
+        String,
+        (
+            HashSet<rivers_core::storage::PartitionKey>,
+            rivers_core::condition::PartitionUniverse,
+        ),
+    >,
     repo: Arc<Py<PyCodeRepository>>,
     storage: Arc<SurrealStorage>,
     cancel: CancellationToken,

--- a/python/src/daemon/tick_processing.rs
+++ b/python/src/daemon/tick_processing.rs
@@ -61,12 +61,24 @@ pub(crate) async fn process_tick_result(
             let backfill_ids = if backfill_requests.is_empty() {
                 vec![]
             } else {
-                let bf_outcome = backfill_dispatcher.dispatch(backfill_requests).await;
-                let (ids, errors) = log_backfill_dispatch_outcome(
+                // Same outcome shape as runs: successful non-dry-run ids +
+                // per-request errors (a dry run produces no record).
+                let bf_outcome = backfill_dispatcher.dispatch(backfill_requests).await.map(
+                    |BackfillDispatchOutcome { results, errors }| DispatchOutcome {
+                        ids: results
+                            .into_iter()
+                            .filter(|r| !r.is_dry_run && !r.backfill_id.is_empty())
+                            .map(|r| r.backfill_id)
+                            .collect(),
+                        errors,
+                    },
+                );
+                let (ids, errors) = log_dispatch_outcome(
                     bf_outcome,
                     &auto_name,
                     auto_type,
                     backfill_dispatcher.mode_label(),
+                    "backfill",
                 );
                 dispatch_errors.extend(errors);
                 ids
@@ -203,48 +215,3 @@ fn log_dispatch_outcome(
     }
 }
 
-/// Backfill counterpart of [`log_dispatch_outcome`]. The dispatcher
-/// returns rich `PyBackfillResult`s; daemon ticks only need the ids
-/// (and a successful dispatch with `is_dry_run=true` is filtered out
-/// since it produces no record).
-fn log_backfill_dispatch_outcome(
-    outcome: anyhow::Result<BackfillDispatchOutcome>,
-    auto_name: &str,
-    auto_type: &str,
-    mode_label: &'static str,
-) -> (Vec<String>, Vec<String>) {
-    match outcome {
-        Ok(BackfillDispatchOutcome { results, errors }) => {
-            for err in &errors {
-                tracing::error!(
-                    target: "rivers::executor",
-                    automation_type = auto_type,
-                    name = %auto_name,
-                    mode = mode_label,
-                    kind = "backfill",
-                    error = %err,
-                    "backfill request failed",
-                );
-            }
-            let messages = errors.iter().map(|e| e.to_string()).collect();
-            let ids = results
-                .into_iter()
-                .filter(|r| !r.is_dry_run && !r.backfill_id.is_empty())
-                .map(|r| r.backfill_id)
-                .collect();
-            (ids, messages)
-        }
-        Err(e) => {
-            tracing::error!(
-                target: "rivers::executor",
-                automation_type = auto_type,
-                name = %auto_name,
-                mode = mode_label,
-                kind = "backfill",
-                error = %e,
-                "backfill dispatch failed",
-            );
-            (vec![], vec![e.to_string()])
-        }
-    }
-}

--- a/python/src/daemon/tick_processing.rs
+++ b/python/src/daemon/tick_processing.rs
@@ -50,7 +50,7 @@ pub(crate) async fn process_tick_result(
             let tick_outcome = run_dispatcher
                 .dispatch_tick(run_requests, materialization_requests, launched_by.clone())
                 .await;
-            let run_ids = log_dispatch_outcome(
+            let (run_ids, mut dispatch_errors) = log_dispatch_outcome(
                 tick_outcome,
                 &auto_name,
                 auto_type,
@@ -62,37 +62,49 @@ pub(crate) async fn process_tick_result(
                 vec![]
             } else {
                 let bf_outcome = backfill_dispatcher.dispatch(backfill_requests).await;
-                log_backfill_dispatch_outcome(
+                let (ids, errors) = log_backfill_dispatch_outcome(
                     bf_outcome,
                     &auto_name,
                     auto_type,
                     backfill_dispatcher.mode_label(),
-                )
+                );
+                dispatch_errors.extend(errors);
+                ids
             };
 
+            // A dropped request is a failed tick — silence here means a run
+            // the automation intended simply never exists.
+            let (status, error) = if dispatch_errors.is_empty() {
+                ("Success".to_string(), None)
+            } else {
+                ("Failed".to_string(), Some(dispatch_errors.join("; ")))
+            };
+            let failed = error.is_some();
             let _ = tick_tx.send(TickWriteMsg {
                 record: TickRecord {
                     code_location_id: handle.code_location_id().to_string(),
                     automation_name: auto_name.clone(),
                     automation_type: auto_type.into(),
-                    status: "Success".into(),
+                    status,
                     timestamp,
                     run_ids,
                     backfill_ids,
                     skip_reason: None,
-                    error: None,
+                    error,
                     cursor: final_cursor,
                 },
                 max_ticks_retained,
             });
             entry.complete_eval(outcome);
-            tracing::info!(
-                target: "rivers::daemon",
-                automation_type = auto_type,
-                name = %auto_name,
-                mode = run_dispatcher.mode_label(),
-                "tick succeeded"
-            );
+            if !failed {
+                tracing::info!(
+                    target: "rivers::daemon",
+                    automation_type = auto_type,
+                    name = %auto_name,
+                    mode = run_dispatcher.mode_label(),
+                    "tick succeeded"
+                );
+            }
         }
         Ok(ref outcome @ EvalOutcome::Skipped { ref reason, .. }) => {
             let final_cursor = outcome.cursor_or(prev_cursor);
@@ -148,16 +160,16 @@ pub(crate) async fn process_tick_result(
     }
 }
 
-/// Unwrap a `DispatchOutcome`, logging any per-request errors and outer failures
-/// uniformly. Returns the successful ids; preserves today's behavior of "tick
-/// status stays Success even if some requests failed."
+/// Unwrap a `DispatchOutcome`, logging any per-request errors and outer
+/// failures uniformly. Returns the successful ids and the error messages —
+/// a dropped request must surface on the tick record, not just in the logs.
 fn log_dispatch_outcome(
     outcome: anyhow::Result<DispatchOutcome>,
     auto_name: &str,
     auto_type: &str,
     mode_label: &'static str,
     kind: &'static str,
-) -> Vec<String> {
+) -> (Vec<String>, Vec<String>) {
     match outcome {
         Ok(DispatchOutcome { ids, errors }) => {
             for err in &errors {
@@ -172,7 +184,8 @@ fn log_dispatch_outcome(
                     kind
                 );
             }
-            ids
+            let messages = errors.iter().map(|e| e.to_string()).collect();
+            (ids, messages)
         }
         Err(e) => {
             tracing::error!(
@@ -185,7 +198,7 @@ fn log_dispatch_outcome(
                 "{} dispatch failed",
                 kind
             );
-            vec![]
+            (vec![], vec![e.to_string()])
         }
     }
 }
@@ -199,7 +212,7 @@ fn log_backfill_dispatch_outcome(
     auto_name: &str,
     auto_type: &str,
     mode_label: &'static str,
-) -> Vec<String> {
+) -> (Vec<String>, Vec<String>) {
     match outcome {
         Ok(BackfillDispatchOutcome { results, errors }) => {
             for err in &errors {
@@ -213,11 +226,13 @@ fn log_backfill_dispatch_outcome(
                     "backfill request failed",
                 );
             }
-            results
+            let messages = errors.iter().map(|e| e.to_string()).collect();
+            let ids = results
                 .into_iter()
                 .filter(|r| !r.is_dry_run && !r.backfill_id.is_empty())
                 .map(|r| r.backfill_id)
-                .collect()
+                .collect();
+            (ids, messages)
         }
         Err(e) => {
             tracing::error!(
@@ -229,7 +244,7 @@ fn log_backfill_dispatch_outcome(
                 error = %e,
                 "backfill dispatch failed",
             );
-            vec![]
+            (vec![], vec![e.to_string()])
         }
     }
 }

--- a/python/src/daemon/tick_processing.rs
+++ b/python/src/daemon/tick_processing.rs
@@ -214,4 +214,3 @@ fn log_dispatch_outcome(
         }
     }
 }
-

--- a/python/src/grpc_server.rs
+++ b/python/src/grpc_server.rs
@@ -105,7 +105,10 @@ impl CodeLocationService for CodeLocationImpl {
         request: Request<MaterializeRequest>,
     ) -> Result<Response<MaterializeResponse>, Status> {
         let req = request.into_inner();
-        let pk = req.partition_key.and_then(proto_partition_key_to_py);
+        let pk = req
+            .partition_key
+            .map(proto_partition_key_to_py)
+            .transpose()?;
         let pk_core = pk.as_ref().map(rivers_core::storage::PartitionKey::from);
         let tags = proto_tags_to_pairs(req.tags).unwrap_or_default();
 
@@ -132,6 +135,7 @@ impl CodeLocationService for CodeLocationImpl {
         // or never-started run.
         self.handle
             .validate_partition_for_selection(&asset_selection, pk.as_ref())
+            .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
         let mat_request = crate::daemon::MaterializationRequestData {
@@ -166,7 +170,10 @@ impl CodeLocationService for CodeLocationImpl {
         let run_request = crate::daemon::RunRequestData {
             run_key: None,
             tags: None,
-            partition_key: req.partition_key.and_then(proto_partition_key_to_py),
+            partition_key: req
+                .partition_key
+                .map(proto_partition_key_to_py)
+                .transpose()?,
             job_name: Some(req.job_name),
         };
 
@@ -532,13 +539,19 @@ impl CodeLocationService for CodeLocationImpl {
         request: Request<LaunchBackfillRequest>,
     ) -> Result<Response<LaunchBackfillResponse>, Status> {
         let req = request.into_inner();
-        let partition_keys = empty_to_none(req.partition_keys).map(|ks| {
-            ks.into_iter()
-                .filter_map(proto_partition_key_to_py)
-                .collect()
-        });
-        let partition_range = req.partition_range.and_then(proto_partition_range_to_py);
-        let strategy = req.strategy.and_then(proto_strategy_to_py);
+        let partition_keys = match empty_to_none(req.partition_keys) {
+            Some(ks) => Some(
+                ks.into_iter()
+                    .map(proto_partition_key_to_py)
+                    .collect::<Result<Vec<_>, Status>>()?,
+            ),
+            None => None,
+        };
+        let partition_range = req
+            .partition_range
+            .map(proto_partition_range_to_py)
+            .transpose()?;
+        let strategy = req.strategy.map(proto_strategy_to_py).transpose()?;
         let failure_policy = if req.failure_policy.is_empty() {
             None
         } else {
@@ -846,43 +859,65 @@ fn node_partition_def_info(pd: &PartitionsDefinition) -> PartitionDefInfo {
     }
 }
 
-/// Render a `PyPartitionKey` for display (and round-trip) in the UI.
-/// `Single` keys collapse to their string; `Multi` keys are encoded as
-/// `dim=val|dim=val` so the UI can split them deterministically.
+/// Render a `PyPartitionKey` for display in the UI — delegates to the
+/// canonical `PartitionKey::to_display` encoding (`dim=val|dim=val`).
 fn py_partition_key_display(pk: PyPartitionKey) -> String {
-    match pk {
-        PyPartitionKey::Single { key } => key.first().cloned().unwrap_or_default(),
-        PyPartitionKey::Multi { keys } => {
-            let mut entries: Vec<(String, Vec<String>)> = keys.into_iter().collect();
-            entries.sort_by(|a, b| a.0.cmp(&b.0));
-            entries
-                .into_iter()
-                .map(|(d, vs)| format!("{}={}", d, vs.join(",")))
-                .collect::<Vec<_>>()
-                .join("|")
-        }
-        PyPartitionKey::Set { keys } => keys
-            .into_iter()
-            .map(py_partition_key_display)
-            .collect::<Vec<_>>()
-            .join(", "),
-    }
+    rivers_core::storage::PartitionKey::from(&pk).to_display()
 }
 
-fn proto_partition_key_to_py(pk: ProtoPartitionKey) -> Option<PyPartitionKey> {
-    match pk.kind? {
-        proto_partition_key::Kind::Single(s) => Some(PyPartitionKey::Single { key: s.keys }),
+/// gRPC is the system boundary: malformed partition keys are rejected with
+/// `InvalidArgument` instead of being silently dropped or coerced. `Single`
+/// values are sorted to match the in-process constructors, so the same
+/// logical key compares equal regardless of which side built it.
+fn proto_partition_key_to_py(pk: ProtoPartitionKey) -> Result<PyPartitionKey, Status> {
+    let kind = pk
+        .kind
+        .ok_or_else(|| Status::invalid_argument("partition_key has no kind set"))?;
+    match kind {
+        proto_partition_key::Kind::Single(s) => {
+            if s.keys.is_empty() {
+                return Err(Status::invalid_argument(
+                    "partition_key.single.keys must not be empty",
+                ));
+            }
+            let mut keys = s.keys;
+            keys.sort();
+            Ok(PyPartitionKey::Single { key: keys })
+        }
         proto_partition_key::Kind::Multi(m) => {
-            let keys: HashMap<String, Vec<String>> =
-                m.dimensions.into_iter().map(|d| (d.name, d.keys)).collect();
-            Some(PyPartitionKey::Multi { keys })
+            if m.dimensions.is_empty() {
+                return Err(Status::invalid_argument(
+                    "multi partition_key has no dimensions",
+                ));
+            }
+            let mut keys: HashMap<String, Vec<String>> = HashMap::with_capacity(m.dimensions.len());
+            for d in m.dimensions {
+                if d.keys.is_empty() {
+                    return Err(Status::invalid_argument(format!(
+                        "partition_key dimension '{}' has no keys",
+                        d.name
+                    )));
+                }
+                let mut vals = d.keys;
+                vals.sort();
+                if keys.insert(d.name.clone(), vals).is_some() {
+                    return Err(Status::invalid_argument(format!(
+                        "duplicate partition_key dimension '{}'",
+                        d.name
+                    )));
+                }
+            }
+            Ok(PyPartitionKey::Multi { keys })
         }
     }
 }
 
-fn proto_partition_range_to_py(r: PartitionRange) -> Option<PyPartitionKeyRange> {
-    match r.kind? {
-        partition_range::Kind::Single(s) => Some(PyPartitionKeyRange {
+fn proto_partition_range_to_py(r: PartitionRange) -> Result<PyPartitionKeyRange, Status> {
+    let kind = r
+        .kind
+        .ok_or_else(|| Status::invalid_argument("partition_range has no kind set"))?;
+    match kind {
+        partition_range::Kind::Single(s) => Ok(PyPartitionKeyRange {
             inner: PartitionKeyRangeInner::Single {
                 from_key: s.from_key,
                 to_key: s.to_key,
@@ -891,7 +926,13 @@ fn proto_partition_range_to_py(r: PartitionRange) -> Option<PyPartitionKeyRange>
         partition_range::Kind::Multi(m) => {
             let mut dims = HashMap::new();
             for d in m.dimensions {
-                let sel = match d.selection? {
+                let selection = d.selection.ok_or_else(|| {
+                    Status::invalid_argument(format!(
+                        "partition_range dimension '{}' has no selection set",
+                        d.name
+                    ))
+                })?;
+                let sel = match selection {
                     dimension_range::Selection::Range(r) => DimensionSelection::Range {
                         from_key: r.from_key,
                         to_key: r.to_key,
@@ -900,22 +941,35 @@ fn proto_partition_range_to_py(r: PartitionRange) -> Option<PyPartitionKeyRange>
                         DimensionSelection::Keys(k.keys.into_iter().collect())
                     }
                 };
-                dims.insert(d.name, sel);
+                if dims.insert(d.name.clone(), sel).is_some() {
+                    return Err(Status::invalid_argument(format!(
+                        "duplicate partition_range dimension '{}'",
+                        d.name
+                    )));
+                }
             }
-            Some(PyPartitionKeyRange {
+            Ok(PyPartitionKeyRange {
                 inner: PartitionKeyRangeInner::Multi { dimensions: dims },
             })
         }
     }
 }
 
-fn proto_strategy_to_py(s: BackfillStrategyProto) -> Option<PyBackfillStrategy> {
-    match s.kind? {
+/// Unknown shorthands are rejected — silently mapping a typo to `MultiRun`
+/// would fan a one-run backfill out into one run per partition.
+fn proto_strategy_to_py(s: BackfillStrategyProto) -> Result<PyBackfillStrategy, Status> {
+    let kind = s
+        .kind
+        .ok_or_else(|| Status::invalid_argument("backfill strategy has no kind set"))?;
+    match kind {
         backfill_strategy_proto::Kind::Shorthand(s) => match s.as_str() {
-            "single_run" => Some(PyBackfillStrategy::SingleRun {}),
-            _ => Some(PyBackfillStrategy::MultiRun {}),
+            "single_run" => Ok(PyBackfillStrategy::SingleRun {}),
+            "multi_run" => Ok(PyBackfillStrategy::MultiRun {}),
+            other => Err(Status::invalid_argument(format!(
+                "unknown backfill strategy '{other}' (expected 'single_run' or 'multi_run')"
+            ))),
         },
-        backfill_strategy_proto::Kind::PerDimension(pd) => Some(PyBackfillStrategy::PerDimension {
+        backfill_strategy_proto::Kind::PerDimension(pd) => Ok(PyBackfillStrategy::PerDimension {
             multi_run_dims: pd.multi_run_dimensions,
             single_run_dims: pd.single_run_dimensions,
         }),

--- a/python/src/partitions/context.rs
+++ b/python/src/partitions/context.rs
@@ -71,8 +71,13 @@ impl PartitionContext {
 impl PartitionContext {
     #[new]
     #[pyo3(signature = (keys, definition))]
-    fn py_new(keys: Vec<PyPartitionKey>, definition: PartitionsDefinition) -> Self {
-        Self { keys, definition }
+    fn py_new(keys: Vec<PyPartitionKey>, definition: PartitionsDefinition) -> PyResult<Self> {
+        if keys.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "PartitionContext keys must not be empty",
+            ));
+        }
+        Ok(Self { keys, definition })
     }
 
     /// The single partition key. Convenience for `keys[0]` when processing

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -489,76 +489,38 @@ impl PartitionsDefinition {
         }
     }
 
+    /// The definition's wall-clock grid, for shifting/aligning keys.
+    /// `None` for non-TimeWindow kinds.
+    pub fn time_grid(&self) -> Option<rivers_core::timegrid::TimeGrid> {
+        match self {
+            Self::TimeWindow {
+                cron_schedule,
+                interval_seconds,
+                start,
+                end,
+                fmt,
+            } => Some(rivers_core::timegrid::TimeGrid {
+                cron_schedule: cron_schedule.clone(),
+                interval_seconds: *interval_seconds,
+                start: *start,
+                end: *end,
+                fmt: fmt.clone(),
+            }),
+            _ => None,
+        }
+    }
+
     /// Shift a TimeWindow key by `offset` windows (negative = earlier) —
-    /// the engine behind `PartitionMapping.time_window(offset=..)`.
-    /// Interval defs shift by exact nanosecond arithmetic; cron defs walk
-    /// the wall-clock tick grid. Errors when the shifted window falls
-    /// outside `[start, end)`.
+    /// the engine behind `PartitionMapping.time_window(offset=..)`. Errors
+    /// when the shifted window falls outside `[start, end)`.
     pub fn shift_time_key(&self, key: &str, offset: i64) -> PyResult<String> {
-        let Self::TimeWindow {
-            cron_schedule,
-            interval_seconds,
-            start,
-            end,
-            fmt,
-        } = self
-        else {
-            return Err(PartitionDefinitionError::new_err(
+        let grid = self.time_grid().ok_or_else(|| {
+            PartitionDefinitionError::new_err(
                 "time_window mapping requires a TimeWindow partition definition",
-            ));
-        };
-        let dt = parse_key_datetime(key, fmt).map_err(|e| {
-            PartitionDefinitionError::new_err(format!("Invalid time window key '{key}': {e}"))
+            )
         })?;
-        if offset == 0 {
-            return Ok(key.to_string());
-        }
-        let shifted = if let Some(secs) = interval_seconds {
-            let interval_ns = (*secs * 1_000_000_000.0) as i64;
-            let total = interval_ns.checked_mul(offset).ok_or_else(|| {
-                PartitionDefinitionError::new_err(format!(
-                    "time_window offset {offset} overflows for interval {secs}s"
-                ))
-            })?;
-            dt + chrono::Duration::nanoseconds(total)
-        } else if let Some(expr) = cron_schedule {
-            let cron = parse_cron(expr)?;
-            let anchor = Utc.from_utc_datetime(&dt);
-            let direction = if offset > 0 {
-                croner::Direction::Forward
-            } else {
-                croner::Direction::Backward
-            };
-            let mut remaining = offset.unsigned_abs();
-            let mut shifted = None;
-            for tick in cron.iter_from(anchor, direction) {
-                if tick == anchor {
-                    continue;
-                }
-                remaining -= 1;
-                if remaining == 0 {
-                    shifted = Some(tick.naive_utc());
-                    break;
-                }
-            }
-            shifted.ok_or_else(|| {
-                PartitionDefinitionError::new_err(format!(
-                    "Cannot shift time window key '{key}' by {offset} windows"
-                ))
-            })?
-        } else {
-            return Err(PartitionDefinitionError::new_err(
-                "TimeWindow requires either cron_schedule or interval_seconds",
-            ));
-        };
-        let end_dt = time_window_end(end);
-        if shifted < *start || shifted >= end_dt {
-            return Err(PartitionDefinitionError::new_err(format!(
-                "time_window(offset={offset}) maps '{key}' outside the partition range \
-                 [{start}, {end_dt})"
-            )));
-        }
-        Ok(shifted.format(fmt).to_string())
+        grid.shift_key(key, offset)
+            .map_err(|e| PartitionDefinitionError::new_err(e.to_string()))
     }
 
     /// Check if a partition key is valid for this definition. Empty key

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -476,9 +476,6 @@ impl PartitionsDefinition {
             Ok(Some((window_start, window_end)))
         } else if let Some(cron_expr) = cron_schedule {
             let cron = parse_cron(cron_expr)?;
-            // Search in wall-clock-as-UTC: a gap-free, unambiguous timeline
-            // croner can't stall on (its Local search spins re-resolving the
-            // DST fall-back hour).
             let start_utc = Utc.from_utc_datetime(&window_start);
             let next = cron.find_next_occurrence(&start_utc, false).map_err(|e| {
                 PartitionDefinitionError::new_err(format!("Failed to find next cron tick: {e}"))
@@ -524,9 +521,7 @@ impl PartitionsDefinition {
     }
 
     /// Check if a partition key is valid for this definition. Empty key
-    /// vectors (constructible via `from_json` / proto, never via the Python
-    /// constructors) are invalid for every kind — without the explicit
-    /// checks they'd pass vacuously.
+    /// vectors are invalid for every kind.
     pub fn validate_partition_key(&self, key: &PyPartitionKey) -> PyResult<bool> {
         match (self, key) {
             (Self::Static { keys: valid_keys }, PyPartitionKey::Single { key }) => {
@@ -543,9 +538,8 @@ impl PartitionsDefinition {
                 PyPartitionKey::Single { key },
             ) => validate_time_window_key(key, cron_schedule, interval_seconds, start, end, fmt),
             (Self::Multi { dimensions }, PyPartitionKey::Multi { keys }) => {
-                // Every def dimension must be present (checked below), so a
-                // length mismatch means the key carries extra dimensions the
-                // def doesn't declare — reject instead of silently ignoring.
+                // Extra dimensions the def doesn't declare are rejected here;
+                // missing ones are caught by the per-dim loop below.
                 if keys.len() != dimensions.len() {
                     return Ok(false);
                 }
@@ -569,9 +563,7 @@ impl PartitionsDefinition {
                 }
                 Ok(true)
             }
-            // Dynamic key *membership* is storage-managed — checked against
-            // `dynamic_partitions` at the submit boundary, not here. The def
-            // only rejects the statically-knowable invalid shape.
+            // Dynamic membership is checked at the submit boundary against storage, not here.
             (Self::Dynamic { .. }, PyPartitionKey::Single { key }) => Ok(!key.is_empty()),
             // A batched Set is valid iff non-empty and every member is valid.
             (_, PyPartitionKey::Set { keys }) => {
@@ -976,11 +968,8 @@ fn validate_time_window_key(
                 return Ok(false);
             }
         } else if let Some(expr) = cron_schedule {
-            // Membership must match enumeration exactly. Matching the parsed
-            // wall-clock against the cron misclassifies keys around DST
-            // transitions (gap ticks are skipped, fall-back and shifted
-            // ticks resolve to different wall-clock times), so walk the
-            // surrounding window's ticks and compare formatted keys.
+            // Compare formatted keys, not parsed datetimes — cron ticks near
+            // DST transitions don't round-trip through the formatter reliably.
             let window_start = (dt - chrono::Duration::hours(26)).max(*start);
             let window_end = (dt + chrono::Duration::hours(26)).min(end_dt);
             let mut found = false;
@@ -1143,10 +1132,6 @@ fn for_each_cron_tick(
     mut f: impl FnMut(NaiveDateTime) -> bool,
 ) -> PyResult<()> {
     let cron = parse_cron(cron_expr)?;
-    // Iterate the cron over the naive wall clock interpreted as UTC. Keys
-    // are wall-clock labels: this grid has no DST gaps or duplicates, is
-    // identical on every host timezone, and croner can't stall on it (its
-    // Local iteration spins re-resolving the DST fall-back hour).
     let start_utc = Utc.from_utc_datetime(start);
     for tick in cron.iter_from(start_utc, croner::Direction::Forward) {
         let naive = tick.naive_utc();

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -985,30 +985,19 @@ fn validate_time_window_fmt(
     end: &Option<NaiveDateTime>,
     fmt: &str,
 ) -> PyResult<()> {
+    // Walk the grid with the same helpers `enumerate` uses — validation must
+    // judge exactly the keys the definition will mint.
     let mut ticks: Vec<NaiveDateTime> = Vec::with_capacity(2);
     if let Some(secs) = interval_seconds {
-        ticks.push(*start);
-        let ns = (*secs * 1_000_000_000.0) as i64;
-        if let Some(t1) = start.checked_add_signed(chrono::Duration::nanoseconds(ns)) {
-            ticks.push(t1);
-        }
-    } else if let Some(expr) = cron_schedule {
-        use chrono::Timelike;
-        let cron = parse_cron(expr)?;
-        let anchor = start
-            .checked_sub_signed(chrono::Duration::seconds(1))
-            .unwrap_or(*start);
-        for tick in cron.iter_from(Utc.from_utc_datetime(&anchor), croner::Direction::Forward) {
-            let naive = tick.naive_utc();
-            let t = naive.with_nanosecond(0).unwrap_or(naive);
-            if t < *start {
-                continue;
-            }
+        for_each_interval_tick(*secs, start, NaiveDateTime::MAX, |t| {
             ticks.push(t);
-            if ticks.len() == 2 {
-                break;
-            }
-        }
+            ticks.len() < 2
+        });
+    } else if let Some(expr) = cron_schedule {
+        for_each_cron_tick(expr, start, NaiveDateTime::MAX, |t| {
+            ticks.push(t);
+            ticks.len() < 2
+        })?;
     }
     if let Some(end_dt) = end {
         ticks.retain(|t| t < end_dt);

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -825,10 +825,7 @@ impl PartitionsDefinition {
             }
             // Dim names sit left of '=' in `dim=value` display segments, so
             // '=' is reserved for them on top of the value separators.
-            if let Some(ch) = ['|', ',', '=']
-                .into_iter()
-                .find(|&c| name.contains(c))
-            {
+            if let Some(ch) = ['|', ',', '='].into_iter().find(|&c| name.contains(c)) {
                 return Err(PartitionDefinitionError::new_err(format!(
                     "dimension name '{name}' contains reserved character '{ch}' \
                      (used by the canonical display form)"

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -1261,7 +1261,7 @@ fn interval_index(
 /// Always terminates at `end_dt` (the explicit `end`, or now if open-ended);
 /// uncapped, so a fine-grained def over a wide range is slow but never hides
 /// partitions.
-fn for_each_interval_tick(
+pub(crate) fn for_each_interval_tick(
     secs: f64,
     start: &NaiveDateTime,
     end_dt: NaiveDateTime,
@@ -1288,7 +1288,7 @@ fn for_each_interval_tick(
 /// Always terminates at `end_dt` (the explicit `end`, or now if open-ended);
 /// uncapped, so a fine-grained schedule over a wide range is slow but never
 /// hides partitions.
-fn for_each_cron_tick(
+pub(crate) fn for_each_cron_tick(
     cron_expr: &str,
     start: &NaiveDateTime,
     end_dt: NaiveDateTime,
@@ -1306,6 +1306,19 @@ fn for_each_cron_tick(
         }
     }
     Ok(())
+}
+
+/// Whether `t` falls exactly on the cron grid (cron is second-granular).
+pub(crate) fn cron_grid_contains(cron_expr: &str, t: NaiveDateTime) -> PyResult<bool> {
+    let probe_end = t
+        .checked_add_signed(chrono::Duration::seconds(1))
+        .unwrap_or(NaiveDateTime::MAX);
+    let mut hit = false;
+    for_each_cron_tick(cron_expr, &t, probe_end, |tick| {
+        hit = tick == t;
+        false
+    })?;
+    Ok(hit)
 }
 
 /// Compute the cartesian product of dimension keys.

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -724,26 +724,40 @@ impl PartitionsDefinition {
 
     #[staticmethod]
     #[pyo3(signature = (start, end=None, fmt=None))]
-    fn daily(start: NaiveDateTime, end: Option<NaiveDateTime>, fmt: Option<String>) -> Self {
-        Self::TimeWindow {
-            cron_schedule: Some("0 0 * * *".to_string()),
+    fn daily(
+        start: NaiveDateTime,
+        end: Option<NaiveDateTime>,
+        fmt: Option<String>,
+    ) -> PyResult<Self> {
+        let cron = Some("0 0 * * *".to_string());
+        let fmt = fmt.unwrap_or_else(|| "%Y-%m-%d".to_string());
+        validate_time_window_fmt(&cron, &None, &start, &end, &fmt)?;
+        Ok(Self::TimeWindow {
+            cron_schedule: cron,
             interval_seconds: None,
             start,
             end,
-            fmt: fmt.unwrap_or_else(|| "%Y-%m-%d".to_string()),
-        }
+            fmt,
+        })
     }
 
     #[staticmethod]
     #[pyo3(signature = (start, end=None, fmt=None))]
-    fn hourly(start: NaiveDateTime, end: Option<NaiveDateTime>, fmt: Option<String>) -> Self {
-        Self::TimeWindow {
-            cron_schedule: Some("0 * * * *".to_string()),
+    fn hourly(
+        start: NaiveDateTime,
+        end: Option<NaiveDateTime>,
+        fmt: Option<String>,
+    ) -> PyResult<Self> {
+        let cron = Some("0 * * * *".to_string());
+        let fmt = fmt.unwrap_or_else(|| "%Y-%m-%dT%H:00".to_string());
+        validate_time_window_fmt(&cron, &None, &start, &end, &fmt)?;
+        Ok(Self::TimeWindow {
+            cron_schedule: cron,
             interval_seconds: None,
             start,
             end,
-            fmt: fmt.unwrap_or_else(|| "%Y-%m-%dT%H:00".to_string()),
-        }
+            fmt,
+        })
     }
 
     #[staticmethod]
@@ -774,12 +788,14 @@ impl PartitionsDefinition {
                 )));
             }
         }
+        let fmt = fmt.unwrap_or_else(|| "%Y-%m-%dT%H:%M:%S".to_string());
+        validate_time_window_fmt(&cron_schedule, &interval_seconds, &start, &end, &fmt)?;
         Ok(Self::TimeWindow {
             cron_schedule,
             interval_seconds,
             start,
             end,
-            fmt: fmt.unwrap_or_else(|| "%Y-%m-%dT%H:%M:%S".to_string()),
+            fmt,
         })
     }
 
@@ -931,6 +947,68 @@ fn parse_cron(expr: &str) -> PyResult<Cron> {
         .map_err(|e| {
             PartitionDefinitionError::new_err(format!("Invalid cron expression '{expr}': {e}"))
         })
+}
+
+/// A TimeWindow fmt must round-trip the grid's window starts: each tick
+/// formats to a key that parses back to exactly that tick. A coarser fmt
+/// collapses neighbouring windows into the same key string (duplicate keys
+/// from enumerate, double-dispatched backfill runs); a non-parseable fmt
+/// breaks every downstream key validation. Checked on the first two ticks.
+fn validate_time_window_fmt(
+    cron_schedule: &Option<String>,
+    interval_seconds: &Option<f64>,
+    start: &NaiveDateTime,
+    end: &Option<NaiveDateTime>,
+    fmt: &str,
+) -> PyResult<()> {
+    let mut ticks: Vec<NaiveDateTime> = Vec::with_capacity(2);
+    if let Some(secs) = interval_seconds {
+        ticks.push(*start);
+        let ns = (*secs * 1_000_000_000.0) as i64;
+        if let Some(t1) = start.checked_add_signed(chrono::Duration::nanoseconds(ns)) {
+            ticks.push(t1);
+        }
+    } else if let Some(expr) = cron_schedule {
+        use chrono::Timelike;
+        let cron = parse_cron(expr)?;
+        let anchor = start
+            .checked_sub_signed(chrono::Duration::seconds(1))
+            .unwrap_or(*start);
+        for tick in cron.iter_from(Utc.from_utc_datetime(&anchor), croner::Direction::Forward) {
+            let naive = tick.naive_utc();
+            let t = naive.with_nanosecond(0).unwrap_or(naive);
+            if t < *start {
+                continue;
+            }
+            ticks.push(t);
+            if ticks.len() == 2 {
+                break;
+            }
+        }
+    }
+    if let Some(end_dt) = end {
+        ticks.retain(|t| t < end_dt);
+    }
+    for t in &ticks {
+        let key = t.format(fmt).to_string();
+        match parse_key_datetime(&key, fmt) {
+            Ok(parsed) if parsed == *t => {}
+            Ok(parsed) => {
+                return Err(PartitionDefinitionError::new_err(format!(
+                    "fmt '{fmt}' cannot represent the partition grid: window start {t} \
+                     formats to '{key}', which parses back to {parsed}; \
+                     use a format at least as fine as the grid"
+                )));
+            }
+            Err(e) => {
+                return Err(PartitionDefinitionError::new_err(format!(
+                    "fmt '{fmt}' cannot represent the partition grid: window start {t} \
+                     formats to '{key}', which does not parse back: {e}"
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Check if all key strings fall on valid time window boundaries within [start, end).

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -717,6 +717,14 @@ impl PartitionsDefinition {
                 "Static partitions must have at least one key",
             ));
         }
+        for key in &keys {
+            if let Some(ch) = rivers_core::storage::PartitionKey::reserved_display_char(key) {
+                return Err(PartitionDefinitionError::new_err(format!(
+                    "partition key '{key}' contains reserved character '{ch}' \
+                     (used by the canonical display form)"
+                )));
+            }
+        }
         Ok(Self::Static {
             keys: OrderedKeySet::new(keys),
         })
@@ -809,6 +817,22 @@ impl PartitionsDefinition {
                 return Err(PartitionDefinitionError::new_err(
                     "Multi partitions cannot contain nested Multi dimensions",
                 ));
+            }
+            if name.is_empty() {
+                return Err(PartitionDefinitionError::new_err(
+                    "Multi dimension names cannot be empty",
+                ));
+            }
+            // Dim names sit left of '=' in `dim=value` display segments, so
+            // '=' is reserved for them on top of the value separators.
+            if let Some(ch) = ['|', ',', '=']
+                .into_iter()
+                .find(|&c| name.contains(c))
+            {
+                return Err(PartitionDefinitionError::new_err(format!(
+                    "dimension name '{name}' contains reserved character '{ch}' \
+                     (used by the canonical display form)"
+                )));
             }
             dims.push((name, def));
         }
@@ -991,6 +1015,12 @@ fn validate_time_window_fmt(
     }
     for t in &ticks {
         let key = t.format(fmt).to_string();
+        if let Some(ch) = rivers_core::storage::PartitionKey::reserved_display_char(&key) {
+            return Err(PartitionDefinitionError::new_err(format!(
+                "fmt '{fmt}' produces keys containing reserved character '{ch}' \
+                 (used by the canonical display form): '{key}'"
+            )));
+        }
         match parse_key_datetime(&key, fmt) {
             Ok(parsed) if parsed == *t => {}
             Ok(parsed) => {

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -990,6 +990,17 @@ fn validate_time_window_fmt(
     end: &Option<NaiveDateTime>,
     fmt: &str,
 ) -> PyResult<()> {
+    // Cron schedules are second-granular: croner leaks a sub-second start's
+    // fraction into every tick here, while the core grid walk truncates to
+    // whole seconds — the two layers would mint different universes.
+    if cron_schedule.is_some() {
+        use chrono::Timelike;
+        if start.nanosecond() != 0 {
+            return Err(PartitionDefinitionError::new_err(format!(
+                "cron-gridded time windows require a start on a whole second, got {start}"
+            )));
+        }
+    }
     const MAX_TICKS: usize = 1024;
     let horizon = start
         .checked_add_signed(chrono::Duration::days(1461))

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -941,7 +941,6 @@ fn parse_cron(expr: &str) -> PyResult<Cron> {
         })
 }
 
-
 /// Check if all key strings fall on valid time window boundaries within [start, end).
 fn validate_time_window_key(
     key: &[String],

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -708,31 +708,115 @@ impl PartitionsDefinition {
     }
 }
 
+impl PartitionsDefinition {
+    /// Full structural validation — every rule the factory staticmethods
+    /// enforce. PyO3 generates a raw constructor per enum variant that
+    /// bypasses the factories (and the unpickle path depends on them), so
+    /// `resolve()` re-validates every asset's definition through this.
+    pub(crate) fn validate_definition(&self) -> PyResult<()> {
+        match self {
+            Self::Static { keys } => {
+                if keys.is_empty() {
+                    return Err(PartitionDefinitionError::new_err(
+                        "Static partitions must have at least one key",
+                    ));
+                }
+                for key in keys.iter() {
+                    if key.is_empty() {
+                        return Err(PartitionDefinitionError::new_err(
+                            "static partition keys must not be empty",
+                        ));
+                    }
+                    if let Some(ch) = rivers_core::storage::PartitionKey::reserved_display_char(key)
+                    {
+                        return Err(PartitionDefinitionError::new_err(format!(
+                            "partition key '{key}' contains reserved character '{ch}' \
+                             (used by the canonical display form)"
+                        )));
+                    }
+                }
+                Ok(())
+            }
+            Self::TimeWindow {
+                cron_schedule,
+                interval_seconds,
+                start,
+                end,
+                fmt,
+            } => {
+                if cron_schedule.is_none() && interval_seconds.is_none() {
+                    return Err(PartitionDefinitionError::new_err(
+                        "time_window requires either cron_schedule or interval_seconds",
+                    ));
+                }
+                if cron_schedule.is_some() && interval_seconds.is_some() {
+                    return Err(PartitionDefinitionError::new_err(
+                        "time_window accepts cron_schedule or interval_seconds, not both",
+                    ));
+                }
+                if let Some(secs) = interval_seconds {
+                    // Sub-nanosecond values truncate to 0ns, which would divide
+                    // by zero in the key-validation modulo.
+                    if !secs.is_finite() || *secs <= 0.0 || (secs * 1_000_000_000.0) as i64 == 0 {
+                        return Err(PartitionDefinitionError::new_err(format!(
+                            "interval_seconds must be positive and at least 1 nanosecond, \
+                             got {secs}"
+                        )));
+                    }
+                }
+                validate_time_window_fmt(cron_schedule, interval_seconds, start, end, fmt)
+            }
+            Self::Multi { dimensions } => {
+                if dimensions.is_empty() {
+                    return Err(PartitionDefinitionError::new_err(
+                        "Multi partitions must have at least one dimension",
+                    ));
+                }
+                for (name, def) in dimensions {
+                    if matches!(def, Self::Multi { .. }) {
+                        return Err(PartitionDefinitionError::new_err(
+                            "Multi partitions cannot contain nested Multi dimensions",
+                        ));
+                    }
+                    if name.is_empty() {
+                        return Err(PartitionDefinitionError::new_err(
+                            "Multi dimension names cannot be empty",
+                        ));
+                    }
+                    // Dim names sit left of '=' in `dim=value` display
+                    // segments, so '=' is reserved for them on top of the
+                    // value separators.
+                    if let Some(ch) = ['|', ',', '='].into_iter().find(|&c| name.contains(c)) {
+                        return Err(PartitionDefinitionError::new_err(format!(
+                            "dimension name '{name}' contains reserved character '{ch}' \
+                             (used by the canonical display form)"
+                        )));
+                    }
+                    def.validate_definition()?;
+                }
+                Ok(())
+            }
+            Self::Dynamic { name } => {
+                if name.is_empty() {
+                    return Err(PartitionDefinitionError::new_err(
+                        "Dynamic partition definition name cannot be empty",
+                    ));
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
 #[pymethods]
 impl PartitionsDefinition {
     #[staticmethod]
     fn static_(keys: Vec<String>) -> PyResult<Self> {
-        if keys.is_empty() {
-            return Err(PartitionDefinitionError::new_err(
-                "Static partitions must have at least one key",
-            ));
-        }
-        for key in &keys {
-            if key.is_empty() {
-                return Err(PartitionDefinitionError::new_err(
-                    "static partition keys must not be empty",
-                ));
-            }
-            if let Some(ch) = rivers_core::storage::PartitionKey::reserved_display_char(key) {
-                return Err(PartitionDefinitionError::new_err(format!(
-                    "partition key '{key}' contains reserved character '{ch}' \
-                     (used by the canonical display form)"
-                )));
-            }
-        }
-        Ok(Self::Static {
+        let def = Self::Static {
             keys: OrderedKeySet::new(keys),
-        })
+        };
+        def.validate_definition()?;
+        Ok(def)
     }
 
     #[staticmethod]
@@ -742,16 +826,15 @@ impl PartitionsDefinition {
         end: Option<NaiveDateTime>,
         fmt: Option<String>,
     ) -> PyResult<Self> {
-        let cron = Some("0 0 * * *".to_string());
-        let fmt = fmt.unwrap_or_else(|| "%Y-%m-%d".to_string());
-        validate_time_window_fmt(&cron, &None, &start, &end, &fmt)?;
-        Ok(Self::TimeWindow {
-            cron_schedule: cron,
+        let def = Self::TimeWindow {
+            cron_schedule: Some("0 0 * * *".to_string()),
             interval_seconds: None,
             start,
             end,
-            fmt,
-        })
+            fmt: fmt.unwrap_or_else(|| "%Y-%m-%d".to_string()),
+        };
+        def.validate_definition()?;
+        Ok(def)
     }
 
     #[staticmethod]
@@ -761,16 +844,15 @@ impl PartitionsDefinition {
         end: Option<NaiveDateTime>,
         fmt: Option<String>,
     ) -> PyResult<Self> {
-        let cron = Some("0 * * * *".to_string());
-        let fmt = fmt.unwrap_or_else(|| "%Y-%m-%dT%H:00".to_string());
-        validate_time_window_fmt(&cron, &None, &start, &end, &fmt)?;
-        Ok(Self::TimeWindow {
-            cron_schedule: cron,
+        let def = Self::TimeWindow {
+            cron_schedule: Some("0 * * * *".to_string()),
             interval_seconds: None,
             start,
             end,
-            fmt,
-        })
+            fmt: fmt.unwrap_or_else(|| "%Y-%m-%dT%H:00".to_string()),
+        };
+        def.validate_definition()?;
+        Ok(def)
     }
 
     #[staticmethod]
@@ -782,34 +864,15 @@ impl PartitionsDefinition {
         end: Option<NaiveDateTime>,
         fmt: Option<String>,
     ) -> PyResult<Self> {
-        if cron_schedule.is_none() && interval_seconds.is_none() {
-            return Err(PartitionDefinitionError::new_err(
-                "time_window requires either cron_schedule or interval_seconds",
-            ));
-        }
-        if cron_schedule.is_some() && interval_seconds.is_some() {
-            return Err(PartitionDefinitionError::new_err(
-                "time_window accepts cron_schedule or interval_seconds, not both",
-            ));
-        }
-        if let Some(secs) = interval_seconds {
-            // Sub-nanosecond values truncate to 0ns, which would divide by
-            // zero in the key-validation modulo.
-            if !secs.is_finite() || secs <= 0.0 || (secs * 1_000_000_000.0) as i64 == 0 {
-                return Err(PartitionDefinitionError::new_err(format!(
-                    "interval_seconds must be positive and at least 1 nanosecond, got {secs}"
-                )));
-            }
-        }
-        let fmt = fmt.unwrap_or_else(|| "%Y-%m-%dT%H:%M:%S".to_string());
-        validate_time_window_fmt(&cron_schedule, &interval_seconds, &start, &end, &fmt)?;
-        Ok(Self::TimeWindow {
+        let def = Self::TimeWindow {
             cron_schedule,
             interval_seconds,
             start,
             end,
-            fmt,
-        })
+            fmt: fmt.unwrap_or_else(|| "%Y-%m-%dT%H:%M:%S".to_string()),
+        };
+        def.validate_definition()?;
+        Ok(def)
     }
 
     #[staticmethod]
@@ -818,32 +881,11 @@ impl PartitionsDefinition {
         for (k, v) in dimensions.iter() {
             let name: String = k.extract()?;
             let def: PartitionsDefinition = v.extract()?;
-            if matches!(def, PartitionsDefinition::Multi { .. }) {
-                return Err(PartitionDefinitionError::new_err(
-                    "Multi partitions cannot contain nested Multi dimensions",
-                ));
-            }
-            if name.is_empty() {
-                return Err(PartitionDefinitionError::new_err(
-                    "Multi dimension names cannot be empty",
-                ));
-            }
-            // Dim names sit left of '=' in `dim=value` display segments, so
-            // '=' is reserved for them on top of the value separators.
-            if let Some(ch) = ['|', ',', '='].into_iter().find(|&c| name.contains(c)) {
-                return Err(PartitionDefinitionError::new_err(format!(
-                    "dimension name '{name}' contains reserved character '{ch}' \
-                     (used by the canonical display form)"
-                )));
-            }
             dims.push((name, def));
         }
-        if dims.is_empty() {
-            return Err(PartitionDefinitionError::new_err(
-                "Multi partitions must have at least one dimension",
-            ));
-        }
-        Ok(Self::Multi { dimensions: dims })
+        let def = Self::Multi { dimensions: dims };
+        def.validate_definition()?;
+        Ok(def)
     }
 
     #[staticmethod]

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -5,7 +5,7 @@
 //! via the `croner` crate, bounded by `start_date` / `end_date` / `end_offset`.
 use std::collections::HashMap;
 
-use chrono::{Local, NaiveDateTime, TimeZone};
+use chrono::{Local, NaiveDateTime, TimeZone, Utc};
 use croner::Cron;
 use ordermap::OrderSet;
 use pyo3::exceptions::PyNotImplementedError;
@@ -476,23 +476,99 @@ impl PartitionsDefinition {
             Ok(Some((window_start, window_end)))
         } else if let Some(cron_expr) = cron_schedule {
             let cron = parse_cron(cron_expr)?;
-            let start_local = naive_to_local(&window_start)?;
-            let next = cron
-                .find_next_occurrence(&start_local, false)
-                .map_err(|e| {
-                    PartitionDefinitionError::new_err(format!("Failed to find next cron tick: {e}"))
-                })?;
-            Ok(Some((window_start, next.naive_local())))
+            // Search in wall-clock-as-UTC: a gap-free, unambiguous timeline
+            // croner can't stall on (its Local search spins re-resolving the
+            // DST fall-back hour).
+            let start_utc = Utc.from_utc_datetime(&window_start);
+            let next = cron.find_next_occurrence(&start_utc, false).map_err(|e| {
+                PartitionDefinitionError::new_err(format!("Failed to find next cron tick: {e}"))
+            })?;
+            Ok(Some((window_start, next.naive_utc())))
         } else {
             Ok(None)
         }
     }
 
-    /// Check if a partition key is valid for this definition.
+    /// Shift a TimeWindow key by `offset` windows (negative = earlier) —
+    /// the engine behind `PartitionMapping.time_window(offset=..)`.
+    /// Interval defs shift by exact nanosecond arithmetic; cron defs walk
+    /// the wall-clock tick grid. Errors when the shifted window falls
+    /// outside `[start, end)`.
+    pub fn shift_time_key(&self, key: &str, offset: i64) -> PyResult<String> {
+        let Self::TimeWindow {
+            cron_schedule,
+            interval_seconds,
+            start,
+            end,
+            fmt,
+        } = self
+        else {
+            return Err(PartitionDefinitionError::new_err(
+                "time_window mapping requires a TimeWindow partition definition",
+            ));
+        };
+        let dt = parse_key_datetime(key, fmt).map_err(|e| {
+            PartitionDefinitionError::new_err(format!("Invalid time window key '{key}': {e}"))
+        })?;
+        if offset == 0 {
+            return Ok(key.to_string());
+        }
+        let shifted = if let Some(secs) = interval_seconds {
+            let interval_ns = (*secs * 1_000_000_000.0) as i64;
+            let total = interval_ns.checked_mul(offset).ok_or_else(|| {
+                PartitionDefinitionError::new_err(format!(
+                    "time_window offset {offset} overflows for interval {secs}s"
+                ))
+            })?;
+            dt + chrono::Duration::nanoseconds(total)
+        } else if let Some(expr) = cron_schedule {
+            let cron = parse_cron(expr)?;
+            let anchor = Utc.from_utc_datetime(&dt);
+            let direction = if offset > 0 {
+                croner::Direction::Forward
+            } else {
+                croner::Direction::Backward
+            };
+            let mut remaining = offset.unsigned_abs();
+            let mut shifted = None;
+            for tick in cron.iter_from(anchor, direction) {
+                if tick == anchor {
+                    continue;
+                }
+                remaining -= 1;
+                if remaining == 0 {
+                    shifted = Some(tick.naive_utc());
+                    break;
+                }
+            }
+            shifted.ok_or_else(|| {
+                PartitionDefinitionError::new_err(format!(
+                    "Cannot shift time window key '{key}' by {offset} windows"
+                ))
+            })?
+        } else {
+            return Err(PartitionDefinitionError::new_err(
+                "TimeWindow requires either cron_schedule or interval_seconds",
+            ));
+        };
+        let end_dt = time_window_end(end);
+        if shifted < *start || shifted >= end_dt {
+            return Err(PartitionDefinitionError::new_err(format!(
+                "time_window(offset={offset}) maps '{key}' outside the partition range \
+                 [{start}, {end_dt})"
+            )));
+        }
+        Ok(shifted.format(fmt).to_string())
+    }
+
+    /// Check if a partition key is valid for this definition. Empty key
+    /// vectors (constructible via `from_json` / proto, never via the Python
+    /// constructors) are invalid for every kind — without the explicit
+    /// checks they'd pass vacuously.
     pub fn validate_partition_key(&self, key: &PyPartitionKey) -> PyResult<bool> {
         match (self, key) {
             (Self::Static { keys: valid_keys }, PyPartitionKey::Single { key }) => {
-                Ok(key.iter().all(|k| valid_keys.contains(k)))
+                Ok(!key.is_empty() && key.iter().all(|k| valid_keys.contains(k)))
             }
             (
                 Self::TimeWindow {
@@ -505,9 +581,18 @@ impl PartitionsDefinition {
                 PyPartitionKey::Single { key },
             ) => validate_time_window_key(key, cron_schedule, interval_seconds, start, end, fmt),
             (Self::Multi { dimensions }, PyPartitionKey::Multi { keys }) => {
+                // Every def dimension must be present (checked below), so a
+                // length mismatch means the key carries extra dimensions the
+                // def doesn't declare — reject instead of silently ignoring.
+                if keys.len() != dimensions.len() {
+                    return Ok(false);
+                }
                 for (dim_name, dim_def) in dimensions {
                     match keys.get(dim_name) {
                         Some(vals) => {
+                            if vals.is_empty() {
+                                return Ok(false);
+                            }
                             for val in vals {
                                 let single_key = PyPartitionKey::Single {
                                     key: vec![val.clone()],
@@ -522,10 +607,15 @@ impl PartitionsDefinition {
                 }
                 Ok(true)
             }
-            // Dynamic partitions accept any single key (keys are storage-managed, not statically validated).
-            (Self::Dynamic { .. }, PyPartitionKey::Single { .. }) => Ok(true),
-            // A batched Set is valid iff every member is valid for this definition.
+            // Dynamic key *membership* is storage-managed — checked against
+            // `dynamic_partitions` at the submit boundary, not here. The def
+            // only rejects the statically-knowable invalid shape.
+            (Self::Dynamic { .. }, PyPartitionKey::Single { key }) => Ok(!key.is_empty()),
+            // A batched Set is valid iff non-empty and every member is valid.
             (_, PyPartitionKey::Set { keys }) => {
+                if keys.is_empty() {
+                    return Ok(false);
+                }
                 for member in keys {
                     if !self.validate_partition_key(member)? {
                         return Ok(false);
@@ -721,6 +811,15 @@ impl PartitionsDefinition {
                 "time_window accepts cron_schedule or interval_seconds, not both",
             ));
         }
+        if let Some(secs) = interval_seconds {
+            // Sub-nanosecond values truncate to 0ns, which would divide by
+            // zero in the key-validation modulo.
+            if !secs.is_finite() || secs <= 0.0 || (secs * 1_000_000_000.0) as i64 == 0 {
+                return Err(PartitionDefinitionError::new_err(format!(
+                    "interval_seconds must be positive and at least 1 nanosecond, got {secs}"
+                )));
+            }
+        }
         Ok(Self::TimeWindow {
             cron_schedule,
             interval_seconds,
@@ -880,12 +979,6 @@ fn parse_cron(expr: &str) -> PyResult<Cron> {
         })
 }
 
-fn naive_to_local(dt: &NaiveDateTime) -> PyResult<chrono::DateTime<Local>> {
-    Local
-        .from_local_datetime(dt)
-        .single()
-        .ok_or_else(|| PartitionDefinitionError::new_err(format!("Ambiguous local time: {dt}")))
-}
 
 /// Check if all key strings fall on valid time window boundaries within [start, end).
 fn validate_time_window_key(
@@ -898,7 +991,9 @@ fn validate_time_window_key(
 ) -> PyResult<bool> {
     let now = Local::now().naive_local();
     let end_dt = end.unwrap_or(now);
-    let cron = cron_schedule.as_deref().map(parse_cron).transpose()?;
+    if key.is_empty() {
+        return Ok(false);
+    }
     for k in key {
         let dt = match parse_key_datetime(k, fmt) {
             Ok(dt) => dt,
@@ -910,18 +1005,32 @@ fn validate_time_window_key(
         if let Some(secs) = interval_seconds {
             let from_start = dt.signed_duration_since(*start);
             let interval_ns = (*secs * 1_000_000_000.0) as i64;
+            if interval_ns <= 0 {
+                return Ok(false);
+            }
             if from_start
                 .num_nanoseconds()
                 .is_none_or(|n| n % interval_ns != 0)
             {
                 return Ok(false);
             }
-        } else if let Some(ref cron) = cron {
-            let dt_local = naive_to_local(&dt)?;
-            let matches = cron
-                .is_time_matching(&dt_local)
-                .map_err(|e| PartitionDefinitionError::new_err(format!("Cron match error: {e}")))?;
-            if !matches {
+        } else if let Some(expr) = cron_schedule {
+            // Membership must match enumeration exactly. Matching the parsed
+            // wall-clock against the cron misclassifies keys around DST
+            // transitions (gap ticks are skipped, fall-back and shifted
+            // ticks resolve to different wall-clock times), so walk the
+            // surrounding window's ticks and compare formatted keys.
+            let window_start = (dt - chrono::Duration::hours(26)).max(*start);
+            let window_end = (dt + chrono::Duration::hours(26)).min(end_dt);
+            let mut found = false;
+            for_each_cron_tick(expr, &window_start, window_end, |naive| {
+                if naive.format(fmt).to_string() == *k {
+                    found = true;
+                    return false;
+                }
+                true
+            })?;
+            if !found {
                 return Ok(false);
             }
         }
@@ -1073,9 +1182,13 @@ fn for_each_cron_tick(
     mut f: impl FnMut(NaiveDateTime) -> bool,
 ) -> PyResult<()> {
     let cron = parse_cron(cron_expr)?;
-    let start_local = naive_to_local(start)?;
-    for tick in cron.iter_from(start_local, croner::Direction::Forward) {
-        let naive = tick.naive_local();
+    // Iterate the cron over the naive wall clock interpreted as UTC. Keys
+    // are wall-clock labels: this grid has no DST gaps or duplicates, is
+    // identical on every host timezone, and croner can't stall on it (its
+    // Local iteration spins re-resolving the DST fall-back hour).
+    let start_utc = Utc.from_utc_datetime(start);
+    for tick in cron.iter_from(start_utc, croner::Direction::Forward) {
+        let naive = tick.naive_utc();
         if naive >= end_dt {
             break;
         }

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -979,7 +979,10 @@ fn parse_cron(expr: &str) -> PyResult<Cron> {
 /// formats to a key that parses back to exactly that tick. A coarser fmt
 /// collapses neighbouring windows into the same key string (duplicate keys
 /// from enumerate, double-dispatched backfill runs); a non-parseable fmt
-/// breaks every downstream key validation. Checked on the first two ticks.
+/// breaks every downstream key validation. Checked across the grid's first
+/// four years (one full leap cycle), capped at 1024 ticks — calendar drift
+/// that two ticks can't show (a month-grain fmt over a 31-day interval first
+/// diverges at tick 2) surfaces inside that horizon.
 fn validate_time_window_fmt(
     cron_schedule: &Option<String>,
     interval_seconds: &Option<f64>,
@@ -987,49 +990,57 @@ fn validate_time_window_fmt(
     end: &Option<NaiveDateTime>,
     fmt: &str,
 ) -> PyResult<()> {
+    const MAX_TICKS: usize = 1024;
+    let horizon = start
+        .checked_add_signed(chrono::Duration::days(1461))
+        .unwrap_or(NaiveDateTime::MAX);
+    let bound = match end {
+        Some(e) => (*e).min(horizon),
+        None => horizon,
+    };
     // Walk the grid with the same helpers `enumerate` uses — validation must
     // judge exactly the keys the definition will mint.
-    let mut ticks: Vec<NaiveDateTime> = Vec::with_capacity(2);
-    if let Some(secs) = interval_seconds {
-        for_each_interval_tick(*secs, start, NaiveDateTime::MAX, |t| {
-            ticks.push(t);
-            ticks.len() < 2
-        });
-    } else if let Some(expr) = cron_schedule {
-        for_each_cron_tick(expr, start, NaiveDateTime::MAX, |t| {
-            ticks.push(t);
-            ticks.len() < 2
-        })?;
-    }
-    if let Some(end_dt) = end {
-        ticks.retain(|t| t < end_dt);
-    }
-    for t in &ticks {
+    let mut checked = 0usize;
+    let mut failure: Option<PyErr> = None;
+    let mut check = |t: NaiveDateTime| -> bool {
+        checked += 1;
         let key = t.format(fmt).to_string();
         if let Some(ch) = rivers_core::storage::PartitionKey::reserved_display_char(&key) {
-            return Err(PartitionDefinitionError::new_err(format!(
+            failure = Some(PartitionDefinitionError::new_err(format!(
                 "fmt '{fmt}' produces keys containing reserved character '{ch}' \
                  (used by the canonical display form): '{key}'"
             )));
+            return false;
         }
         match parse_key_datetime(&key, fmt) {
-            Ok(parsed) if parsed == *t => {}
+            Ok(parsed) if parsed == t => {}
             Ok(parsed) => {
-                return Err(PartitionDefinitionError::new_err(format!(
+                failure = Some(PartitionDefinitionError::new_err(format!(
                     "fmt '{fmt}' cannot represent the partition grid: window start {t} \
                      formats to '{key}', which parses back to {parsed}; \
                      use a format at least as fine as the grid"
                 )));
+                return false;
             }
             Err(e) => {
-                return Err(PartitionDefinitionError::new_err(format!(
+                failure = Some(PartitionDefinitionError::new_err(format!(
                     "fmt '{fmt}' cannot represent the partition grid: window start {t} \
                      formats to '{key}', which does not parse back: {e}"
                 )));
+                return false;
             }
         }
+        checked < MAX_TICKS
+    };
+    if let Some(secs) = interval_seconds {
+        for_each_interval_tick(*secs, start, bound, &mut check);
+    } else if let Some(expr) = cron_schedule {
+        for_each_cron_tick(expr, start, bound, &mut check)?;
     }
-    Ok(())
+    match failure {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
 }
 
 /// Check if all key strings fall on valid time window boundaries within [start, end).

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -718,6 +718,11 @@ impl PartitionsDefinition {
             ));
         }
         for key in &keys {
+            if key.is_empty() {
+                return Err(PartitionDefinitionError::new_err(
+                    "static partition keys must not be empty",
+                ));
+            }
             if let Some(ch) = rivers_core::storage::PartitionKey::reserved_display_char(key) {
                 return Err(PartitionDefinitionError::new_err(format!(
                     "partition key '{key}' contains reserved character '{ch}' \

--- a/python/src/partitions/key.rs
+++ b/python/src/partitions/key.rs
@@ -243,9 +243,14 @@ impl From<&PyPartitionKey> for rivers_core::storage::PartitionKey {
     fn from(pk: &PyPartitionKey) -> Self {
         match pk {
             PyPartitionKey::Single { key } => Self::Single { keys: key.clone() },
-            PyPartitionKey::Multi { keys } => Self::Multi {
-                dims: keys.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-            },
+            PyPartitionKey::Multi { keys } => {
+                // HashMap iteration order is seed-dependent — sort so the
+                // converted key is deterministic.
+                let mut dims: Vec<(String, Vec<String>)> =
+                    keys.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                dims.sort_by(|a, b| a.0.cmp(&b.0));
+                Self::Multi { dims }
+            }
             PyPartitionKey::Set { keys } => Self::Set {
                 keys: keys.iter().map(|k| k.into()).collect(),
             },

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -425,14 +425,20 @@ impl PyPartitionKeyRange {
                 format!("PartitionKeyRange.single(from_key={from_key:?}, to_key={to_key:?})")
             }
             PartitionKeyRangeInner::Multi { dimensions } => {
-                let dims: Vec<String> = dimensions
-                    .iter()
+                // Sorted dims and key lists — HashMap/HashSet iteration order
+                // is seed-dependent and must not leak into the repr.
+                let mut entries: Vec<_> = dimensions.iter().collect();
+                entries.sort_by(|a, b| a.0.cmp(b.0));
+                let dims: Vec<String> = entries
+                    .into_iter()
                     .map(|(name, sel)| match sel {
                         DimensionSelection::Range { from_key, to_key } => {
                             format!("{name:?}: ({from_key:?}, {to_key:?})")
                         }
                         DimensionSelection::Keys(keys) => {
-                            format!("{name:?}: {keys:?}")
+                            let mut sorted: Vec<&String> = keys.iter().collect();
+                            sorted.sort();
+                            format!("{name:?}: {sorted:?}")
                         }
                     })
                     .collect();

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -91,6 +91,21 @@ pub(crate) fn validate_single_dim_range(
                     "from_key '{from_key}' is after to_key '{to_key}'{suffix}"
                 ));
             }
+            // Endpoints must be real window starts — an off-grid endpoint is
+            // not a partition key (same contract as Static membership).
+            for k in [from_key, to_key] {
+                let single = PyPartitionKey::Single {
+                    key: vec![k.to_string()],
+                };
+                let on_grid = def
+                    .validate_partition_key(&single)
+                    .map_err(|e| e.to_string())?;
+                if !on_grid {
+                    return Err(format!(
+                        "Range endpoint '{k}' is not a partition key{suffix}"
+                    ));
+                }
+            }
             Ok(())
         }
         _ => Ok(()),

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -64,6 +64,17 @@ pub(crate) fn validate_single_dim_range(
         .map(|d| format!(" for dimension '{d}'"))
         .unwrap_or_default();
     match def {
+        // A single-dim range can never match a Multi key — reject instead of
+        // letting the selector silently match nothing at runtime.
+        PartitionsDefinition::Multi { dimensions } => Err(format!(
+            "a single-dimension range cannot select from Multi partitions{suffix}; \
+             use PartitionKeyRange.multi() with dimensions: {}",
+            dimensions
+                .iter()
+                .map(|(n, _)| n.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
         PartitionsDefinition::Static { keys } => {
             let pos = |k: &str| {
                 keys.get_index_of(k)

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -285,11 +285,35 @@ impl PyPartitionKeyRange {
                     // Shape mismatches are reported by the mapping/def checks.
                     return Ok(());
                 };
-                for (name, sel) in dimensions {
-                    if let DimensionSelection::Range { from_key, to_key } = sel
-                        && let Some((_, dd)) = dim_defs.iter().find(|(n, _)| n == name)
-                    {
-                        validate_single_dim_range(dd, from_key, to_key, Some(name))?;
+                // Sorted iteration: HashMap order must not pick which
+                // dimension's error surfaces.
+                let mut entries: Vec<_> = dimensions.iter().collect();
+                entries.sort_by(|a, b| a.0.cmp(b.0));
+                for (name, sel) in entries {
+                    let Some((_, dd)) = dim_defs.iter().find(|(n, _)| n == name) else {
+                        return Err(unknown_dims_message(&[name], dim_defs));
+                    };
+                    match sel {
+                        DimensionSelection::Range { from_key, to_key } => {
+                            validate_single_dim_range(dd, from_key, to_key, Some(name))?;
+                        }
+                        DimensionSelection::Keys(keys) => {
+                            let mut sorted: Vec<&String> = keys.iter().collect();
+                            sorted.sort();
+                            for k in sorted {
+                                let single = PyPartitionKey::Single {
+                                    key: vec![k.clone()],
+                                };
+                                let valid = dd
+                                    .validate_partition_key(&single)
+                                    .map_err(|e| e.to_string())?;
+                                if !valid {
+                                    return Err(format!(
+                                        "'{k}' is not a partition key of dimension '{name}'"
+                                    ));
+                                }
+                            }
+                        }
                     }
                 }
                 Ok(())

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -92,8 +92,9 @@ pub(crate) fn validate_single_dim_range(
                 ));
             }
             // Endpoints must be real window starts — an off-grid endpoint is
-            // not a partition key (same contract as Static membership).
-            for k in [from_key, to_key] {
+            // not a partition key (same contract as Static membership). Name
+            // the neighbouring valid keys so the typo is fixable.
+            for (k, dt) in [(from_key, from_dt), (to_key, to_dt)] {
                 let single = PyPartitionKey::Single {
                     key: vec![k.to_string()],
                 };
@@ -101,8 +102,20 @@ pub(crate) fn validate_single_dim_range(
                     .validate_partition_key(&single)
                     .map_err(|e| e.to_string())?;
                 if !on_grid {
+                    let hint = def
+                        .time_grid()
+                        .map(|g| match g.nearest_keys(dt) {
+                            (Some(p), Some(n)) => {
+                                format!("; nearest valid keys are '{p}' and '{n}'")
+                            }
+                            (Some(x), None) | (None, Some(x)) => {
+                                format!("; nearest valid key is '{x}'")
+                            }
+                            (None, None) => String::new(),
+                        })
+                        .unwrap_or_default();
                     return Err(format!(
-                        "Range endpoint '{k}' is not a partition key{suffix}"
+                        "Range endpoint '{k}' is not a partition key{suffix}{hint}"
                     ));
                 }
             }

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -150,8 +150,7 @@ fn resolve_single_dim_range(
         PartitionsDefinition::TimeWindow { fmt, .. } => {
             let from_dt = parse_key_datetime(from_key, fmt).expect("validated above");
             let to_dt = parse_key_datetime(to_key, fmt).expect("validated above");
-            // Walk only [from, to] — enumerating the whole universe and
-            // filtering is O(universe) on million-window definitions.
+            // Walk only [from, to] — avoids enumerating the full definition.
             def.time_grid()
                 .expect("TimeWindow always has a grid")
                 .keys_in_range(from_dt, to_dt)

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -8,10 +8,118 @@ use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use rivers_core::util::parse_key_datetime;
+
 use crate::errors::{ExecutionError, PartitionDefinitionError};
 
 use super::PyPartitionKey;
 use super::definition::{PartitionsDefinition, cartesian_product};
+
+/// Def-aware `[from, to]` membership for one single-dimension key value:
+/// positional for Static (keys aren't necessarily lexicographic),
+/// chronological via `fmt` for TimeWindow (custom formats aren't either),
+/// plain string comparison when no definition is available.
+fn key_in_range(
+    key: &str,
+    from_key: &str,
+    to_key: &str,
+    def: Option<&PartitionsDefinition>,
+) -> bool {
+    match def {
+        Some(PartitionsDefinition::Static { keys }) => {
+            match (
+                keys.get_index_of(from_key),
+                keys.get_index_of(to_key),
+                keys.get_index_of(key),
+            ) {
+                (Some(f), Some(t), Some(p)) => p >= f && p <= t,
+                _ => false,
+            }
+        }
+        Some(PartitionsDefinition::TimeWindow { fmt, .. }) => {
+            match (
+                parse_key_datetime(key, fmt),
+                parse_key_datetime(from_key, fmt),
+                parse_key_datetime(to_key, fmt),
+            ) {
+                (Ok(k), Ok(f), Ok(t)) => k >= f && k <= t,
+                _ => false,
+            }
+        }
+        _ => key >= from_key && key <= to_key,
+    }
+}
+
+/// Resolve `[from, to]` against one single-dimension definition using its
+/// own ordering (see [`key_in_range`]). Errors on endpoints that aren't
+/// members (Static) or don't parse (TimeWindow), and on inverted ranges —
+/// ordering belongs to the definition, so this is where it's checked, not
+/// in the range constructors.
+fn resolve_single_dim_range(
+    def: &PartitionsDefinition,
+    from_key: &str,
+    to_key: &str,
+    dim: Option<&str>,
+) -> PyResult<Vec<String>> {
+    let suffix = dim
+        .map(|d| format!(" for dimension '{d}'"))
+        .unwrap_or_default();
+    match def {
+        PartitionsDefinition::Static { keys } => {
+            let pos = |k: &str| {
+                keys.get_index_of(k).ok_or_else(|| {
+                    ExecutionError::new_err(format!(
+                        "Range endpoint '{k}' is not a partition key{suffix}"
+                    ))
+                })
+            };
+            let from_pos = pos(from_key)?;
+            let to_pos = pos(to_key)?;
+            if from_pos > to_pos {
+                return Err(ExecutionError::new_err(format!(
+                    "from_key '{from_key}' is after to_key '{to_key}'{suffix}"
+                )));
+            }
+            Ok((from_pos..=to_pos)
+                .filter_map(|i| keys.get_at(i).cloned())
+                .collect())
+        }
+        PartitionsDefinition::TimeWindow { fmt, .. } => {
+            let parse = |k: &str| {
+                parse_key_datetime(k, fmt).map_err(|_| {
+                    ExecutionError::new_err(format!(
+                        "Range endpoint '{k}' does not match the partition format '{fmt}'{suffix}"
+                    ))
+                })
+            };
+            let from_dt = parse(from_key)?;
+            let to_dt = parse(to_key)?;
+            if from_dt > to_dt {
+                return Err(ExecutionError::new_err(format!(
+                    "from_key '{from_key}' is after to_key '{to_key}'{suffix}"
+                )));
+            }
+            Ok(def
+                .enumerate_single_dim_keys()?
+                .into_iter()
+                .filter(|k| {
+                    parse_key_datetime(k, fmt)
+                        .map(|dt| dt >= from_dt && dt <= to_dt)
+                        .unwrap_or(false)
+                })
+                .collect())
+        }
+        // Dynamic (storage-backed): the def's enumerator raises the precise
+        // "needs storage" error.
+        _ => {
+            let keys = def.enumerate_single_dim_keys()?;
+            Ok(keys
+                .into_iter()
+                .filter(|k| k.as_str() >= from_key && k.as_str() <= to_key)
+                .collect())
+        }
+    }
+}
 
 /// Per-dimension selection: either a (from, to) range or explicit key list.
 #[derive(Clone, Debug, PartialEq)]
@@ -21,10 +129,11 @@ pub enum DimensionSelection {
 }
 
 impl DimensionSelection {
-    /// Check whether a single key string falls within this selection.
-    pub fn contains_key(&self, key: &str) -> bool {
+    /// Check whether a single key string falls within this selection,
+    /// using the dimension's definition ordering when available.
+    pub fn contains_key(&self, key: &str, def: Option<&PartitionsDefinition>) -> bool {
         match self {
-            Self::Range { from_key, to_key } => key >= from_key.as_str() && key <= to_key.as_str(),
+            Self::Range { from_key, to_key } => key_in_range(key, from_key, to_key, def),
             Self::Keys(allowed) => allowed.contains(key),
         }
     }
@@ -57,13 +166,9 @@ pub(crate) enum PartitionKeyRangeInner {
 }
 
 impl PyPartitionKeyRange {
-    /// Check whether a partition key falls within this range.
-    ///
-    /// When a `PartitionsDefinition` is provided and is `Static`, uses positional
-    /// ordering (index in the definition's key list) instead of string comparison.
-    /// This is necessary because static partition keys are not necessarily
-    /// lexicographically ordered. For TimeWindow/Dynamic partitions (or when no
-    /// definition is provided), string comparison is correct.
+    /// Check whether a partition key falls within this range, using the
+    /// definition's ordering when provided (see [`key_in_range`]) — static
+    /// keys and custom time formats are not necessarily lexicographic.
     pub fn contains(&self, key: &PyPartitionKey, def: Option<&PartitionsDefinition>) -> bool {
         match (&self.inner, key) {
             (
@@ -74,50 +179,36 @@ impl PyPartitionKeyRange {
                     Some(k) => k.as_str(),
                     None => return false,
                 };
-                // Static defs: use positional ordering (keys may not be lexicographic)
-                if let Some(PartitionsDefinition::Static { keys }) = def {
-                    let from_pos = keys.get_index_of(from_key.as_str());
-                    let to_pos = keys.get_index_of(to_key.as_str());
-                    let key_pos = keys.get_index_of(k);
-                    match (from_pos, to_pos, key_pos) {
-                        (Some(f), Some(t), Some(p)) => p >= f && p <= t,
-                        _ => false,
-                    }
-                } else {
-                    // TimeWindow/Dynamic: string comparison is correct
-                    k >= from_key.as_str() && k <= to_key.as_str()
-                }
+                key_in_range(k, from_key, to_key, def)
             }
             (PartitionKeyRangeInner::Multi { dimensions }, PyPartitionKey::Multi { keys }) => {
+                let dim_defs = match def {
+                    Some(PartitionsDefinition::Multi { dimensions }) => Some(dimensions),
+                    _ => None,
+                };
                 dimensions.iter().all(|(dim_name, sel)| {
+                    let dim_def = dim_defs
+                        .and_then(|dims| dims.iter().find(|(n, _)| n == dim_name).map(|(_, d)| d));
                     keys.get(dim_name)
                         .and_then(|v| v.first())
-                        .is_some_and(|k| sel.contains_key(k))
+                        .is_some_and(|k| sel.contains_key(k, dim_def))
                 })
             }
             _ => false,
         }
     }
 
-    /// Resolve this range into concrete partition keys using the given definition.
+    /// Resolve this range into concrete partition keys using the given
+    /// definition's ordering (positional for Static, chronological for
+    /// TimeWindow — see [`resolve_single_dim_range`]).
     pub fn resolve(&self, parts_def: &PartitionsDefinition) -> PyResult<Vec<PyPartitionKey>> {
         match &self.inner {
             PartitionKeyRangeInner::Single { from_key, to_key } => {
-                let all_keys = parts_def.get_partition_keys()?;
-                let filtered: Vec<PyPartitionKey> = all_keys
-                    .into_iter()
-                    .filter(|pk| {
-                        if let PyPartitionKey::Single { key } = pk {
-                            if let Some(k) = key.first() {
-                                k.as_str() >= from_key.as_str() && k.as_str() <= to_key.as_str()
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        }
-                    })
-                    .collect();
+                let filtered: Vec<PyPartitionKey> =
+                    resolve_single_dim_range(parts_def, from_key, to_key, None)?
+                        .into_iter()
+                        .map(|k| PyPartitionKey::Single { key: vec![k] })
+                        .collect();
                 if filtered.is_empty() {
                     return Err(ExecutionError::new_err(format!(
                         "No partition keys found in range [{from_key}, {to_key}]"
@@ -142,14 +233,12 @@ impl PyPartitionKeyRange {
                     let dim_keys = if let Some(sel) = dim_selections.get(dim_name) {
                         match sel {
                             DimensionSelection::Range { from_key, to_key } => {
-                                let keys: Vec<String> = dim_def
-                                    .enumerate_single_dim_keys()?
-                                    .into_iter()
-                                    .filter(|k| {
-                                        k.as_str() >= from_key.as_str()
-                                            && k.as_str() <= to_key.as_str()
-                                    })
-                                    .collect();
+                                let keys = resolve_single_dim_range(
+                                    dim_def,
+                                    from_key,
+                                    to_key,
+                                    Some(dim_name),
+                                )?;
                                 if keys.is_empty() {
                                     return Err(ExecutionError::new_err(format!(
                                         "No keys in range [{from_key}, {to_key}] for dimension '{dim_name}'"
@@ -157,7 +246,19 @@ impl PyPartitionKeyRange {
                                 }
                                 keys
                             }
-                            DimensionSelection::Keys(keys) => keys.iter().cloned().collect(),
+                            DimensionSelection::Keys(keys) => {
+                                for k in keys {
+                                    let single = PyPartitionKey::Single {
+                                        key: vec![k.clone()],
+                                    };
+                                    if !dim_def.validate_partition_key(&single)? {
+                                        return Err(ExecutionError::new_err(format!(
+                                            "'{k}' is not a partition key of dimension '{dim_name}'"
+                                        )));
+                                    }
+                                }
+                                keys.iter().cloned().collect()
+                            }
                         }
                     } else {
                         // Omitted dimension: include all keys
@@ -190,19 +291,19 @@ impl PyPartitionKeyRange {
 impl PyPartitionKeyRange {
     /// Create a single-dimension range.
     ///
+    /// Endpoint ordering is checked at resolve/match time against the
+    /// partition definition (positional for Static, chronological for
+    /// TimeWindow) — lexicographic order of the raw strings is meaningless
+    /// for non-ISO formats and unordered static keys.
+    ///
     /// ```python
     /// PartitionKeyRange.single(from_key="2024-01-01", to_key="2024-03-31")
     /// ```
     #[staticmethod]
-    fn single(from_key: String, to_key: String) -> PyResult<Self> {
-        if from_key > to_key {
-            return Err(PartitionDefinitionError::new_err(format!(
-                "from_key '{from_key}' must be <= to_key '{to_key}'"
-            )));
-        }
-        Ok(Self {
+    fn single(from_key: String, to_key: String) -> Self {
+        Self {
             inner: PartitionKeyRangeInner::Single { from_key, to_key },
-        })
+        }
     }
 
     /// Create a multi-dimension range from a dict.
@@ -223,11 +324,6 @@ impl PyPartitionKeyRange {
         for (k, v) in dimensions.iter() {
             let name: String = k.extract()?;
             if let Ok((from, to)) = v.extract::<(String, String)>() {
-                if from > to {
-                    return Err(PartitionDefinitionError::new_err(format!(
-                        "from_key '{from}' must be <= to_key '{to}' for dimension '{name}'"
-                    )));
-                }
                 result.insert(
                     name,
                     DimensionSelection::Range {
@@ -285,10 +381,40 @@ impl PyPartitionKeyRange {
         self == other
     }
 
+    /// Structural, order-independent hash consistent with `__eq__` — the
+    /// Multi variant's HashMap/HashSet iterate in seed-dependent order, so
+    /// contents are sorted before hashing.
     fn __hash__(&self) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        format!("{:?}", self).hash(&mut hasher);
+        match &self.inner {
+            PartitionKeyRangeInner::Single { from_key, to_key } => {
+                0u8.hash(&mut hasher);
+                from_key.hash(&mut hasher);
+                to_key.hash(&mut hasher);
+            }
+            PartitionKeyRangeInner::Multi { dimensions } => {
+                1u8.hash(&mut hasher);
+                let mut dims: Vec<_> = dimensions.iter().collect();
+                dims.sort_by(|a, b| a.0.cmp(b.0));
+                for (name, sel) in dims {
+                    name.hash(&mut hasher);
+                    match sel {
+                        DimensionSelection::Range { from_key, to_key } => {
+                            0u8.hash(&mut hasher);
+                            from_key.hash(&mut hasher);
+                            to_key.hash(&mut hasher);
+                        }
+                        DimensionSelection::Keys(keys) => {
+                            1u8.hash(&mut hasher);
+                            let mut sorted: Vec<&String> = keys.iter().collect();
+                            sorted.sort();
+                            sorted.hash(&mut hasher);
+                        }
+                    }
+                }
+            }
+        }
         hasher.finish()
     }
 }

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -172,6 +172,26 @@ fn resolve_single_dim_range(
     }
 }
 
+/// Error for selector dimensions that don't exist on the definition —
+/// silently ignoring one would treat the real dimension as omitted and
+/// expand it to every key. `dim_defs` keeps the definition's own order.
+fn unknown_dims_message<T>(unknown: &[&String], dim_defs: &[(String, T)]) -> String {
+    let plural = if unknown.len() == 1 { "" } else { "s" };
+    let names = unknown
+        .iter()
+        .map(|n| format!("'{n}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let available = dim_defs
+        .iter()
+        .map(|(n, _)| format!("'{n}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "Unknown dimension{plural} {names} in partition range; available dimensions: {available}"
+    )
+}
+
 /// Per-dimension selection: either a (from, to) range or explicit key list.
 #[derive(Clone, Debug, PartialEq)]
 pub enum DimensionSelection {
@@ -306,6 +326,17 @@ impl PyPartitionKeyRange {
                         ));
                     }
                 };
+
+                let mut unknown: Vec<&String> = dim_selections
+                    .keys()
+                    .filter(|name| !dim_defs.iter().any(|(n, _)| n == *name))
+                    .collect();
+                unknown.sort();
+                if !unknown.is_empty() {
+                    return Err(ExecutionError::new_err(unknown_dims_message(
+                        &unknown, dim_defs,
+                    )));
+                }
 
                 let mut resolved_dims: Vec<(String, Vec<String>)> = Vec::new();
                 for (dim_name, dim_def) in dim_defs {

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -81,7 +81,9 @@ pub(crate) fn validate_single_dim_range(
         PartitionsDefinition::TimeWindow { fmt, .. } => {
             let parse = |k: &str| {
                 parse_key_datetime(k, fmt).map_err(|_| {
-                    format!("Range endpoint '{k}' does not match the partition format '{fmt}'{suffix}")
+                    format!(
+                        "Range endpoint '{k}' does not match the partition format '{fmt}'{suffix}"
+                    )
                 })
             };
             let from_dt = parse(from_key)?;

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -150,15 +150,12 @@ fn resolve_single_dim_range(
         PartitionsDefinition::TimeWindow { fmt, .. } => {
             let from_dt = parse_key_datetime(from_key, fmt).expect("validated above");
             let to_dt = parse_key_datetime(to_key, fmt).expect("validated above");
-            Ok(def
-                .enumerate_single_dim_keys()?
-                .into_iter()
-                .filter(|k| {
-                    parse_key_datetime(k, fmt)
-                        .map(|dt| dt >= from_dt && dt <= to_dt)
-                        .unwrap_or(false)
-                })
-                .collect())
+            // Walk only [from, to] — enumerating the whole universe and
+            // filtering is O(universe) on million-window definitions.
+            def.time_grid()
+                .expect("TimeWindow always has a grid")
+                .keys_in_range(from_dt, to_dt)
+                .map_err(|e| ExecutionError::new_err(e.to_string()))
         }
         // Dynamic (storage-backed): the def's enumerator raises the precise
         // "needs storage" error.

--- a/python/src/partitions/key_range.rs
+++ b/python/src/partitions/key_range.rs
@@ -50,6 +50,53 @@ fn key_in_range(
     }
 }
 
+/// Validate `[from, to]` endpoints against one single-dimension definition:
+/// membership (Static) / format (TimeWindow) plus def-order. Returns a plain
+/// message so resolve-time and validate-time callers wrap it in their own
+/// error types. Dynamic defs carry no static key knowledge — nothing to check.
+pub(crate) fn validate_single_dim_range(
+    def: &PartitionsDefinition,
+    from_key: &str,
+    to_key: &str,
+    dim: Option<&str>,
+) -> Result<(), String> {
+    let suffix = dim
+        .map(|d| format!(" for dimension '{d}'"))
+        .unwrap_or_default();
+    match def {
+        PartitionsDefinition::Static { keys } => {
+            let pos = |k: &str| {
+                keys.get_index_of(k)
+                    .ok_or_else(|| format!("Range endpoint '{k}' is not a partition key{suffix}"))
+            };
+            let from_pos = pos(from_key)?;
+            let to_pos = pos(to_key)?;
+            if from_pos > to_pos {
+                return Err(format!(
+                    "from_key '{from_key}' is after to_key '{to_key}'{suffix}"
+                ));
+            }
+            Ok(())
+        }
+        PartitionsDefinition::TimeWindow { fmt, .. } => {
+            let parse = |k: &str| {
+                parse_key_datetime(k, fmt).map_err(|_| {
+                    format!("Range endpoint '{k}' does not match the partition format '{fmt}'{suffix}")
+                })
+            };
+            let from_dt = parse(from_key)?;
+            let to_dt = parse(to_key)?;
+            if from_dt > to_dt {
+                return Err(format!(
+                    "from_key '{from_key}' is after to_key '{to_key}'{suffix}"
+                ));
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 /// Resolve `[from, to]` against one single-dimension definition using its
 /// own ordering (see [`key_in_range`]). Errors on endpoints that aren't
 /// members (Static) or don't parse (TimeWindow), and on inverted ranges —
@@ -61,44 +108,18 @@ fn resolve_single_dim_range(
     to_key: &str,
     dim: Option<&str>,
 ) -> PyResult<Vec<String>> {
-    let suffix = dim
-        .map(|d| format!(" for dimension '{d}'"))
-        .unwrap_or_default();
+    validate_single_dim_range(def, from_key, to_key, dim).map_err(ExecutionError::new_err)?;
     match def {
         PartitionsDefinition::Static { keys } => {
-            let pos = |k: &str| {
-                keys.get_index_of(k).ok_or_else(|| {
-                    ExecutionError::new_err(format!(
-                        "Range endpoint '{k}' is not a partition key{suffix}"
-                    ))
-                })
-            };
-            let from_pos = pos(from_key)?;
-            let to_pos = pos(to_key)?;
-            if from_pos > to_pos {
-                return Err(ExecutionError::new_err(format!(
-                    "from_key '{from_key}' is after to_key '{to_key}'{suffix}"
-                )));
-            }
+            let from_pos = keys.get_index_of(from_key).expect("validated above");
+            let to_pos = keys.get_index_of(to_key).expect("validated above");
             Ok((from_pos..=to_pos)
                 .filter_map(|i| keys.get_at(i).cloned())
                 .collect())
         }
         PartitionsDefinition::TimeWindow { fmt, .. } => {
-            let parse = |k: &str| {
-                parse_key_datetime(k, fmt).map_err(|_| {
-                    ExecutionError::new_err(format!(
-                        "Range endpoint '{k}' does not match the partition format '{fmt}'{suffix}"
-                    ))
-                })
-            };
-            let from_dt = parse(from_key)?;
-            let to_dt = parse(to_key)?;
-            if from_dt > to_dt {
-                return Err(ExecutionError::new_err(format!(
-                    "from_key '{from_key}' is after to_key '{to_key}'{suffix}"
-                )));
-            }
+            let from_dt = parse_key_datetime(from_key, fmt).expect("validated above");
+            let to_dt = parse_key_datetime(to_key, fmt).expect("validated above");
             Ok(def
                 .enumerate_single_dim_keys()?
                 .into_iter()
@@ -195,6 +216,34 @@ impl PyPartitionKeyRange {
                 })
             }
             _ => false,
+        }
+    }
+
+    /// Validate this range's endpoints against the definition it will be
+    /// matched against — membership/format and def-order. Returns a plain
+    /// message; callers wrap it in their error type.
+    pub fn validate_against(&self, def: &PartitionsDefinition) -> Result<(), String> {
+        match &self.inner {
+            PartitionKeyRangeInner::Single { from_key, to_key } => {
+                validate_single_dim_range(def, from_key, to_key, None)
+            }
+            PartitionKeyRangeInner::Multi { dimensions } => {
+                let PartitionsDefinition::Multi {
+                    dimensions: dim_defs,
+                } = def
+                else {
+                    // Shape mismatches are reported by the mapping/def checks.
+                    return Ok(());
+                };
+                for (name, sel) in dimensions {
+                    if let DimensionSelection::Range { from_key, to_key } = sel
+                        && let Some((_, dd)) = dim_defs.iter().find(|(n, _)| n == name)
+                    {
+                        validate_single_dim_range(dd, from_key, to_key, Some(name))?;
+                    }
+                }
+                Ok(())
+            }
         }
     }
 

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -829,10 +829,16 @@ fn validate_time_window_grid_compat(
                 return Err(MappingValidationError::DefinitionError(msg));
             }
             if let Some(t) = offgrid {
+                let upstream_grid = match (up_cron, up_interval) {
+                    (Some(expr), _) => format!("cron '{expr}'"),
+                    (None, Some(ui)) => format!("every {ui}s from {up_start}"),
+                    (None, None) => "with no schedule".to_string(),
+                };
                 return Err(MappingValidationError::DefinitionError(format!(
                     "{mapping} mapping requires the downstream grid to be a \
                      subgrid of the upstream grid: downstream window start {t} \
-                     (key '{}') is not on the upstream grid",
+                     (key '{}') is not on the upstream grid ({upstream_grid}), \
+                     so that key would never exist upstream",
                     t.format(down_fmt)
                 )));
             }

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -1006,20 +1006,28 @@ impl PartitionMapping {
             Self::AllPartitions {} => Ok(()),
             Self::ForKeys { selectors } => {
                 for s in selectors {
-                    if let PartitionKeySelector::Key(k) = s {
-                        let valid = down
-                            .validate_partition_key(k)
-                            .map_err(|e| MappingValidationError::DefinitionError(e.to_string()))?;
-                        if !valid {
-                            return Err(MappingValidationError::KeyNotInDefinition {
-                                key: format!("{k:?}"),
-                                side: Side::Downstream,
-                                mapping: "ForKeys",
-                            });
+                    match s {
+                        PartitionKeySelector::Key(k) => {
+                            let valid = down.validate_partition_key(k).map_err(|e| {
+                                MappingValidationError::DefinitionError(e.to_string())
+                            })?;
+                            if !valid {
+                                return Err(MappingValidationError::KeyNotInDefinition {
+                                    key: format!("{k:?}"),
+                                    side: Side::Downstream,
+                                    mapping: "ForKeys",
+                                });
+                            }
+                        }
+                        // An unknown or inverted range endpoint would silently
+                        // match nothing (every downstream key Skips its dep) —
+                        // surface it here instead.
+                        PartitionKeySelector::Range(range) => {
+                            range
+                                .validate_against(down)
+                                .map_err(MappingValidationError::DefinitionError)?;
                         }
                     }
-                    // Range bounds are not validated against the partition def
-                    // at resolve time — the range may intentionally cover a subset.
                 }
                 Ok(())
             }

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -13,7 +13,9 @@ use pyo3::types::{PyDict, PyList, PyTuple};
 use crate::errors::PartitionValidationError;
 
 use super::PyPartitionKey;
-use super::definition::PartitionsDefinition;
+use super::definition::{
+    PartitionsDefinition, cron_grid_contains, for_each_cron_tick, for_each_interval_tick,
+};
 use super::key_range::PyPartitionKeyRange;
 
 /// Identifies which side of a dependency edge an error refers to.
@@ -757,15 +759,7 @@ fn validate_time_window_grid_compat(
         )));
     }
     match (down_cron, down_interval, up_cron, up_interval) {
-        (Some(dc), _, Some(uc), _) => {
-            if dc != uc {
-                return Err(MappingValidationError::DefinitionError(format!(
-                    "{mapping} mapping requires identical cron schedules: \
-                     downstream '{dc}' != upstream '{uc}'"
-                )));
-            }
-        }
-        (_, Some(di), _, Some(ui)) => {
+        (None, Some(di), None, Some(ui)) => {
             let down_ns = (di * 1_000_000_000.0) as i64;
             let up_ns = (ui * 1_000_000_000.0) as i64;
             if up_ns <= 0 || down_ns <= 0 || down_ns % up_ns != 0 {
@@ -788,10 +782,60 @@ fn validate_time_window_grid_compat(
             }
         }
         _ => {
-            return Err(MappingValidationError::DefinitionError(format!(
-                "{mapping} mapping requires both definitions on the same \
-                 grid kind (both cron or both interval)"
-            )));
+            // At least one side is a cron grid. Equivalent schedules can be
+            // spelled differently (5- vs 6-field, nicknames) and a cron grid
+            // can coincide with an interval grid, so prove the subgrid
+            // relation on the ticks themselves: every downstream window
+            // start over a bounded probe must fall on the upstream grid.
+            const PROBE_TICKS: usize = 32;
+            let horizon = down_start
+                .checked_add_signed(chrono::Duration::days(1461))
+                .unwrap_or(chrono::NaiveDateTime::MAX);
+            let mut count = 0usize;
+            let mut offgrid: Option<chrono::NaiveDateTime> = None;
+            let mut walk_err: Option<String> = None;
+            let mut visit = |t: chrono::NaiveDateTime| -> bool {
+                count += 1;
+                let on_upstream = match (up_cron, up_interval) {
+                    (Some(expr), _) => match cron_grid_contains(expr, t) {
+                        Ok(hit) => hit,
+                        Err(e) => {
+                            walk_err = Some(e.to_string());
+                            return false;
+                        }
+                    },
+                    (None, Some(ui)) => {
+                        let up_ns = (ui * 1_000_000_000.0) as i64;
+                        up_ns > 0
+                            && (t - *up_start)
+                                .num_nanoseconds()
+                                .is_some_and(|ns| ns.rem_euclid(up_ns) == 0)
+                    }
+                    (None, None) => false,
+                };
+                if !on_upstream {
+                    offgrid = Some(t);
+                    return false;
+                }
+                count < PROBE_TICKS
+            };
+            if let Some(dc) = down_cron {
+                for_each_cron_tick(dc, down_start, horizon, &mut visit)
+                    .map_err(|e| MappingValidationError::DefinitionError(e.to_string()))?;
+            } else if let Some(di) = down_interval {
+                for_each_interval_tick(*di, down_start, horizon, &mut visit);
+            }
+            if let Some(msg) = walk_err {
+                return Err(MappingValidationError::DefinitionError(msg));
+            }
+            if let Some(t) = offgrid {
+                return Err(MappingValidationError::DefinitionError(format!(
+                    "{mapping} mapping requires the downstream grid to be a \
+                     subgrid of the upstream grid: downstream window start {t} \
+                     (key '{}') is not on the upstream grid",
+                    t.format(down_fmt)
+                )));
+            }
         }
     }
     Ok(())

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -1004,9 +1004,17 @@ impl PartitionMapping {
                         )
                     })?;
 
+                // The inner mapping's orientation follows the edge: with a
+                // Multi downstream it maps the named dim's key -> the single
+                // upstream; with a Multi upstream it maps the downstream
+                // single key -> the named dim.
+                let (inner_down, inner_up) = match multi_side {
+                    Side::Downstream => (dim_def, single_def),
+                    Side::Upstream => (single_def, dim_def),
+                };
                 partition_mapping
                     .0
-                    .validate_partitioned_pair(single_def, dim_def)
+                    .validate_partitioned_pair(inner_down, inner_up)
                     .map_err(|e| MappingValidationError::InDimension {
                         dim: dimension_name.clone(),
                         source: Box::new(e),

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -562,7 +562,21 @@ impl PartitionMapping {
                 let def =
                     upstream_def.ok_or("TimeWindow mapping requires a partitioned upstream")?;
                 let shifted = def.shift_time_key(k, *offset).map_err(|e| e.to_string())?;
-                Ok(PyPartitionKey::Single { key: vec![shifted] })
+                let shifted_key = PyPartitionKey::Single {
+                    key: vec![shifted.clone()],
+                };
+                // A cross-cadence mapping can land between upstream windows —
+                // loading a partition that doesn't exist must fail loudly.
+                if !def
+                    .validate_partition_key(&shifted_key)
+                    .map_err(|e| e.to_string())?
+                {
+                    return Err(format!(
+                        "time_window(offset={offset}) maps '{k}' to '{shifted}', \
+                         which is not a partition of the upstream definition"
+                    ));
+                }
+                Ok(shifted_key)
             }
 
             Self::Multi { dimension_mappings } => match downstream_key {

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -550,12 +550,19 @@ impl PartitionMapping {
             }
 
             Self::TimeWindow { offset } => {
-                // TimeWindow offset is handled at the IO level (not key transformation).
-                // The key itself stays the same — the offset shifts which time window is loaded.
-                // For now, pass through as-is.
-                // TODO: implement actual time window offset key shifting
-                let _ = offset;
-                Ok(downstream_key.clone())
+                if *offset == 0 {
+                    return Ok(downstream_key.clone());
+                }
+                let PyPartitionKey::Single { key } = downstream_key else {
+                    return Err(
+                        "TimeWindow mapping only works with Single partition keys".to_string()
+                    );
+                };
+                let k = key.first().ok_or("Empty partition key")?;
+                let def =
+                    upstream_def.ok_or("TimeWindow mapping requires a partitioned upstream")?;
+                let shifted = def.shift_time_key(k, *offset).map_err(|e| e.to_string())?;
+                Ok(PyPartitionKey::Single { key: vec![shifted] })
             }
 
             Self::Multi { dimension_mappings } => match downstream_key {
@@ -576,7 +583,16 @@ impl PartitionMapping {
                         let single_key = PyPartitionKey::Single {
                             key: dim_values.clone(),
                         };
-                        let mapped = per_dim_mapping.map_key(&single_key, None)?;
+                        // Thread the upstream dimension's own def so nested
+                        // mappings that need it (TimeWindow offset) can shift.
+                        let dim_def = upstream_def.and_then(|d| match d {
+                            PartitionsDefinition::Multi { dimensions } => dimensions
+                                .iter()
+                                .find(|(n, _)| n == upstream_dim)
+                                .map(|(_, dd)| dd),
+                            _ => None,
+                        });
+                        let mapped = per_dim_mapping.map_key(&single_key, dim_def)?;
                         match mapped {
                             PyPartitionKey::Single { key } => {
                                 upstream_keys.insert(upstream_dim.clone(), key);
@@ -620,13 +636,6 @@ impl PartitionMapping {
                     // The named dimension gets the (mapped) single key value.
                     // Unmapped dimensions get ALL their partition keys (fan-in).
                     PyPartitionKey::Single { key } => {
-                        let single_key = PyPartitionKey::Single { key: key.clone() };
-                        let mapped_single = partition_mapping.0.map_key(&single_key, None)?;
-                        let mapped_values = match &mapped_single {
-                            PyPartitionKey::Single { key } => key.clone(),
-                            _ => return Err("Inner mapping produced a Multi key".to_string()),
-                        };
-
                         // Get the upstream Multi definition to enumerate unmapped dimensions
                         let up_def = upstream_def.ok_or(
                             "MultiToSingle (Single→Multi) requires upstream PartitionsDefinition",
@@ -639,6 +648,20 @@ impl PartitionMapping {
                                         .to_string(),
                                 ),
                             };
+
+                        let single_key = PyPartitionKey::Single { key: key.clone() };
+                        // The inner mapping maps within the named dimension —
+                        // give it that dimension's def (TimeWindow offset).
+                        let named_dim_def = dimensions
+                            .iter()
+                            .find(|(n, _)| n == dimension_name)
+                            .map(|(_, dd)| dd);
+                        let mapped_single =
+                            partition_mapping.0.map_key(&single_key, named_dim_def)?;
+                        let mapped_values = match &mapped_single {
+                            PyPartitionKey::Single { key } => key.clone(),
+                            _ => return Err("Inner mapping produced a Multi key".to_string()),
+                        };
 
                         let mut multi_keys = HashMap::new();
                         for (dim_name, dim_def) in dimensions {
@@ -670,7 +693,9 @@ impl PartitionMapping {
                         let single_key = PyPartitionKey::Single {
                             key: dim_values.clone(),
                         };
-                        partition_mapping.0.map_key(&single_key, None)
+                        // Upstream is Single here, so its whole def belongs to
+                        // the inner mapping (TimeWindow offset shifts in it).
+                        partition_mapping.0.map_key(&single_key, upstream_def)
                     }
                     PyPartitionKey::Set { .. } => {
                         Err("MultiToSingle mapping does not support batched Set keys".to_string())

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -866,6 +866,18 @@ impl PartitionMapping {
                 // requirement as a zero-offset time_window mapping.
                 validate_time_window_grid_compat("Identity", down, up)?;
                 if let (
+                    PartitionsDefinition::Dynamic { name: down_name },
+                    PartitionsDefinition::Dynamic { name: up_name },
+                ) = (down, up)
+                {
+                    if down_name != up_name {
+                        return Err(MappingValidationError::DefinitionError(format!(
+                            "Identity mapping requires matching dynamic namespaces: \
+                             downstream '{down_name}' != upstream '{up_name}'"
+                        )));
+                    }
+                }
+                if let (
                     PartitionsDefinition::Static { keys: down_keys },
                     PartitionsDefinition::Static { keys: up_keys },
                 ) = (down, up)

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -817,11 +817,8 @@ impl PartitionMapping {
                         found: up.variant_name().to_string(),
                     });
                 };
-                // The offset shifts downstream keys on the UPSTREAM grid, so
-                // every downstream key must itself be an upstream grid tick:
-                // the downstream grid must be a subgrid of the upstream one.
-                // Ranges (start/end) may differ — the runtime per-key check
-                // covers range edges.
+                // Downstream keys are shifted on the upstream grid, so the
+                // downstream grid must be a subgrid of the upstream one.
                 if down_fmt != up_fmt {
                     return Err(MappingValidationError::DefinitionError(format!(
                         "time_window mapping requires matching key formats: \

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -787,21 +787,85 @@ impl PartitionMapping {
                 Ok(())
             }
             Self::TimeWindow { .. } => {
-                if !matches!(down, PartitionsDefinition::TimeWindow { .. }) {
+                let PartitionsDefinition::TimeWindow {
+                    cron_schedule: down_cron,
+                    interval_seconds: down_interval,
+                    start: down_start,
+                    fmt: down_fmt,
+                    ..
+                } = down
+                else {
                     return Err(MappingValidationError::RequiredDefinitionType {
                         mapping: "TimeWindow",
                         side: Side::Downstream,
                         expected: "TimeWindow",
                         found: down.variant_name().to_string(),
                     });
-                }
-                if !matches!(up, PartitionsDefinition::TimeWindow { .. }) {
+                };
+                let PartitionsDefinition::TimeWindow {
+                    cron_schedule: up_cron,
+                    interval_seconds: up_interval,
+                    start: up_start,
+                    fmt: up_fmt,
+                    ..
+                } = up
+                else {
                     return Err(MappingValidationError::RequiredDefinitionType {
                         mapping: "TimeWindow",
                         side: Side::Upstream,
                         expected: "TimeWindow",
                         found: up.variant_name().to_string(),
                     });
+                };
+                // The offset shifts downstream keys on the UPSTREAM grid, so
+                // every downstream key must itself be an upstream grid tick:
+                // the downstream grid must be a subgrid of the upstream one.
+                // Ranges (start/end) may differ — the runtime per-key check
+                // covers range edges.
+                if down_fmt != up_fmt {
+                    return Err(MappingValidationError::DefinitionError(format!(
+                        "time_window mapping requires matching key formats: \
+                         downstream fmt '{down_fmt}' != upstream fmt '{up_fmt}'"
+                    )));
+                }
+                match (down_cron, down_interval, up_cron, up_interval) {
+                    (Some(dc), _, Some(uc), _) => {
+                        if dc != uc {
+                            return Err(MappingValidationError::DefinitionError(format!(
+                                "time_window mapping requires identical cron schedules: \
+                                 downstream '{dc}' != upstream '{uc}'"
+                            )));
+                        }
+                    }
+                    (_, Some(di), _, Some(ui)) => {
+                        let down_ns = (di * 1_000_000_000.0) as i64;
+                        let up_ns = (ui * 1_000_000_000.0) as i64;
+                        if up_ns <= 0 || down_ns <= 0 || down_ns % up_ns != 0 {
+                            return Err(MappingValidationError::DefinitionError(format!(
+                                "time_window mapping requires the downstream grid to be a \
+                                 subgrid of the upstream grid: downstream interval {di}s \
+                                 is not a multiple of upstream interval {ui}s"
+                            )));
+                        }
+                        let aligned = (*down_start - *up_start)
+                            .num_nanoseconds()
+                            .is_some_and(|ns| ns.rem_euclid(up_ns) == 0);
+                        if !aligned {
+                            return Err(MappingValidationError::DefinitionError(format!(
+                                "time_window mapping requires the downstream grid to be a \
+                                 subgrid of the upstream grid: downstream start {down_start} \
+                                 is not aligned to the upstream grid (start {up_start}, \
+                                 interval {ui}s)"
+                            )));
+                        }
+                    }
+                    _ => {
+                        return Err(MappingValidationError::DefinitionError(
+                            "time_window mapping requires both definitions on the same \
+                             grid kind (both cron or both interval)"
+                                .to_string(),
+                        ));
+                    }
                 }
                 Ok(())
             }

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -720,6 +720,83 @@ impl PartitionMapping {
     }
 }
 
+/// Require the downstream grid to be a subgrid of the upstream one (same
+/// fmt; identical cron, or interval multiple with aligned starts). Applies
+/// to any mapping that resolves downstream keys on the upstream grid —
+/// `time_window` shifts them, `Identity` loads them verbatim. Ranges
+/// (start/end) may differ; range edges are a per-key concern. No-op unless
+/// both definitions are TimeWindow.
+fn validate_time_window_grid_compat(
+    mapping: &str,
+    down: &PartitionsDefinition,
+    up: &PartitionsDefinition,
+) -> Result<(), MappingValidationError> {
+    let (
+        PartitionsDefinition::TimeWindow {
+            cron_schedule: down_cron,
+            interval_seconds: down_interval,
+            start: down_start,
+            fmt: down_fmt,
+            ..
+        },
+        PartitionsDefinition::TimeWindow {
+            cron_schedule: up_cron,
+            interval_seconds: up_interval,
+            start: up_start,
+            fmt: up_fmt,
+            ..
+        },
+    ) = (down, up)
+    else {
+        return Ok(());
+    };
+    if down_fmt != up_fmt {
+        return Err(MappingValidationError::DefinitionError(format!(
+            "{mapping} mapping requires matching key formats: \
+             downstream fmt '{down_fmt}' != upstream fmt '{up_fmt}'"
+        )));
+    }
+    match (down_cron, down_interval, up_cron, up_interval) {
+        (Some(dc), _, Some(uc), _) => {
+            if dc != uc {
+                return Err(MappingValidationError::DefinitionError(format!(
+                    "{mapping} mapping requires identical cron schedules: \
+                     downstream '{dc}' != upstream '{uc}'"
+                )));
+            }
+        }
+        (_, Some(di), _, Some(ui)) => {
+            let down_ns = (di * 1_000_000_000.0) as i64;
+            let up_ns = (ui * 1_000_000_000.0) as i64;
+            if up_ns <= 0 || down_ns <= 0 || down_ns % up_ns != 0 {
+                return Err(MappingValidationError::DefinitionError(format!(
+                    "{mapping} mapping requires the downstream grid to be a \
+                     subgrid of the upstream grid: downstream interval {di}s \
+                     is not a multiple of upstream interval {ui}s"
+                )));
+            }
+            let aligned = (*down_start - *up_start)
+                .num_nanoseconds()
+                .is_some_and(|ns| ns.rem_euclid(up_ns) == 0);
+            if !aligned {
+                return Err(MappingValidationError::DefinitionError(format!(
+                    "{mapping} mapping requires the downstream grid to be a \
+                     subgrid of the upstream grid: downstream start {down_start} \
+                     is not aligned to the upstream grid (start {up_start}, \
+                     interval {ui}s)"
+                )));
+            }
+        }
+        _ => {
+            return Err(MappingValidationError::DefinitionError(format!(
+                "{mapping} mapping requires both definitions on the same \
+                 grid kind (both cron or both interval)"
+            )));
+        }
+    }
+    Ok(())
+}
+
 impl PartitionMapping {
     /// Variant name as a string (e.g. "Identity", "Multi"). Used in error messages.
     pub fn variant_name(&self) -> &'static str {
@@ -784,87 +861,49 @@ impl PartitionMapping {
                         upstream: up.variant_name().to_string(),
                     });
                 }
+                // Identity loads each downstream key verbatim from upstream,
+                // so every downstream key must exist there — same subgrid
+                // requirement as a zero-offset time_window mapping.
+                validate_time_window_grid_compat("Identity", down, up)?;
+                if let (
+                    PartitionsDefinition::Static { keys: down_keys },
+                    PartitionsDefinition::Static { keys: up_keys },
+                ) = (down, up)
+                {
+                    let mut missing: Vec<&str> = down_keys
+                        .iter()
+                        .filter(|k| !up_keys.contains(k.as_str()))
+                        .map(String::as_str)
+                        .collect();
+                    if !missing.is_empty() {
+                        missing.sort_unstable();
+                        return Err(MappingValidationError::DefinitionError(format!(
+                            "Identity mapping requires every downstream key to exist \
+                             upstream; missing upstream: {}",
+                            missing.join(", ")
+                        )));
+                    }
+                }
                 Ok(())
             }
             Self::TimeWindow { .. } => {
-                let PartitionsDefinition::TimeWindow {
-                    cron_schedule: down_cron,
-                    interval_seconds: down_interval,
-                    start: down_start,
-                    fmt: down_fmt,
-                    ..
-                } = down
-                else {
+                if !matches!(down, PartitionsDefinition::TimeWindow { .. }) {
                     return Err(MappingValidationError::RequiredDefinitionType {
                         mapping: "TimeWindow",
                         side: Side::Downstream,
                         expected: "TimeWindow",
                         found: down.variant_name().to_string(),
                     });
-                };
-                let PartitionsDefinition::TimeWindow {
-                    cron_schedule: up_cron,
-                    interval_seconds: up_interval,
-                    start: up_start,
-                    fmt: up_fmt,
-                    ..
-                } = up
-                else {
+                }
+                if !matches!(up, PartitionsDefinition::TimeWindow { .. }) {
                     return Err(MappingValidationError::RequiredDefinitionType {
                         mapping: "TimeWindow",
                         side: Side::Upstream,
                         expected: "TimeWindow",
                         found: up.variant_name().to_string(),
                     });
-                };
-                // Downstream keys are shifted on the upstream grid, so the
-                // downstream grid must be a subgrid of the upstream one.
-                if down_fmt != up_fmt {
-                    return Err(MappingValidationError::DefinitionError(format!(
-                        "time_window mapping requires matching key formats: \
-                         downstream fmt '{down_fmt}' != upstream fmt '{up_fmt}'"
-                    )));
                 }
-                match (down_cron, down_interval, up_cron, up_interval) {
-                    (Some(dc), _, Some(uc), _) => {
-                        if dc != uc {
-                            return Err(MappingValidationError::DefinitionError(format!(
-                                "time_window mapping requires identical cron schedules: \
-                                 downstream '{dc}' != upstream '{uc}'"
-                            )));
-                        }
-                    }
-                    (_, Some(di), _, Some(ui)) => {
-                        let down_ns = (di * 1_000_000_000.0) as i64;
-                        let up_ns = (ui * 1_000_000_000.0) as i64;
-                        if up_ns <= 0 || down_ns <= 0 || down_ns % up_ns != 0 {
-                            return Err(MappingValidationError::DefinitionError(format!(
-                                "time_window mapping requires the downstream grid to be a \
-                                 subgrid of the upstream grid: downstream interval {di}s \
-                                 is not a multiple of upstream interval {ui}s"
-                            )));
-                        }
-                        let aligned = (*down_start - *up_start)
-                            .num_nanoseconds()
-                            .is_some_and(|ns| ns.rem_euclid(up_ns) == 0);
-                        if !aligned {
-                            return Err(MappingValidationError::DefinitionError(format!(
-                                "time_window mapping requires the downstream grid to be a \
-                                 subgrid of the upstream grid: downstream start {down_start} \
-                                 is not aligned to the upstream grid (start {up_start}, \
-                                 interval {ui}s)"
-                            )));
-                        }
-                    }
-                    _ => {
-                        return Err(MappingValidationError::DefinitionError(
-                            "time_window mapping requires both definitions on the same \
-                             grid kind (both cron or both interval)"
-                                .to_string(),
-                        ));
-                    }
-                }
-                Ok(())
+                validate_time_window_grid_compat("time_window", down, up)
             }
             Self::Static { mapping: key_map } => {
                 let down_keys = single_dim_key_set(down)?;

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -3,7 +3,7 @@
 //! `PartitionMapping` enum with 7 variants (Identity, AllPartitions, LastPartition, etc.).
 //! `map_key()` transforms downstream partition keys to upstream keys for dependency loading.
 //! `PartitionMappingDict` accepts `str` or `AssetDef` keys from Python for per-dep overrides.
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ops::Deref;
 
 use pyo3::exceptions::PyTypeError;
@@ -894,6 +894,41 @@ impl PartitionMapping {
                              upstream; missing upstream: {}",
                             missing.join(", ")
                         )));
+                    }
+                }
+                if let (
+                    PartitionsDefinition::Multi {
+                        dimensions: down_dims,
+                    },
+                    PartitionsDefinition::Multi {
+                        dimensions: up_dims,
+                    },
+                ) = (down, up)
+                {
+                    let down_names: BTreeSet<&str> =
+                        down_dims.iter().map(|(n, _)| n.as_str()).collect();
+                    let up_names: BTreeSet<&str> =
+                        up_dims.iter().map(|(n, _)| n.as_str()).collect();
+                    if down_names != up_names {
+                        let join = |names: &BTreeSet<&str>| {
+                            names.iter().copied().collect::<Vec<_>>().join(", ")
+                        };
+                        return Err(MappingValidationError::DefinitionError(format!(
+                            "Identity mapping requires matching Multi dimensions: \
+                             downstream [{}] != upstream [{}]",
+                            join(&down_names),
+                            join(&up_names)
+                        )));
+                    }
+                    let up_map: HashMap<&str, &PartitionsDefinition> =
+                        up_dims.iter().map(|(n, d)| (n.as_str(), d)).collect();
+                    for (name, down_sub) in down_dims {
+                        Self::Identity {}
+                            .validate_partitioned_pair(down_sub, up_map[name.as_str()])
+                            .map_err(|e| MappingValidationError::InDimension {
+                                dim: name.clone(),
+                                source: Box::new(e),
+                            })?;
                     }
                 }
                 Ok(())

--- a/python/src/repository/mod.rs
+++ b/python/src/repository/mod.rs
@@ -102,6 +102,125 @@ fn validate_partition_for_selection<'a>(
     Ok(())
 }
 
+/// Storage-side companion to [`validate_partition_for_selection`]: a Dynamic
+/// def can't validate membership statically (its keys live in storage), so
+/// collect the `(asset, namespace, keys)` triples to verify against
+/// `dynamic_partitions` once the state lock is released.
+type DynamicKeyCheck = (String, String, Vec<String>);
+
+fn dynamic_partition_checks<'a, I>(
+    state: &'a ResolvedState,
+    asset_names: I,
+    partition_key: Option<&PyPartitionKey>,
+) -> Vec<DynamicKeyCheck>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let Some(pk) = partition_key else {
+        return Vec::new();
+    };
+    iter_partitioned_assets(&state.node_map, asset_names)
+        .into_iter()
+        .flat_map(|(name, pd)| {
+            collect_dynamic_namespaces(pd, pk)
+                .into_iter()
+                .map(|(ns, keys)| (name.to_string(), ns, keys))
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+/// `(namespace, key values)` pairs a key must have registered in storage to
+/// be valid for `pd` — the Dynamic def itself and any Dynamic dimension of a
+/// Multi def. Shape mismatches are already rejected by
+/// `validate_partition_key`, so unmatched shapes yield nothing here.
+fn collect_dynamic_namespaces(
+    pd: &PartitionsDefinition,
+    pk: &PyPartitionKey,
+) -> Vec<(String, Vec<String>)> {
+    match (pd, pk) {
+        (PartitionsDefinition::Dynamic { name }, PyPartitionKey::Single { key }) => {
+            vec![(name.clone(), key.clone())]
+        }
+        (PartitionsDefinition::Multi { dimensions }, PyPartitionKey::Multi { keys }) => dimensions
+            .iter()
+            .filter_map(|(dim, dim_def)| match dim_def {
+                PartitionsDefinition::Dynamic { name } => {
+                    keys.get(dim).map(|vals| (name.clone(), vals.clone()))
+                }
+                _ => None,
+            })
+            .collect(),
+        (_, PyPartitionKey::Set { keys }) => keys
+            .iter()
+            .flat_map(|k| collect_dynamic_namespaces(pd, k))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// PerDimension only groups what it can see: an unknown dimension name (or a
+/// non-Multi def, whose keys carry no dimensions at all) matches nothing, so
+/// every key would get the same empty group key and the whole backfill would
+/// silently collapse into ONE run. Reject the strategy against the
+/// selection's partition defs instead.
+fn validate_backfill_strategy(
+    strategy: &PyBackfillStrategy,
+    state: &ResolvedState,
+    selection: &[String],
+) -> PyResult<()> {
+    let PyBackfillStrategy::PerDimension {
+        multi_run_dims,
+        single_run_dims,
+    } = strategy
+    else {
+        return Ok(());
+    };
+    let partitioned =
+        iter_partitioned_assets(&state.node_map, selection.iter().map(String::as_str));
+    for (asset, pd) in &partitioned {
+        let PartitionsDefinition::Multi { dimensions } = pd else {
+            return Err(ExecutionError::new_err(format!(
+                "BackfillStrategy.per_dimension requires Multi-partitioned assets; \
+                 asset '{asset}' is not Multi-partitioned"
+            )));
+        };
+        for dim in multi_run_dims.iter().chain(single_run_dims.iter()) {
+            if !dimensions.iter().any(|(name, _)| name == dim) {
+                return Err(ExecutionError::new_err(format!(
+                    "BackfillStrategy.per_dimension references dimension '{dim}', \
+                     which is not a dimension of asset '{asset}'"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn verify_dynamic_partition_keys(
+    storage: &SurrealStorage,
+    code_location_id: &str,
+    checks: &[DynamicKeyCheck],
+) -> PyResult<()> {
+    let ctx = rivers_core::storage::CodeLocationContext::new(code_location_id);
+    let scoped = storage.for_code_location(&ctx);
+    for (asset, ns, keys) in checks {
+        for key in keys {
+            let known = scoped.has_dynamic_partition(ns, key).await.map_err(|e| {
+                ExecutionError::new_err(format!("Failed to check dynamic partition '{key}': {e}"))
+            })?;
+            if !known {
+                return Err(ExecutionError::new_err(format!(
+                    "Invalid partition_key '{key}' for asset '{asset}': not a registered \
+                     dynamic partition key of namespace '{ns}'. Register it with \
+                     add_dynamic_partitions(\"{ns}\", [...]) first."
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Reject a user-defined job whose partitioned assets can never share a
 /// single partition_key. Folds `PartitionsDefinition::intersect` across
 /// every partitioned asset; on failure the assets and the per-kind reason
@@ -1216,7 +1335,7 @@ impl RepoHandle {
         job_name: Option<String>,
     ) -> PyResult<PyRunHandle> {
         // Sync prep under the read lock — drop the guard before the await.
-        let (record, storage) = {
+        let (record, storage, dyn_checks) = {
             let guard = self.state.read().unwrap();
             let state = guard.as_ref().ok_or_else(|| {
                 ExecutionError::new_err("Repository not resolved — call resolve() first")
@@ -1241,6 +1360,11 @@ impl RepoHandle {
                 asset_names.iter().map(String::as_str),
                 partition_key,
             )?;
+            let dyn_checks = dynamic_partition_checks(
+                state,
+                asset_names.iter().map(String::as_str),
+                partition_key,
+            );
 
             let run_id = uuid::Uuid::new_v4().to_string();
             let now = now_ts();
@@ -1262,8 +1386,10 @@ impl RepoHandle {
                 block_reason: None,
                 launched_by,
             };
-            (record, state.storage.clone())
+            (record, state.storage.clone(), dyn_checks)
         };
+
+        verify_dynamic_partition_keys(&storage, &record.code_location_id, &dyn_checks).await?;
 
         storage
             .enqueue_run(&record)
@@ -1288,7 +1414,7 @@ impl RepoHandle {
         runs: Vec<RunSubmission>,
         launched_by: LaunchedBy,
     ) -> PyResult<Vec<String>> {
-        let (records, storage) = {
+        let (records, storage, dyn_checks) = {
             let guard = self.state.read().unwrap();
             let state = guard.as_ref().ok_or_else(|| {
                 ExecutionError::new_err("Repository not resolved — call resolve() first")
@@ -1306,6 +1432,7 @@ impl RepoHandle {
                 .collect();
 
             let mut records: Vec<RunRecord> = Vec::with_capacity(runs.len());
+            let mut dyn_checks: Vec<DynamicKeyCheck> = Vec::new();
 
             for sub in &runs {
                 let asset_names = sub.selection.clone().unwrap_or_else(|| all_names.clone());
@@ -1314,6 +1441,11 @@ impl RepoHandle {
                     asset_names.iter().map(String::as_str),
                     sub.partition_key.as_ref(),
                 )?;
+                dyn_checks.extend(dynamic_partition_checks(
+                    state,
+                    asset_names.iter().map(String::as_str),
+                    sub.partition_key.as_ref(),
+                ));
                 let run_id = uuid::Uuid::new_v4().to_string();
                 let run_tags = sub.tags.clone().unwrap_or_default();
                 let priority = priority_from_tags(&run_tags);
@@ -1334,8 +1466,12 @@ impl RepoHandle {
                     launched_by: launched_by.clone(),
                 });
             }
-            (records, state.storage.clone())
+            (records, state.storage.clone(), dyn_checks)
         };
+
+        if let Some(first) = records.first() {
+            verify_dynamic_partition_keys(&storage, &first.code_location_id, &dyn_checks).await?;
+        }
 
         storage
             .enqueue_runs(&records)
@@ -1368,7 +1504,7 @@ impl RepoHandle {
         partition_key: Option<&PyPartitionKey>,
         launched_by: LaunchedBy,
     ) -> PyResult<String> {
-        let (record, storage) = {
+        let (record, storage, dyn_checks) = {
             let guard = self.state.read().unwrap();
             let state = guard.as_ref().ok_or_else(|| {
                 ExecutionError::new_err("Repository not resolved — call resolve() first")
@@ -1385,6 +1521,11 @@ impl RepoHandle {
                 asset_names.iter().map(String::as_str),
                 partition_key,
             )?;
+            let dyn_checks = dynamic_partition_checks(
+                state,
+                asset_names.iter().map(String::as_str),
+                partition_key,
+            );
 
             let run_id = uuid::Uuid::new_v4().to_string();
             let now = now_ts();
@@ -1404,8 +1545,10 @@ impl RepoHandle {
                 block_reason: None,
                 launched_by,
             };
-            (record, state.storage.clone())
+            (record, state.storage.clone(), dyn_checks)
         };
+
+        verify_dynamic_partition_keys(&storage, &record.code_location_id, &dyn_checks).await?;
 
         storage
             .create_run(&record)
@@ -1490,20 +1633,32 @@ impl RepoHandle {
     /// (e.g. gRPC `materialize` going through
     /// `dispatch_materialization`) can fail synchronously instead of
     /// after a fire-and-forget thread swallows the error.
-    pub(crate) fn validate_partition_for_selection(
+    pub(crate) async fn validate_partition_for_selection(
         &self,
         asset_names: &[String],
         partition_key: Option<&PyPartitionKey>,
     ) -> PyResult<()> {
-        let guard = self.state.read().unwrap();
-        let state = guard.as_ref().ok_or_else(|| {
-            ExecutionError::new_err("Repository not resolved — call resolve() first")
-        })?;
-        validate_partition_for_selection(
-            state,
-            asset_names.iter().map(String::as_str),
-            partition_key,
-        )
+        let (dyn_checks, storage, code_location_id) = {
+            let guard = self.state.read().unwrap();
+            let state = guard.as_ref().ok_or_else(|| {
+                ExecutionError::new_err("Repository not resolved — call resolve() first")
+            })?;
+            validate_partition_for_selection(
+                state,
+                asset_names.iter().map(String::as_str),
+                partition_key,
+            )?;
+            (
+                dynamic_partition_checks(
+                    state,
+                    asset_names.iter().map(String::as_str),
+                    partition_key,
+                ),
+                state.storage.clone(),
+                state.code_location_id.clone(),
+            )
+        };
+        verify_dynamic_partition_keys(&storage, &code_location_id, &dyn_checks).await
     }
 
     /// Reject any name in `asset_names` that isn't a resolved node in
@@ -1976,6 +2131,18 @@ impl PyCodeRepository {
             selected_names.iter().map(String::as_str),
             partition_key.as_ref(),
         )?;
+        let dyn_checks = dynamic_partition_checks(
+            state,
+            selected_names.iter().map(String::as_str),
+            partition_key.as_ref(),
+        );
+        if !dyn_checks.is_empty() {
+            rt().block_on(verify_dynamic_partition_keys(
+                &state.storage,
+                &state.code_location_id,
+                &dyn_checks,
+            ))?;
+        }
 
         // allow_incomplete_deps keeps the permissive "load missing upstream
         // from io_handler" semantics materialize has always offered (Job's
@@ -3465,6 +3632,17 @@ impl PyCodeRepository {
             if keys.is_empty() {
                 return Err(ExecutionError::new_err("partition_keys must not be empty"));
             }
+            // repo.backfill() and gRPC LaunchBackfill are boundaries — reject
+            // invalid keys here like `materialize` does, instead of persisting
+            // a BackfillRecord that counts them and fails per-run later. (The
+            // range branch validates via `resolve()`.)
+            for key in &keys {
+                validate_partition_for_selection(
+                    state,
+                    selection.iter().map(String::as_str),
+                    Some(key),
+                )?;
+            }
             keys
         } else if let Some(range) = partition_range {
             let selected = selection.as_slice();
@@ -3491,6 +3669,22 @@ impl PyCodeRepository {
             ));
         };
 
+        let mut dyn_checks: Vec<DynamicKeyCheck> = Vec::new();
+        for key in &resolved_keys {
+            dyn_checks.extend(dynamic_partition_checks(
+                state,
+                selection.iter().map(String::as_str),
+                Some(key),
+            ));
+        }
+        if !dyn_checks.is_empty() {
+            rt().block_on(verify_dynamic_partition_keys(
+                &state.storage,
+                &state.code_location_id,
+                &dyn_checks,
+            ))?;
+        }
+
         let num_partitions = resolved_keys.len();
 
         // Resolution: explicit > asset default > MultiRun.
@@ -3510,6 +3704,7 @@ impl PyCodeRepository {
                 PyBackfillStrategy::MultiRun {}
             }
         };
+        validate_backfill_strategy(&resolved_strategy, state, &selection)?;
 
         let core_strategy = resolved_strategy.to_core();
         let run_groups = rivers_core::execution::backfill::group_into_runs(

--- a/python/src/repository/mod.rs
+++ b/python/src/repository/mod.rs
@@ -3728,8 +3728,7 @@ impl PyCodeRepository {
             }
             // repo.backfill() and gRPC LaunchBackfill are boundaries — reject
             // invalid keys here like `materialize` does, instead of persisting
-            // a BackfillRecord that counts them and fails per-run later. (The
-            // range branch validates via `resolve()`.)
+            // a BackfillRecord that counts them and fails per-run later.
             for key in &keys {
                 validate_partition_for_selection(
                     state,
@@ -3756,7 +3755,18 @@ impl PyCodeRepository {
                         "partition_range specified but no partitioned assets found in selection",
                     )
                 })?;
-            range.resolve(parts_def)?
+            let resolved = range.resolve(parts_def)?;
+            // The range resolved against one def — the selection's other
+            // partitioned assets must accept each key too, same boundary
+            // contract as the explicit-keys branch.
+            for key in &resolved {
+                validate_partition_for_selection(
+                    state,
+                    selection.iter().map(String::as_str),
+                    Some(key),
+                )?;
+            }
+            resolved
         } else {
             return Err(ExecutionError::new_err(
                 "Either partition_keys or partition_range must be provided",

--- a/python/src/repository/mod.rs
+++ b/python/src/repository/mod.rs
@@ -93,9 +93,10 @@ fn validate_partition_for_selection<'a>(
     for (name, pd) in &partitioned {
         if !pd.validate_partition_key(pk)? {
             return Err(ExecutionError::new_err(format!(
-                "Invalid partition_key {:?} for asset '{}': not a member of its \
+                "Invalid partition_key '{}' for asset '{}': not a member of its \
                  partition definition.",
-                pk, name
+                PartitionKey::from(pk).to_display(),
+                name
             )));
         }
     }

--- a/python/src/repository/mod.rs
+++ b/python/src/repository/mod.rs
@@ -177,6 +177,26 @@ fn validate_backfill_strategy(
     else {
         return Ok(());
     };
+    // Same invariants as BackfillStrategy.per_dimension() — strategies built
+    // from the proto path skip the constructor, and an empty multi_run list
+    // would collapse the whole backfill into a single run.
+    if multi_run_dims.is_empty() {
+        return Err(ExecutionError::new_err(
+            "multi_run must contain at least one dimension",
+        ));
+    }
+    if single_run_dims.is_empty() {
+        return Err(ExecutionError::new_err(
+            "single_run must contain at least one dimension",
+        ));
+    }
+    for dim in multi_run_dims {
+        if single_run_dims.contains(dim) {
+            return Err(ExecutionError::new_err(format!(
+                "dimension '{dim}' cannot be in both multi_run and single_run"
+            )));
+        }
+    }
     let partitioned =
         iter_partitioned_assets(&state.node_map, selection.iter().map(String::as_str));
     for (asset, pd) in &partitioned {

--- a/python/src/repository/mod.rs
+++ b/python/src/repository/mod.rs
@@ -198,26 +198,42 @@ fn validate_backfill_strategy(
     Ok(())
 }
 
-async fn verify_dynamic_partition_keys(
+/// Storage-backed membership check: returns the `(asset, ns, key)` triples
+/// that are NOT registered. Storage failures propagate — an unreachable
+/// store says nothing about whether a key is retired.
+async fn unregistered_dynamic_keys(
     storage: &SurrealStorage,
     code_location_id: &str,
     checks: &[DynamicKeyCheck],
-) -> PyResult<()> {
+) -> PyResult<Vec<(String, String, String)>> {
     let ctx = rivers_core::storage::CodeLocationContext::new(code_location_id);
     let scoped = storage.for_code_location(&ctx);
+    let mut missing = Vec::new();
     for (asset, ns, keys) in checks {
         for key in keys {
             let known = scoped.has_dynamic_partition(ns, key).await.map_err(|e| {
                 ExecutionError::new_err(format!("Failed to check dynamic partition '{key}': {e}"))
             })?;
             if !known {
-                return Err(ExecutionError::new_err(format!(
-                    "Invalid partition_key '{key}' for asset '{asset}': not a registered \
-                     dynamic partition key of namespace '{ns}'. Register it with \
-                     add_dynamic_partitions(\"{ns}\", [...]) first."
-                )));
+                missing.push((asset.clone(), ns.clone(), key.clone()));
             }
         }
+    }
+    Ok(missing)
+}
+
+async fn verify_dynamic_partition_keys(
+    storage: &SurrealStorage,
+    code_location_id: &str,
+    checks: &[DynamicKeyCheck],
+) -> PyResult<()> {
+    let missing = unregistered_dynamic_keys(storage, code_location_id, checks).await?;
+    if let Some((asset, ns, key)) = missing.first() {
+        return Err(ExecutionError::new_err(format!(
+            "Invalid partition_key '{key}' for asset '{asset}': not a registered \
+             dynamic partition key of namespace '{ns}'. Register it with \
+             add_dynamic_partitions(\"{ns}\", [...]) first."
+        )));
     }
     Ok(())
 }
@@ -3443,20 +3459,22 @@ impl PyCodeRepository {
                     state.code_location_id.clone(),
                 )
             };
-            let partition_keys: Vec<PyPartitionKey> = candidates
-                .into_iter()
-                .filter_map(|(key, checks)| {
-                    (checks.is_empty()
-                        || rt()
-                            .block_on(verify_dynamic_partition_keys(
-                                &storage,
-                                &code_location_id,
-                                &checks,
-                            ))
-                            .is_ok())
-                    .then_some(key)
-                })
-                .collect();
+            let mut partition_keys: Vec<PyPartitionKey> = Vec::with_capacity(candidates.len());
+            for (key, checks) in candidates {
+                // Only a genuinely unregistered key is retired — a storage
+                // failure says nothing about the key and must abort the rerun.
+                let retired = !checks.is_empty()
+                    && !rt()
+                        .block_on(unregistered_dynamic_keys(
+                            &storage,
+                            &code_location_id,
+                            &checks,
+                        ))?
+                        .is_empty();
+                if !retired {
+                    partition_keys.push(key);
+                }
+            }
             if partition_keys.len() < total {
                 tracing::warn!(
                     target: "rivers::repo",

--- a/python/src/repository/mod.rs
+++ b/python/src/repository/mod.rs
@@ -3399,6 +3399,79 @@ impl PyCodeRepository {
                 .iter()
                 .map(PyPartitionKey::from)
                 .collect();
+
+            // Definitions may have evolved since the original backfill —
+            // replay the partitions that still exist instead of failing the
+            // whole rerun on the first retired key.
+            let total = partition_keys.len();
+            let (candidates, storage, code_location_id) = {
+                let guard = self.state.read().unwrap();
+                let state = guard.as_ref().expect("ensure_resolved succeeded above");
+                let selection_names: Vec<String> = match &record.job_name {
+                    Some(name) => state
+                        .jobs_info
+                        .get(name)
+                        .map(|j| j.asset_names.clone())
+                        .ok_or_else(|| {
+                            ExecutionError::new_err(format!("Job '{name}' not found"))
+                        })?,
+                    None => record.asset_selection.clone(),
+                };
+                let candidates: Vec<(PyPartitionKey, Vec<DynamicKeyCheck>)> = partition_keys
+                    .into_iter()
+                    .filter(|key| {
+                        validate_partition_for_selection(
+                            state,
+                            selection_names.iter().map(String::as_str),
+                            Some(key),
+                        )
+                        .is_ok()
+                    })
+                    .map(|key| {
+                        let checks = dynamic_partition_checks(
+                            state,
+                            selection_names.iter().map(String::as_str),
+                            Some(&key),
+                        );
+                        (key, checks)
+                    })
+                    .collect();
+                (
+                    candidates,
+                    state.storage.clone(),
+                    state.code_location_id.clone(),
+                )
+            };
+            let partition_keys: Vec<PyPartitionKey> = candidates
+                .into_iter()
+                .filter_map(|(key, checks)| {
+                    (checks.is_empty()
+                        || rt()
+                            .block_on(verify_dynamic_partition_keys(
+                                &storage,
+                                &code_location_id,
+                                &checks,
+                            ))
+                            .is_ok())
+                    .then_some(key)
+                })
+                .collect();
+            if partition_keys.len() < total {
+                tracing::warn!(
+                    target: "rivers::repo",
+                    backfill_id = %backfill_id,
+                    dropped = total - partition_keys.len(),
+                    kept = partition_keys.len(),
+                    "rerun skipping partitions no longer valid for the current definitions"
+                );
+            }
+            if partition_keys.is_empty() {
+                return Err(ExecutionError::new_err(format!(
+                    "Cannot rerun backfill '{backfill_id}': none of its {total} partitions \
+                     are valid for the current definitions"
+                )));
+            }
+
             let strategy = PyBackfillStrategy::from_core(&record.strategy);
             let failure_policy = match record.failure_policy {
                 BackfillFailurePolicy::Continue => "continue",

--- a/python/src/repository/mod.rs
+++ b/python/src/repository/mod.rs
@@ -3627,6 +3627,26 @@ impl PyCodeRepository {
                 (assets, Some(name))
             }
         };
+        // An empty Materialization selection means "all assets" — expand it
+        // so key/strategy validation sees the effective selection.
+        let selection: Vec<String> = if selection.is_empty() {
+            state.node_map.keys().cloned().collect()
+        } else {
+            selection
+        };
+
+        // Keys/ranges against an unpartitioned selection would bypass every
+        // def-aware check (and PerDimension grouping would silently collapse
+        // all keys into one run).
+        if (partition_keys.is_some() || partition_range.is_some())
+            && iter_partitioned_assets(&state.node_map, selection.iter().map(String::as_str))
+                .is_empty()
+        {
+            return Err(ExecutionError::new_err(
+                "Backfill partition_keys/partition_range require a partitioned selection; \
+                 no asset in the selection is partitioned.",
+            ));
+        }
 
         let resolved_keys: Vec<PyPartitionKey> = if let Some(keys) = partition_keys {
             if keys.is_empty() {

--- a/python/src/repository/mod.rs
+++ b/python/src/repository/mod.rs
@@ -1168,9 +1168,25 @@ pub(crate) fn build_unresolved_graph(
 /// - If downstream is partitioned and upstream is NOT partitioned, no mapping needed (unpartitioned dep is shared)
 /// - If downstream is NOT partitioned and upstream IS partitioned, error (need AllPartitions mapping)
 fn validate_partition_mappings(
+    py: Python,
     node_map: &HashMap<String, ResolvedNode>,
     unresolved_graph: &BTreeMap<String, Vec<NodeRef>>,
 ) -> PyResult<()> {
+    // PyO3's per-variant constructors bypass the factory validation, so the
+    // resolve boundary re-checks every definition before edge validation.
+    let mut names: Vec<&String> = node_map.keys().collect();
+    names.sort_unstable();
+    for node_name in names {
+        if let Some(def) = node_map[node_name].partitions_def() {
+            def.validate_definition().map_err(|e| {
+                PartitionValidationError::new_err(format!(
+                    "Asset '{}': invalid partitions definition: {}",
+                    node_name,
+                    e.value(py)
+                ))
+            })?;
+        }
+    }
     for (node_name, deps) in unresolved_graph {
         let downstream_node = match node_map.get(node_name) {
             Some(n) => n,
@@ -2307,7 +2323,7 @@ impl PyCodeRepository {
             step_kinds,
         } = build_unresolved_graph(py, &self.raw_assets, &self.raw_tasks, resource_keys)?;
 
-        validate_partition_mappings(&node_map, &unresolved_graph)?;
+        validate_partition_mappings(py, &node_map, &unresolved_graph)?;
 
         // External assets with automation_condition must have an observe_fn.
         for node in node_map.values() {

--- a/python/tests/backfill/test_backfill.py
+++ b/python/tests/backfill/test_backfill.py
@@ -127,6 +127,34 @@ class TestBackfillExplicitKeys:
 
 
 class TestBackfillPartitionRange:
+    def test_range_validates_against_every_partitioned_asset(self):
+        """The range resolves against ONE def; the other partitioned assets
+        in the selection must still accept every resolved key — reject at the
+        boundary instead of persisting a record whose runs fail per-partition."""
+
+        @rs.Asset(partitions_def=_static_pd(["a", "b", "c"]))
+        def first(context: rs.AssetExecutionContext) -> int:
+            return 1
+
+        @rs.Asset(partitions_def=_static_pd(["x", "y"]))
+        def second(context: rs.AssetExecutionContext) -> int:
+            return 1
+
+        repo = rs.CodeRepository(
+            assets=[first, second], default_executor=rs.Executor.in_process()
+        )
+        with pytest.raises(
+            ExecutionError,
+            match=re.escape(
+                "Invalid partition_key 'a' for asset 'second': "
+                "not a member of its partition definition."
+            ),
+        ):
+            repo.backfill(
+                selection=["first", "second"],
+                partition_range=rs.PartitionKeyRange.single(from_key="a", to_key="b"),
+            )
+
     def test_single_range_filters_keys(self, executor_env, is_async):
         executor, _ = executor_env
 

--- a/python/tests/backfill/test_backfill.py
+++ b/python/tests/backfill/test_backfill.py
@@ -672,6 +672,35 @@ class TestBackfillRerun:
         assert dry.is_dry_run
         assert dry.num_partitions == 2
 
+    def test_rerun_skips_retired_dynamic_keys(self, storage):
+        """A dynamic key deleted since the original backfill is skipped on
+        rerun. Only a genuinely unregistered key counts as retired — a
+        storage failure during the check aborts the rerun instead of
+        silently dropping replayable partitions."""
+
+        @rs.Asset(
+            partitions_def=rs.PartitionsDefinition.dynamic("tenants"),
+            io_handler=rs.InMemoryIOHandler(),
+        )
+        def asset(context: rs.AssetExecutionContext) -> int:
+            return 1
+
+        repo = rs.CodeRepository(
+            assets=[asset], default_executor=rs.Executor.in_process()
+        )
+        repo.resolve(storage=storage)
+        storage.add_dynamic_partitions("tenants", ["acme", "globex"])
+        original = repo.backfill(
+            selection=["asset"],
+            partition_keys=[rs.PartitionKey.single(k) for k in ("acme", "globex")],
+        )
+        assert original.completed == 2
+
+        storage.delete_dynamic_partition("tenants", "globex")
+        rerun = repo.rerun_backfill(original.backfill_id)
+        assert rerun.num_partitions == 1
+        assert rerun.completed == 1
+
     def test_rerun_with_no_surviving_keys_errors(self, storage):
         def build_repo(keys):
             @rs.Asset(

--- a/python/tests/backfill/test_backfill.py
+++ b/python/tests/backfill/test_backfill.py
@@ -851,3 +851,35 @@ class TestRangeDefinitionOrdering:
             rs.PartitionKey.multi({"size": "medium", "region": "us"}),
             rs.PartitionKey.multi({"size": "large", "region": "us"}),
         }
+
+    def test_multi_range_unknown_dimension_rejected(self):
+        """A typo'd selector dimension must error — silently ignoring it
+        treats the real dimension as omitted and expands it to ALL keys,
+        backfilling far more partitions than requested."""
+        pd = rs.PartitionsDefinition.multi(
+            {
+                "size": _static_pd(self.SIZES),
+                "region": _static_pd(["us", "eu"]),
+            }
+        )
+
+        @rs.Asset(partitions_def=pd)
+        def asset(context: rs.AssetExecutionContext) -> int:
+            return 1
+
+        repo = rs.CodeRepository(
+            assets=[asset], default_executor=rs.Executor.in_process()
+        )
+        with pytest.raises(
+            ExecutionError,
+            match=re.escape(
+                "Unknown dimension 'regon' in partition range; "
+                "available dimensions: 'size', 'region'"
+            ),
+        ):
+            repo.backfill(
+                selection=["asset"],
+                partition_range=rs.PartitionKeyRange.multi(
+                    {"size": ("medium", "large"), "regon": ["us"]}
+                ),
+            )

--- a/python/tests/backfill/test_backfill.py
+++ b/python/tests/backfill/test_backfill.py
@@ -752,7 +752,8 @@ class TestRangeDefinitionOrdering:
 
     def test_time_window_range_off_grid_endpoint_rejected(self):
         """An endpoint that parses under the fmt but isn't a window start is
-        not a partition key — same contract as Static unknown endpoints."""
+        not a partition key — same contract as Static unknown endpoints. The
+        error names the neighbouring valid keys so the typo is fixable."""
         pd = rs.PartitionsDefinition.time_window(
             start=datetime(2024, 1, 1),
             interval_seconds=3600,
@@ -770,13 +771,29 @@ class TestRangeDefinitionOrdering:
         with pytest.raises(
             ExecutionError,
             match=re.escape(
-                "Range endpoint '2024-01-01T07:30:00' is not a partition key"
+                "Range endpoint '2024-01-01T07:30:00' is not a partition key; "
+                "nearest valid keys are '2024-01-01T07:00:00' and "
+                "'2024-01-01T08:00:00'"
             ),
         ):
             repo.backfill(
                 selection=["asset"],
                 partition_range=rs.PartitionKeyRange.single(
                     from_key="2024-01-01T07:30:00", to_key="2024-01-01T10:00:00"
+                ),
+            )
+        # Out-of-range endpoint: only one side has a valid neighbour.
+        with pytest.raises(
+            ExecutionError,
+            match=re.escape(
+                "Range endpoint '2024-01-02T05:00:00' is not a partition key; "
+                "nearest valid key is '2024-01-01T23:00:00'"
+            ),
+        ):
+            repo.backfill(
+                selection=["asset"],
+                partition_range=rs.PartitionKeyRange.single(
+                    from_key="2024-01-01T10:00:00", to_key="2024-01-02T05:00:00"
                 ),
             )
 

--- a/python/tests/backfill/test_backfill.py
+++ b/python/tests/backfill/test_backfill.py
@@ -612,6 +612,66 @@ class TestBackfillRerun:
         with pytest.raises(Exception, match="not found"):
             repo.rerun_backfill("nonexistent-id")
 
+    def test_rerun_skips_keys_removed_from_def(self, storage):
+        """Rerunning after the def shrank replays the surviving keys instead
+        of hard-erroring the whole rerun."""
+
+        def build_repo(keys):
+            @rs.Asset(
+                partitions_def=_static_pd(keys), io_handler=rs.InMemoryIOHandler()
+            )
+            def asset(context: rs.AssetExecutionContext) -> int:
+                return 1
+
+            repo = rs.CodeRepository(
+                assets=[asset], default_executor=rs.Executor.in_process()
+            )
+            repo.resolve(storage=storage)
+            return repo
+
+        original = build_repo(["a", "b", "c"]).backfill(
+            selection=["asset"],
+            partition_keys=[rs.PartitionKey.single(k) for k in ("a", "b", "c")],
+        )
+        assert original.completed == 3
+
+        redeployed = build_repo(["a", "b"])
+        rerun = redeployed.rerun_backfill(original.backfill_id)
+        assert rerun.num_partitions == 2
+        assert rerun.completed == 2
+
+        dry = redeployed.rerun_backfill(original.backfill_id, dry_run=True)
+        assert dry.is_dry_run
+        assert dry.num_partitions == 2
+
+    def test_rerun_with_no_surviving_keys_errors(self, storage):
+        def build_repo(keys):
+            @rs.Asset(
+                partitions_def=_static_pd(keys), io_handler=rs.InMemoryIOHandler()
+            )
+            def asset(context: rs.AssetExecutionContext) -> int:
+                return 1
+
+            repo = rs.CodeRepository(
+                assets=[asset], default_executor=rs.Executor.in_process()
+            )
+            repo.resolve(storage=storage)
+            return repo
+
+        original = build_repo(["a", "b"]).backfill(
+            selection=["asset"],
+            partition_keys=[rs.PartitionKey.single(k) for k in ("a", "b")],
+        )
+
+        redeployed = build_repo(["x", "y"])
+        with pytest.raises(
+            ExecutionError,
+            match=re.escape(
+                "none of its 2 partitions are valid for the current definitions"
+            ),
+        ):
+            redeployed.rerun_backfill(original.backfill_id)
+
     def test_rerun_dry_run(self, executor_env):
         executor, _ = executor_env
 

--- a/python/tests/backfill/test_backfill.py
+++ b/python/tests/backfill/test_backfill.py
@@ -690,6 +690,36 @@ class TestRangeDefinitionOrdering:
                 ),
             )
 
+    def test_time_window_range_off_grid_endpoint_rejected(self):
+        """An endpoint that parses under the fmt but isn't a window start is
+        not a partition key — same contract as Static unknown endpoints."""
+        pd = rs.PartitionsDefinition.time_window(
+            start=datetime(2024, 1, 1),
+            interval_seconds=3600,
+            end=datetime(2024, 1, 2),
+            fmt="%Y-%m-%dT%H:%M:%S",
+        )
+
+        @rs.Asset(partitions_def=pd)
+        def asset(context: rs.AssetExecutionContext) -> int:
+            return 1
+
+        repo = rs.CodeRepository(
+            assets=[asset], default_executor=rs.Executor.in_process()
+        )
+        with pytest.raises(
+            ExecutionError,
+            match=re.escape(
+                "Range endpoint '2024-01-01T07:30:00' is not a partition key"
+            ),
+        ):
+            repo.backfill(
+                selection=["asset"],
+                partition_range=rs.PartitionKeyRange.single(
+                    from_key="2024-01-01T07:30:00", to_key="2024-01-01T10:00:00"
+                ),
+            )
+
     def test_custom_fmt_range_resolves_chronologically(self):
         # %m/%d/%Y sorts "01/02/2025" before "12/30/2024" lexicographically —
         # the range must follow the calendar instead.

--- a/python/tests/backfill/test_backfill.py
+++ b/python/tests/backfill/test_backfill.py
@@ -4,10 +4,12 @@ Covers plain @rs.Asset across executor (in_process, parallel) and sync/async.
 """
 
 import asyncio
+import re
 from datetime import datetime
 
 import pytest
 import rivers as rs
+from rivers.exceptions import ExecutionError
 
 from _helpers import daily_pd as _daily_pd
 from _helpers import static_pd as _static_pd
@@ -627,3 +629,118 @@ class TestBackfillRerun:
         rerun = repo.rerun_backfill(original.backfill_id, dry_run=True)
         assert rerun.is_dry_run
         assert rerun.num_partitions == 1
+
+
+# ---------------------------------------------------------------------------
+# Range ordering follows the definition, not lexicographic strings. Static
+# keys are positionally ordered; TimeWindow keys are chronologically ordered
+# via their fmt — neither is guaranteed to sort lexicographically.
+# ---------------------------------------------------------------------------
+
+
+class TestRangeDefinitionOrdering:
+    SIZES = ["small", "medium", "large"]  # NOT lexicographically sorted
+
+    def _sized_repo(self):
+        @rs.Asset(partitions_def=_static_pd(self.SIZES))
+        def sized(context: rs.AssetExecutionContext) -> int:
+            return 1
+
+        return rs.CodeRepository(
+            assets=[sized], default_executor=rs.Executor.in_process()
+        )
+
+    def test_static_range_resolves_positionally(self):
+        repo = self._sized_repo()
+        result = repo.backfill(
+            selection=["sized"],
+            partition_range=rs.PartitionKeyRange.single(
+                from_key="medium", to_key="large"
+            ),
+        )
+        assert result.num_partitions == 2
+        assert set(repo.storage.get_materialized_partitions("sized")) == {
+            rs.PartitionKey.single("medium"),
+            rs.PartitionKey.single("large"),
+        }
+
+    def test_static_range_positionally_inverted_rejected(self):
+        repo = self._sized_repo()
+        with pytest.raises(
+            ExecutionError,
+            match=re.escape("from_key 'large' is after to_key 'small'"),
+        ):
+            repo.backfill(
+                selection=["sized"],
+                partition_range=rs.PartitionKeyRange.single(
+                    from_key="large", to_key="small"
+                ),
+            )
+
+    def test_static_range_unknown_endpoint_rejected(self):
+        repo = self._sized_repo()
+        with pytest.raises(
+            ExecutionError,
+            match=re.escape("Range endpoint 'huge' is not a partition key"),
+        ):
+            repo.backfill(
+                selection=["sized"],
+                partition_range=rs.PartitionKeyRange.single(
+                    from_key="medium", to_key="huge"
+                ),
+            )
+
+    def test_custom_fmt_range_resolves_chronologically(self):
+        # %m/%d/%Y sorts "01/02/2025" before "12/30/2024" lexicographically —
+        # the range must follow the calendar instead.
+        pd = rs.PartitionsDefinition.daily(
+            start=datetime(2024, 12, 30),
+            end=datetime(2025, 1, 3),
+            fmt="%m/%d/%Y",
+        )
+
+        @rs.Asset(partitions_def=pd)
+        def asset(context: rs.AssetExecutionContext) -> int:
+            return 1
+
+        repo = rs.CodeRepository(
+            assets=[asset], default_executor=rs.Executor.in_process()
+        )
+        result = repo.backfill(
+            selection=["asset"],
+            partition_range=rs.PartitionKeyRange.single(
+                from_key="12/30/2024", to_key="01/02/2025"
+            ),
+        )
+        assert result.num_partitions == 4
+        assert set(repo.storage.get_materialized_partitions("asset")) == {
+            rs.PartitionKey.single("12/30/2024"),
+            rs.PartitionKey.single("12/31/2024"),
+            rs.PartitionKey.single("01/01/2025"),
+            rs.PartitionKey.single("01/02/2025"),
+        }
+
+    def test_multi_static_dim_range_resolves_positionally(self):
+        pd = rs.PartitionsDefinition.multi(
+            {
+                "size": _static_pd(self.SIZES),
+                "region": _static_pd(["us"]),
+            }
+        )
+
+        @rs.Asset(partitions_def=pd)
+        def asset(context: rs.AssetExecutionContext) -> int:
+            return 1
+
+        repo = rs.CodeRepository(
+            assets=[asset], default_executor=rs.Executor.in_process()
+        )
+        result = repo.backfill(
+            selection=["asset"],
+            partition_range=rs.PartitionKeyRange.multi({"size": ("medium", "large")}),
+        )
+        assert result.num_partitions == 2
+        assert set(repo.storage.get_materialized_partitions("asset")) == {
+            rs.PartitionKey.multi({"size": "medium", "region": "us"}),
+            rs.PartitionKey.multi({"size": "large", "region": "us"}),
+        }

--- a/python/tests/backfill/test_backfill_priority.py
+++ b/python/tests/backfill/test_backfill_priority.py
@@ -253,10 +253,12 @@ class TestDaemonBackfillPriority:
             partition_key=rs.PartitionKey.single("b"),
         )
 
+        # Per-partition dep matching: the upstream re-materializations must
+        # land within one tick window to dispatch as a single backfill.
         daemon = AutomationDaemon(
             repo=repo,
             storage=storage,
-            condition_eval_interval="1s",
+            condition_eval_interval="3s",
         )
         daemon.start()
         try:

--- a/python/tests/backfill/test_backfill_strategy.py
+++ b/python/tests/backfill/test_backfill_strategy.py
@@ -4,10 +4,12 @@ Covers plain @rs.Asset across executor (in_process, parallel) and sync/async.
 """
 
 import asyncio
+import re
 from datetime import datetime
 
 import pytest
 import rivers as rs
+from rivers.exceptions import ExecutionError
 
 from _helpers import multi_pd as _multi_pd
 from _helpers import static_pd as _static_pd
@@ -787,3 +789,94 @@ class TestPartitionedRaiseRecordsFailure:
             if e.event_type == "StepFailure" and e.partition_key is not None
         ]
         assert len(pfails) == 1, [e.partition_key for e in pfails]
+
+
+# ---------------------------------------------------------------------------
+# Strategy ↔ definition validation — a typo'd dimension name or a
+# PerDimension strategy on a single-dim asset would otherwise silently
+# collapse the whole backfill into ONE run.
+# ---------------------------------------------------------------------------
+
+UNKNOWN_DIM_MSG = (
+    "BackfillStrategy.per_dimension references dimension '{dim}', "
+    "which is not a dimension of asset 'asset'"
+)
+NOT_MULTI_MSG = (
+    "BackfillStrategy.per_dimension requires Multi-partitioned assets; "
+    "asset 'asset' is not Multi-partitioned"
+)
+
+
+class TestPerDimensionValidation:
+    def _multi_repo(self):
+        @rs.Asset(partitions_def=_multi_pd())
+        def asset(context: rs.AssetExecutionContext) -> int:
+            return 1
+
+        return rs.CodeRepository(
+            assets=[asset], default_executor=rs.Executor.in_process()
+        )
+
+    def test_unknown_multi_run_dim_rejected(self):
+        repo = self._multi_repo()
+        with pytest.raises(
+            ExecutionError, match=re.escape(UNKNOWN_DIM_MSG.format(dim="reigon"))
+        ):
+            repo.backfill(
+                selection=["asset"],
+                partition_keys=[
+                    rs.PartitionKey.multi({"region": "us", "date": "d1"})
+                ],
+                strategy=rs.BackfillStrategy.per_dimension(
+                    multi_run=["reigon"], single_run=["date"]
+                ),
+            )
+        assert repo.storage.get_runs(limit=10) == []
+
+    def test_unknown_single_run_dim_rejected(self):
+        repo = self._multi_repo()
+        with pytest.raises(
+            ExecutionError, match=re.escape(UNKNOWN_DIM_MSG.format(dim="daet"))
+        ):
+            repo.backfill(
+                selection=["asset"],
+                partition_keys=[
+                    rs.PartitionKey.multi({"region": "us", "date": "d1"})
+                ],
+                strategy=rs.BackfillStrategy.per_dimension(
+                    multi_run=["region"], single_run=["daet"]
+                ),
+            )
+
+    def test_per_dimension_on_single_dim_asset_rejected(self):
+        @rs.Asset(partitions_def=_static_pd(["a", "b"]))
+        def asset(context: rs.AssetExecutionContext) -> int:
+            return 1
+
+        repo = rs.CodeRepository(
+            assets=[asset], default_executor=rs.Executor.in_process()
+        )
+        with pytest.raises(ExecutionError, match=re.escape(NOT_MULTI_MSG)):
+            repo.backfill(
+                selection=["asset"],
+                partition_keys=[rs.PartitionKey.single("a")],
+                strategy=rs.BackfillStrategy.per_dimension(
+                    multi_run=["region"], single_run=["date"]
+                ),
+            )
+
+    def test_dry_run_also_validates(self):
+        repo = self._multi_repo()
+        with pytest.raises(
+            ExecutionError, match=re.escape(UNKNOWN_DIM_MSG.format(dim="reigon"))
+        ):
+            repo.backfill(
+                selection=["asset"],
+                partition_keys=[
+                    rs.PartitionKey.multi({"region": "us", "date": "d1"})
+                ],
+                strategy=rs.BackfillStrategy.per_dimension(
+                    multi_run=["reigon"], single_run=["date"]
+                ),
+                dry_run=True,
+            )

--- a/python/tests/backfill/test_backfill_strategy.py
+++ b/python/tests/backfill/test_backfill_strategy.py
@@ -824,9 +824,7 @@ class TestPerDimensionValidation:
         ):
             repo.backfill(
                 selection=["asset"],
-                partition_keys=[
-                    rs.PartitionKey.multi({"region": "us", "date": "d1"})
-                ],
+                partition_keys=[rs.PartitionKey.multi({"region": "us", "date": "d1"})],
                 strategy=rs.BackfillStrategy.per_dimension(
                     multi_run=["reigon"], single_run=["date"]
                 ),
@@ -840,9 +838,7 @@ class TestPerDimensionValidation:
         ):
             repo.backfill(
                 selection=["asset"],
-                partition_keys=[
-                    rs.PartitionKey.multi({"region": "us", "date": "d1"})
-                ],
+                partition_keys=[rs.PartitionKey.multi({"region": "us", "date": "d1"})],
                 strategy=rs.BackfillStrategy.per_dimension(
                     multi_run=["region"], single_run=["daet"]
                 ),
@@ -872,9 +868,7 @@ class TestPerDimensionValidation:
         ):
             repo.backfill(
                 selection=["asset"],
-                partition_keys=[
-                    rs.PartitionKey.multi({"region": "us", "date": "d1"})
-                ],
+                partition_keys=[rs.PartitionKey.multi({"region": "us", "date": "d1"})],
                 strategy=rs.BackfillStrategy.per_dimension(
                     multi_run=["reigon"], single_run=["date"]
                 ),

--- a/python/tests/backfill/test_daemon_backfill.py
+++ b/python/tests/backfill/test_daemon_backfill.py
@@ -85,7 +85,7 @@ class TestDaemonConditionBackfill:
         daemon = AutomationDaemon(
             repo=repo,
             storage=storage,
-            condition_eval_interval="1s",
+            condition_eval_interval="3s",
         )
         daemon.start()
         try:
@@ -249,7 +249,7 @@ class TestDaemonConditionBackfill:
         daemon = AutomationDaemon(
             repo=repo,
             storage=storage,
-            condition_eval_interval="1s",
+            condition_eval_interval="3s",
         )
         daemon.start()
         try:
@@ -346,10 +346,13 @@ class TestDaemonConditionBackfill:
                     partition_key=pk,
                 )
 
+        # Dep matching is per-partition: the four upstream re-materializations
+        # below must land within one tick window or the condition legitimately
+        # fires as two separate backfills.
         daemon = AutomationDaemon(
             repo=repo,
             storage=storage,
-            condition_eval_interval="1s",
+            condition_eval_interval="3s",
         )
         daemon.start()
         try:

--- a/python/tests/core/test_task_graph.py
+++ b/python/tests/core/test_task_graph.py
@@ -441,7 +441,7 @@ def test_partitioned_task_materialize():
     assert repo.load_node("sink", partition_key=pk) == "sink(computed-p1)"
 
 
-def test_dynamic_partitioned_task():
+def test_dynamic_partitioned_task(storage):
     """Task with dynamic partitions_def works correctly."""
     dyn = rs.PartitionsDefinition.dynamic("tenants")
 
@@ -450,7 +450,8 @@ def test_dynamic_partitioned_task():
         return f"tenant={context.partition_key}"
 
     repo = rs.CodeRepository(assets=[], tasks=[process])
-    repo.resolve()
+    repo.resolve(storage=storage)
+    storage.add_dynamic_partitions("tenants", ["acme"])
     result = repo.materialize(["process"], partition_key=rs.PartitionKey.single("acme"))
     assert result.success
     assert (

--- a/python/tests/daemon/test_automation.py
+++ b/python/tests/daemon/test_automation.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+import pytest
+
 import rivers as rs
 
 # ---------------------------------------------------------------------------
@@ -60,6 +62,14 @@ class TestLeafConditions:
     def test_in_latest_time_window_with_lookback(self):
         cond = rs.AutomationCondition.in_latest_time_window(lookback_delta=3600.0)
         assert cond.description == "in_latest_time_window(lookback=3600)"
+
+    def test_in_latest_time_window_rejects_non_finite_or_non_positive_lookback(self):
+        """NaN/negative silently empty the window selection (the condition
+        never fires); inf overflows the cutoff arithmetic — reject at
+        construction like interval_seconds."""
+        for bad in (float("nan"), float("inf"), -3600.0, 0.0):
+            with pytest.raises(ValueError, match="lookback_delta must be"):
+                rs.AutomationCondition.in_latest_time_window(lookback_delta=bad)
 
     def test_any_deps_missing(self):
         cond = rs.AutomationCondition.any_deps_missing()

--- a/python/tests/daemon/test_condition_dep_partitions.py
+++ b/python/tests/daemon/test_condition_dep_partitions.py
@@ -1,0 +1,72 @@
+"""Dep-based conditions on partitioned assets with the default Identity mapping.
+
+An unmapped partitioned->partitioned edge defaults to Identity at resolve time.
+The condition engine must honor that per-partition: an upstream materialization
+of one key may only make the matching downstream key eligible — never the whole
+universe.
+"""
+
+import time
+
+import rivers as rs
+from rivers._core import AutomationDaemon
+
+
+def test_implicit_identity_dep_fires_only_matching_partition(storage):
+    """``any_deps_updated`` with no explicit mapping targets the updated key only."""
+    pd = rs.PartitionsDefinition.static_(["a", "b", "c"])
+
+    @rs.Asset(name="up", io_handler=rs.InMemoryIOHandler(), partitions_def=pd)
+    def up() -> str:
+        return "u"
+
+    @rs.Asset(
+        name="down",
+        io_handler=rs.InMemoryIOHandler(),
+        partitions_def=pd,
+        automation_condition=rs.AutomationCondition.any_deps_updated(),
+    )
+    def down(up: str) -> str:
+        return up + "!"
+
+    repo = rs.CodeRepository(
+        assets=[up, down],
+        default_executor=rs.Executor.in_process(),
+    )
+    repo.resolve(storage=storage)
+
+    daemon = AutomationDaemon(
+        repo=repo,
+        storage=storage,
+        condition_eval_interval="500ms",
+    )
+    daemon.start()
+    try:
+        repo.materialize(selection=["up"], partition_key=rs.PartitionKey.single("a"))
+
+        deadline = time.monotonic() + 25
+        while time.monotonic() < deadline:
+            if storage.get_latest_materialization("down", "a") is not None:
+                break
+            time.sleep(0.2)
+        assert storage.get_latest_materialization("down", "a") is not None, (
+            "the condition never fired for the updated upstream key"
+        )
+
+        # The broadcast bug dispatches 'b'/'c' in the same classify pass that
+        # dispatched 'a' (their runs then fail on the missing upstream dep),
+        # so a short settle window over run records is enough to catch it.
+        forbidden = {rs.PartitionKey.single("b"), rs.PartitionKey.single("c")}
+        settle = time.monotonic() + 3
+        while time.monotonic() < settle:
+            stray = [
+                r.partition_key
+                for r in storage.get_runs(limit=100)
+                if r.partition_key in forbidden
+            ]
+            assert not stray, (
+                f"condition dispatched runs for {stray} whose upstream was never materialized"
+            )
+            time.sleep(0.25)
+    finally:
+        daemon.stop()

--- a/python/tests/daemon/test_condition_partition_universe.py
+++ b/python/tests/daemon/test_condition_partition_universe.py
@@ -6,8 +6,6 @@ next tick, and retired keys leave it. A universe frozen at daemon start
 silently kills automation for dynamic-partitioned assets.
 """
 
-import time
-
 import rivers as rs
 from _polling import wait_for_runs as _wait_for_runs
 from rivers._core import AutomationDaemon
@@ -31,6 +29,10 @@ def test_condition_fires_for_dynamic_partition_added_after_start(storage):
     )
     repo.resolve(storage=storage)
 
+    # 'blue' exists before the daemon starts; its materialization proves the
+    # eval loop is ticking before 'red' is registered.
+    storage.add_dynamic_partitions("colors", ["blue"])
+
     daemon = AutomationDaemon(
         repo=repo,
         storage=storage,
@@ -38,11 +40,14 @@ def test_condition_fires_for_dynamic_partition_added_after_start(storage):
     )
     daemon.start()
     try:
-        # A couple of ticks run against the still-empty dynamic universe first.
-        time.sleep(1.5)
+        _wait_for_runs(storage, min_count=1, timeout=25, status="Success")
+        assert storage.get_latest_materialization("colored", "blue") is not None
+
+        # The running daemon has never seen this key — only the per-tick
+        # universe refresh can pick it up.
         storage.add_dynamic_partitions("colors", ["red"])
-        runs = _wait_for_runs(storage, min_count=1, timeout=25, status="Success")
-        assert len(runs) >= 1, "condition never fired for the registered dynamic key"
+        runs = _wait_for_runs(storage, min_count=2, timeout=25, status="Success")
+        assert len(runs) >= 2, "condition never fired for the registered dynamic key"
         ev = storage.get_latest_materialization("colored", "red")
         assert ev is not None, "the dynamic key 'red' was never materialized"
     finally:

--- a/python/tests/daemon/test_condition_partition_universe.py
+++ b/python/tests/daemon/test_condition_partition_universe.py
@@ -1,0 +1,49 @@
+"""Per-tick partition universe refresh for automation conditions.
+
+The condition engine's view of an asset's partitions must track reality:
+dynamic keys registered while the daemon runs enter the universe on the
+next tick, and retired keys leave it. A universe frozen at daemon start
+silently kills automation for dynamic-partitioned assets.
+"""
+
+import time
+
+import rivers as rs
+from _polling import wait_for_runs as _wait_for_runs
+from rivers._core import AutomationDaemon
+
+
+def test_condition_fires_for_dynamic_partition_added_after_start(storage):
+    """``on_missing`` must fire for a dynamic key registered after daemon start."""
+
+    @rs.Asset(
+        name="colored",
+        io_handler=rs.InMemoryIOHandler(),
+        partitions_def=rs.PartitionsDefinition.dynamic("colors"),
+        automation_condition=rs.AutomationCondition.on_missing(),
+    )
+    def colored() -> str:
+        return "data"
+
+    repo = rs.CodeRepository(
+        assets=[colored],
+        default_executor=rs.Executor.in_process(),
+    )
+    repo.resolve(storage=storage)
+
+    daemon = AutomationDaemon(
+        repo=repo,
+        storage=storage,
+        condition_eval_interval="500ms",
+    )
+    daemon.start()
+    try:
+        # A couple of ticks run against the still-empty dynamic universe first.
+        time.sleep(1.5)
+        storage.add_dynamic_partitions("colors", ["red"])
+        runs = _wait_for_runs(storage, min_count=1, timeout=25, status="Success")
+        assert len(runs) >= 1, "condition never fired for the registered dynamic key"
+        ev = storage.get_latest_materialization("colored", "red")
+        assert ev is not None, "the dynamic key 'red' was never materialized"
+    finally:
+        daemon.stop()

--- a/python/tests/daemon/test_daemon.py
+++ b/python/tests/daemon/test_daemon.py
@@ -152,6 +152,39 @@ class TestDaemonSensor:
         finally:
             daemon.stop()
 
+    def test_dispatch_failure_marks_tick_failed(self, storage):
+        """A run request the dispatcher rejects (invalid partition key) must
+        surface on the tick record instead of silently dropping the run."""
+        pd = rs.PartitionsDefinition.static_(["a", "b"])
+
+        @rs.Asset(name="part_a", partitions_def=pd)
+        def part_a() -> int:
+            return 1
+
+        job = rs.Job(name="part_job", assets=[part_a])
+
+        @rs.Sensor(
+            asset_selection=["part_a"],
+            minimum_interval="1s",
+            default_status=rs.SensorStatus.Running,
+        )
+        def bad_key_sensor(context: rs.SensorEvaluationContext):
+            return rs.RunRequest(job_name="part_job", partition_key="nope")
+
+        repo = rs.CodeRepository(assets=[part_a], jobs=[job], sensors=[bad_key_sensor])
+        repo.resolve(storage=storage)
+
+        daemon = AutomationDaemon(repo=repo, storage=storage)
+        daemon.start()
+        try:
+            ticks = _wait_for_ticks(storage, "bad_key_sensor", min_count=1)
+            tick = ticks[0]
+            assert tick.status == "Failed"
+            assert "Invalid partition_key" in (tick.error or "")
+            assert tick.run_ids == []
+        finally:
+            daemon.stop()
+
     def test_sensor_error_stores_failed_tick(self, storage):
         """Sensor that raises an exception stores a Failed tick."""
 

--- a/python/tests/daemon/test_daemon.py
+++ b/python/tests/daemon/test_daemon.py
@@ -185,6 +185,40 @@ class TestDaemonSensor:
         finally:
             daemon.stop()
 
+    def test_backfill_dispatch_failure_marks_tick_failed(self, storage):
+        """A backfill request the dispatcher rejects flows through the same
+        outcome path as run requests — Failed tick, error recorded, no ids."""
+        pd = rs.PartitionsDefinition.static_(["a", "b"])
+
+        @rs.Asset(name="part_b", partitions_def=pd)
+        def part_b() -> int:
+            return 1
+
+        @rs.Sensor(
+            asset_selection=["part_b"],
+            minimum_interval="1s",
+            default_status=rs.SensorStatus.Running,
+        )
+        def bad_backfill_sensor(context: rs.SensorEvaluationContext):
+            return rs.BackfillRequest(
+                selection=["part_b"],
+                partition_keys=[rs.PartitionKey.single("nope")],
+            )
+
+        repo = rs.CodeRepository(assets=[part_b], sensors=[bad_backfill_sensor])
+        repo.resolve(storage=storage)
+
+        daemon = AutomationDaemon(repo=repo, storage=storage)
+        daemon.start()
+        try:
+            ticks = _wait_for_ticks(storage, "bad_backfill_sensor", min_count=1)
+            tick = ticks[0]
+            assert tick.status == "Failed"
+            assert "Invalid partition_key" in (tick.error or "")
+            assert tick.backfill_ids == []
+        finally:
+            daemon.stop()
+
     def test_sensor_error_stores_failed_tick(self, storage):
         """Sensor that raises an exception stores a Failed tick."""
 

--- a/python/tests/grpc_api/test_grpc_server.py
+++ b/python/tests/grpc_api/test_grpc_server.py
@@ -525,6 +525,91 @@ def test_launch_backfill_dry_run(backfill_grpc_channel):
     assert response.num_partitions == 1
 
 
+@pytest.fixture
+def multi_backfill_grpc_channel(grpc_stubs, storage):
+    """gRPC server with a Multi-partitioned asset for strategy validation."""
+    handler = DictIOHandler()
+    pd = rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.static_(["d1", "d2"]),
+            "region": rs.PartitionsDefinition.static_(["eu", "us"]),
+        }
+    )
+
+    @rs.Asset(io_handler=handler, partitions_def=pd)
+    def multi_asset(context: rs.AssetExecutionContext):
+        return context.partition_key
+
+    repo = rs.CodeRepository(
+        assets=[multi_asset],
+        default_executor=rs.Executor.in_process(),
+    )
+    repo.resolve(storage=storage)
+    port = repo._start_grpc_server("127.0.0.1", 0)
+
+    channel = grpc.insecure_channel(f"127.0.0.1:{port}")
+    grpc.channel_ready_future(channel).result(timeout=5)
+
+    pb2, pb2_grpc = grpc_stubs
+    yield channel, pb2, pb2_grpc
+    channel.close()
+    repo._stop_grpc_server()
+
+
+def _multi_partition_key(pb2, date: str, region: str):
+    return pb2.ProtoPartitionKey(
+        multi=pb2.MultiPartitionKey(
+            dimensions=[
+                pb2.MultiPartitionDimension(name="date", keys=[date]),
+                pb2.MultiPartitionDimension(name="region", keys=[region]),
+            ]
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "multi_run, single_run, message",
+    [
+        ([], ["region"], "multi_run must contain at least one dimension"),
+        (["date"], [], "single_run must contain at least one dimension"),
+        (
+            ["date"],
+            ["date"],
+            "dimension 'date' cannot be in both multi_run and single_run",
+        ),
+    ],
+)
+def test_launch_backfill_per_dimension_invariants_enforced(
+    multi_backfill_grpc_channel, multi_run, single_run, message
+):
+    """The proto path must enforce the same PerDimension invariants as the
+    Python constructor — an empty multi_run list otherwise collapses the
+    whole backfill into a single run."""
+    channel, pb2, pb2_grpc = multi_backfill_grpc_channel
+    stub = pb2_grpc.CodeLocationServiceStub(channel)
+
+    with pytest.raises(grpc.RpcError) as exc_info:
+        stub.LaunchBackfill(
+            pb2.LaunchBackfillRequest(
+                selection=["multi_asset"],
+                partition_keys=[
+                    _multi_partition_key(pb2, "d1", "eu"),
+                    _multi_partition_key(pb2, "d2", "us"),
+                ],
+                strategy=pb2.BackfillStrategyProto(
+                    per_dimension=pb2.PerDimensionStrategy(
+                        multi_run_dimensions=multi_run,
+                        single_run_dimensions=single_run,
+                    )
+                ),
+                failure_policy="continue",
+                max_concurrency=1,
+                dry_run=True,
+            )
+        )
+    assert message in exc_info.value.details()
+
+
 def test_get_backfill_status(backfill_grpc_channel):
     channel, pb2, pb2_grpc, _, _ = backfill_grpc_channel
     stub = pb2_grpc.CodeLocationServiceStub(channel)

--- a/python/tests/partitions/test_dst_handling.py
+++ b/python/tests/partitions/test_dst_handling.py
@@ -1,0 +1,89 @@
+"""Time-window keys are a pure wall-clock grid — DST plays no part.
+
+Definitions take tz-naive datetimes and keys are wall-clock labels: the cron
+grid is enumerated on the naive timeline, so DST transitions in the host
+timezone neither drop keys (spring-forward gap) nor duplicate them
+(fall-back hour), and enumeration round-trips through validation on any
+host. (Resolving keys against a real timezone — gaps, ambiguous hours —
+would require an explicit `timezone` parameter on the definition; today the
+grid is timezone-independent by construction.)
+"""
+
+import datetime
+
+import rivers as rs
+
+
+def test_hourly_grid_on_fall_back_day_round_trips():
+    """2024-11-03 (US fall-back): one key per wall-clock hour, no duplicate
+    01:00, and every enumerated key validates."""
+    pd = rs.PartitionsDefinition.hourly(
+        start=datetime.datetime(2024, 11, 3, 0, 0),
+        end=datetime.datetime(2024, 11, 3, 6, 0),
+    )
+    keys = [k.key[0] for k in pd.get_partition_keys()]
+    assert keys == [
+        "2024-11-03T00:00",
+        "2024-11-03T01:00",
+        "2024-11-03T02:00",
+        "2024-11-03T03:00",
+        "2024-11-03T04:00",
+        "2024-11-03T05:00",
+    ]
+    for k in pd.get_partition_keys():
+        assert pd.validate_partition_key(k) is True, k
+
+
+def test_hourly_grid_on_spring_forward_day_round_trips():
+    """2024-03-10 (US spring-forward): the wall-clock grid still carries
+    every hour — 02:00 is a label, not an instant — and round-trips."""
+    pd = rs.PartitionsDefinition.hourly(
+        start=datetime.datetime(2024, 3, 10, 0, 0),
+        end=datetime.datetime(2024, 3, 10, 6, 0),
+    )
+    keys = [k.key[0] for k in pd.get_partition_keys()]
+    assert keys == [
+        "2024-03-10T00:00",
+        "2024-03-10T01:00",
+        "2024-03-10T02:00",
+        "2024-03-10T03:00",
+        "2024-03-10T04:00",
+        "2024-03-10T05:00",
+    ]
+    for k in pd.get_partition_keys():
+        assert pd.validate_partition_key(k) is True, k
+    # Off-grid wall times stay invalid.
+    assert (
+        pd.validate_partition_key(rs.PartitionKey.single("2024-03-10T02:30")) is False
+    )
+
+
+def test_hourly_key_time_window_preserves_hour():
+    """The hourly fmt carries no minutes — parsing must not collapse the key
+    to midnight."""
+    pd = rs.PartitionsDefinition.hourly(
+        start=datetime.datetime(2024, 11, 3, 0, 0),
+        end=datetime.datetime(2024, 11, 3, 6, 0),
+    )
+    ctx = rs.PartitionContext(
+        keys=[rs.PartitionKey.single("2024-11-03T01:00")], definition=pd
+    )
+    window = ctx.time_window()
+    assert window is not None
+    start, end = window
+    assert start == datetime.datetime(2024, 11, 3, 1, 0)
+    assert end == datetime.datetime(2024, 11, 3, 2, 0)
+
+
+def test_daily_grid_across_midnight_transition_zone_dates():
+    """Daily keys around 2024-09-08 (midnight DST transition in
+    America/Santiago) enumerate the full date grid and validate — wall-clock
+    labels are host-timezone-independent."""
+    pd = rs.PartitionsDefinition.daily(
+        start=datetime.datetime(2024, 9, 7),
+        end=datetime.datetime(2024, 9, 11),
+    )
+    keys = [k.key[0] for k in pd.get_partition_keys()]
+    assert keys == ["2024-09-07", "2024-09-08", "2024-09-09", "2024-09-10"]
+    for k in pd.get_partition_keys():
+        assert pd.validate_partition_key(k) is True, k

--- a/python/tests/partitions/test_dynamic_partitions.py
+++ b/python/tests/partitions/test_dynamic_partitions.py
@@ -358,9 +358,7 @@ def test_dynamic_materialize_unregistered_key_raises(storage):
             'it with add_dynamic_partitions("tenants", [...]) first.'
         ),
     ):
-        repo.materialize(
-            ["tenant_data"], partition_key=rs.PartitionKey.single("acmme")
-        )
+        repo.materialize(["tenant_data"], partition_key=rs.PartitionKey.single("acmme"))
 
     # No run/materialization recorded for the rejected key.
     assert storage.get_materialized_partitions("tenant_data") == []

--- a/python/tests/partitions/test_dynamic_partitions.py
+++ b/python/tests/partitions/test_dynamic_partitions.py
@@ -66,6 +66,19 @@ def test_storage_idempotent_add(storage):
     assert keys == ["u1", "u2", "u3"]
 
 
+def test_storage_add_rejects_reserved_and_empty_keys(storage):
+    """Dynamic keys feed the canonical display form — '|' and ',' would make
+    stored events unreachable through partition-string lookups."""
+    from rivers.exceptions import StorageError
+
+    for key in ("us|eu", "a,b"):
+        with pytest.raises(StorageError, match="reserved character"):
+            storage.add_dynamic_partitions("users", [key])
+    with pytest.raises(StorageError, match="must not be empty"):
+        storage.add_dynamic_partitions("users", [""])
+    assert storage.get_dynamic_partitions("users") == []
+
+
 def test_storage_delete(storage):
     storage.add_dynamic_partitions("users", ["u1", "u2", "u3"])
     storage.delete_dynamic_partition("users", "u2")

--- a/python/tests/partitions/test_dynamic_partitions.py
+++ b/python/tests/partitions/test_dynamic_partitions.py
@@ -1,5 +1,6 @@
 """Tests for dynamic partitions — storage-backed partition management."""
 
+import re
 from typing import Any
 
 import pytest
@@ -228,7 +229,7 @@ def test_dynamic_partitions_via_repo_storage():
 # ---------------------------------------------------------------------------
 
 
-def test_dynamic_materialize_partition_context():
+def test_dynamic_materialize_partition_context(storage):
     """Materializing a dynamic-partitioned asset provides correct PartitionContext."""
     dyn = rs.PartitionsDefinition.dynamic("tenants")
     captured = {}
@@ -243,7 +244,8 @@ def test_dynamic_materialize_partition_context():
         return f"data-for-{context.partition_key}"
 
     repo = rs.CodeRepository(assets=[tenant_data])
-    repo.resolve()
+    repo.resolve(storage=storage)
+    storage.add_dynamic_partitions("tenants", ["acme"])
     result = repo.materialize(
         ["tenant_data"], partition_key=rs.PartitionKey.single("acme")
     )
@@ -262,7 +264,7 @@ def test_dynamic_materialize_partition_context():
     assert captured["partition_time_window"] is None
 
 
-def test_dynamic_materialize_chain():
+def test_dynamic_materialize_chain(storage):
     """Two dynamic-partitioned assets in a chain receive the same partition key."""
     dyn = rs.PartitionsDefinition.dynamic("regions")
     seen_keys = {}
@@ -278,7 +280,8 @@ def test_dynamic_materialize_chain():
         return f"processed({raw})"
 
     repo = rs.CodeRepository(assets=[raw, processed])
-    repo.resolve()
+    repo.resolve(storage=storage)
+    storage.add_dynamic_partitions("regions", ["us-west"])
     result = repo.materialize(
         ["raw", "processed"], partition_key=rs.PartitionKey.single("us-west")
     )
@@ -291,7 +294,7 @@ def test_dynamic_materialize_chain():
     assert repo.load_node("processed", partition_key=pk) == "processed(raw-us-west)"
 
 
-def test_dynamic_materialize_io_handler_receives_partition():
+def test_dynamic_materialize_io_handler_receives_partition(storage):
     """IO handler's OutputContext has the correct partition for dynamic assets."""
     dyn = rs.PartitionsDefinition.dynamic("datasets")
     captured_contexts = []
@@ -308,7 +311,8 @@ def test_dynamic_materialize_io_handler_receives_partition():
         return 42
 
     repo = rs.CodeRepository(assets=[my_dataset])
-    repo.resolve()
+    repo.resolve(storage=storage)
+    storage.add_dynamic_partitions("datasets", ["2024-q1"])
     repo.materialize(["my_dataset"], partition_key=rs.PartitionKey.single("2024-q1"))
 
     assert len(captured_contexts) == 1
@@ -331,3 +335,63 @@ def test_dynamic_materialize_without_partition_key_raises():
 
     with pytest.raises(ExecutionError, match="partition_key"):
         repo.materialize(["tenant_data"])
+
+
+def test_dynamic_materialize_unregistered_key_raises(storage):
+    """A dynamic key that was never registered in storage is rejected at submit
+    — the def can't know its keys, so membership is checked against storage."""
+    dyn = rs.PartitionsDefinition.dynamic("tenants")
+
+    @rs.Asset(partitions_def=dyn)
+    def tenant_data() -> int:
+        return 1
+
+    repo = rs.CodeRepository(assets=[tenant_data])
+    repo.resolve(storage=storage)
+    storage.add_dynamic_partitions("tenants", ["acme"])
+
+    with pytest.raises(
+        ExecutionError,
+        match=re.escape(
+            "Invalid partition_key 'acmme' for asset 'tenant_data': not a "
+            "registered dynamic partition key of namespace 'tenants'. Register "
+            'it with add_dynamic_partitions("tenants", [...]) first.'
+        ),
+    ):
+        repo.materialize(
+            ["tenant_data"], partition_key=rs.PartitionKey.single("acmme")
+        )
+
+    # No run/materialization recorded for the rejected key.
+    assert storage.get_materialized_partitions("tenant_data") == []
+
+
+def test_dynamic_materialize_deleted_key_raises(storage):
+    """A dynamic key that was registered and later deleted is rejected."""
+    dyn = rs.PartitionsDefinition.dynamic("tenants")
+
+    @rs.Asset(partitions_def=dyn)
+    def tenant_data() -> int:
+        return 1
+
+    repo = rs.CodeRepository(assets=[tenant_data])
+    repo.resolve(storage=storage)
+    storage.add_dynamic_partitions("tenants", ["acme", "globex"])
+    storage.delete_dynamic_partition("tenants", "globex")
+
+    result = repo.materialize(
+        ["tenant_data"], partition_key=rs.PartitionKey.single("acme")
+    )
+    assert result.success
+
+    with pytest.raises(
+        ExecutionError,
+        match=re.escape(
+            "Invalid partition_key 'globex' for asset 'tenant_data': not a "
+            "registered dynamic partition key of namespace 'tenants'. Register "
+            'it with add_dynamic_partitions("tenants", [...]) first.'
+        ),
+    ):
+        repo.materialize(
+            ["tenant_data"], partition_key=rs.PartitionKey.single("globex")
+        )

--- a/python/tests/partitions/test_partition_context.py
+++ b/python/tests/partitions/test_partition_context.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 import rivers as rs
 
 
@@ -68,3 +70,11 @@ def test_keys_and_key():
     )
     assert len(ctx.keys) == 2
     assert ctx.key == rs.PartitionKey.single("a")
+
+
+def test_empty_keys_rejected():
+    """PartitionContext(keys=[]) raises ValueError instead of arming an
+    index-out-of-bounds panic on `.key`."""
+    pd = rs.PartitionsDefinition.static_(["a"])
+    with pytest.raises(ValueError, match="must not be empty"):
+        rs.PartitionContext(keys=[], definition=pd)

--- a/python/tests/partitions/test_partition_key.py
+++ b/python/tests/partitions/test_partition_key.py
@@ -154,6 +154,13 @@ def test_multi_range_key_lists_hash_order_independent():
     assert hash(r1) == hash(r2)
 
 
+def test_multi_range_repr_deterministic():
+    """repr sorts dimensions and key lists — HashMap iteration order must
+    not leak into the string."""
+    r = rs.PartitionKeyRange.multi({"b": ("1", "2"), "a": ["y", "x"]})
+    assert repr(r) == 'PartitionKeyRange.multi({"a": ["x", "y"], "b": ("1", "2")})'
+
+
 def test_single_range_usable_as_dict_key():
     r1 = rs.PartitionKeyRange.single(from_key="2024-01-01", to_key="2024-01-31")
     r2 = rs.PartitionKeyRange.single(from_key="2024-01-01", to_key="2024-01-31")

--- a/python/tests/partitions/test_partition_key.py
+++ b/python/tests/partitions/test_partition_key.py
@@ -130,3 +130,31 @@ def test_from_json_invalid():
 def test_from_json_missing_key():
     with pytest.raises(PartitionDefinitionError):
         rs.PartitionKey.from_json('{"unknown": [1]}')
+
+
+# ---------------------------------------------------------------------------
+# PartitionKeyRange hash/eq contract — equal ranges must hash equal
+# regardless of construction order; hashing the Debug string of a
+# HashMap-backed range breaks that (seed-dependent iteration order).
+# ---------------------------------------------------------------------------
+
+
+def test_multi_range_equal_ranges_hash_equal():
+    dims = {f"d{i}": (f"a{i}", f"b{i}") for i in range(8)}
+    r1 = rs.PartitionKeyRange.multi(dims)
+    r2 = rs.PartitionKeyRange.multi(dict(reversed(list(dims.items()))))
+    assert r1 == r2
+    assert hash(r1) == hash(r2)
+
+
+def test_multi_range_key_lists_hash_order_independent():
+    r1 = rs.PartitionKeyRange.multi({"d": ["x", "y", "z", "w", "v", "u", "t", "s"]})
+    r2 = rs.PartitionKeyRange.multi({"d": ["s", "t", "u", "v", "w", "x", "y", "z"]})
+    assert r1 == r2
+    assert hash(r1) == hash(r2)
+
+
+def test_single_range_usable_as_dict_key():
+    r1 = rs.PartitionKeyRange.single(from_key="2024-01-01", to_key="2024-01-31")
+    r2 = rs.PartitionKeyRange.single(from_key="2024-01-01", to_key="2024-01-31")
+    assert {r1: "jan"}[r2] == "jan"

--- a/python/tests/partitions/test_partition_mapping_materialize.py
+++ b/python/tests/partitions/test_partition_mapping_materialize.py
@@ -687,10 +687,16 @@ def test_time_window_offset_off_grid_result_rejected():
     handler = TrackingHandler()
     fmt = "%Y-%m-%dT%H:%M:%S"
     six_hourly = rs.PartitionsDefinition.time_window(
-        start=datetime(2024, 1, 1), interval_seconds=21600, end=datetime(2024, 1, 3), fmt=fmt
+        start=datetime(2024, 1, 1),
+        interval_seconds=21600,
+        end=datetime(2024, 1, 3),
+        fmt=fmt,
     )
     hourly = rs.PartitionsDefinition.time_window(
-        start=datetime(2024, 1, 1), interval_seconds=3600, end=datetime(2024, 1, 3), fmt=fmt
+        start=datetime(2024, 1, 1),
+        interval_seconds=3600,
+        end=datetime(2024, 1, 3),
+        fmt=fmt,
     )
 
     @rs.Asset(partitions_def=six_hourly, io_handler=handler)

--- a/python/tests/partitions/test_partition_mapping_materialize.py
+++ b/python/tests/partitions/test_partition_mapping_materialize.py
@@ -599,3 +599,113 @@ def test_mixed_mapping_types_in_single_asset():
     assert rs.PartitionKey.single("a") in keys_loaded
     # Static: "a" → "x"
     assert rs.PartitionKey.single("x") in keys_loaded
+
+
+# ---------------------------------------------------------------------------
+# TimeWindow offset mapping — the offset parameter must shift which upstream
+# window is loaded, not silently behave as identity.
+# ---------------------------------------------------------------------------
+
+
+def _daily_jan() -> rs.PartitionsDefinition:
+    return rs.PartitionsDefinition.daily(
+        start=datetime(2024, 1, 1), end=datetime(2024, 1, 10)
+    )
+
+
+def test_time_window_offset_loads_previous_window():
+    handler = TrackingHandler()
+
+    @rs.Asset(partitions_def=_daily_jan(), io_handler=handler)
+    def upstream(context: rs.AssetExecutionContext) -> str:
+        return f"up-{context.partition_key}"
+
+    @rs.Asset(
+        partitions_def=_daily_jan(),
+        io_handler=handler,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.time_window(offset=-1),
+            )
+        ],
+    )
+    def downstream(upstream: str) -> str:
+        return f"down({upstream})"
+
+    repo = make_repo([upstream, downstream])
+    repo.materialize(["upstream"], partition_key=rs.PartitionKey.single("2024-01-04"))
+
+    handler.load_input_partitions.clear()
+    result = repo.materialize(
+        ["downstream"], partition_key=rs.PartitionKey.single("2024-01-05")
+    )
+    assert result.success
+    # The dep load was routed to the previous window's partition.
+    assert [p.key for p in handler.load_input_partitions] == [
+        rs.PartitionKey.single("2024-01-04")
+    ]
+
+
+def test_time_window_offset_zero_is_identity():
+    handler = TrackingHandler()
+
+    @rs.Asset(partitions_def=_daily_jan(), io_handler=handler)
+    def upstream(context: rs.AssetExecutionContext) -> str:
+        return f"up-{context.partition_key}"
+
+    @rs.Asset(
+        partitions_def=_daily_jan(),
+        io_handler=handler,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.time_window(offset=0),
+            )
+        ],
+    )
+    def downstream(upstream: str) -> str:
+        return f"down({upstream})"
+
+    repo = make_repo([upstream, downstream])
+    repo.materialize(["upstream"], partition_key=rs.PartitionKey.single("2024-01-05"))
+
+    handler.load_input_partitions.clear()
+    result = repo.materialize(
+        ["downstream"], partition_key=rs.PartitionKey.single("2024-01-05")
+    )
+    assert result.success
+    assert [p.key for p in handler.load_input_partitions] == [
+        rs.PartitionKey.single("2024-01-05")
+    ]
+
+
+def test_time_window_offset_before_start_errors():
+    """offset=-1 from the first partition maps before the upstream's start —
+    a precise error, not a silent identity load."""
+    handler = TrackingHandler()
+
+    @rs.Asset(partitions_def=_daily_jan(), io_handler=handler)
+    def upstream(context: rs.AssetExecutionContext) -> str:
+        return f"up-{context.partition_key}"
+
+    @rs.Asset(
+        partitions_def=_daily_jan(),
+        io_handler=handler,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.time_window(offset=-1),
+            )
+        ],
+    )
+    def downstream(upstream: str) -> str:
+        return f"down({upstream})"
+
+    repo = make_repo([upstream, downstream])
+    result = repo.materialize(
+        ["downstream"],
+        partition_key=rs.PartitionKey.single("2024-01-01"),
+        raise_on_error=False,
+    )
+    assert not result.success

--- a/python/tests/partitions/test_partition_mapping_materialize.py
+++ b/python/tests/partitions/test_partition_mapping_materialize.py
@@ -1,10 +1,12 @@
 """Tests for partition mapping key transformation during materialization."""
 
+import re
 from datetime import datetime
 
 import pytest
 
 import rivers as rs
+from rivers.exceptions import PartitionValidationError
 
 from _helpers import TrackingHandler, make_repo
 
@@ -680,11 +682,10 @@ def test_time_window_offset_zero_is_identity():
     ]
 
 
-def test_time_window_offset_off_grid_result_rejected():
-    """A shifted key that parses under the upstream fmt but isn't on the
-    upstream grid (cross-cadence mapping) must error precisely instead of
-    silently loading a partition that doesn't exist."""
-    handler = TrackingHandler()
+def test_time_window_finer_downstream_rejected_at_resolve():
+    """An hourly downstream over a six-hourly upstream: most downstream keys
+    shift off the upstream grid, so the edge is a misconfiguration — rejected
+    at resolve time instead of failing per-partition at runtime."""
     fmt = "%Y-%m-%dT%H:%M:%S"
     six_hourly = rs.PartitionsDefinition.time_window(
         start=datetime(2024, 1, 1),
@@ -699,12 +700,59 @@ def test_time_window_offset_off_grid_result_rejected():
         fmt=fmt,
     )
 
-    @rs.Asset(partitions_def=six_hourly, io_handler=handler)
+    @rs.Asset(partitions_def=six_hourly)
     def upstream(context: rs.AssetExecutionContext) -> int:
         return 1
 
     @rs.Asset(
         partitions_def=hourly,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.time_window(offset=-1),
+            )
+        ],
+    )
+    def downstream(upstream: int) -> int:
+        return upstream
+
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': time_window mapping "
+            "requires the downstream grid to be a subgrid of the upstream "
+            "grid: downstream interval 3600s is not a multiple of upstream "
+            "interval 21600s"
+        ),
+    ):
+        make_repo([upstream, downstream])
+
+
+def test_time_window_offset_coarser_downstream_loads_shifted():
+    """A six-hourly downstream over an hourly upstream is a true subgrid —
+    every downstream key is an upstream tick, and the offset shifts on the
+    upstream (hourly) grid."""
+    handler = TrackingHandler()
+    fmt = "%Y-%m-%dT%H:%M:%S"
+    hourly = rs.PartitionsDefinition.time_window(
+        start=datetime(2024, 1, 1),
+        interval_seconds=3600,
+        end=datetime(2024, 1, 3),
+        fmt=fmt,
+    )
+    six_hourly = rs.PartitionsDefinition.time_window(
+        start=datetime(2024, 1, 1),
+        interval_seconds=21600,
+        end=datetime(2024, 1, 3),
+        fmt=fmt,
+    )
+
+    @rs.Asset(partitions_def=hourly, io_handler=handler)
+    def upstream(context: rs.AssetExecutionContext) -> int:
+        return 1
+
+    @rs.Asset(
+        partitions_def=six_hourly,
         io_handler=handler,
         deps=[
             rs.AssetDef.input(
@@ -717,19 +765,8 @@ def test_time_window_offset_off_grid_result_rejected():
         return upstream
 
     repo = make_repo([upstream, downstream])
-    # 07:00 - 1h = 06:00? No: the offset shifts on the UPSTREAM grid only for
-    # cron; for intervals it shifts by the upstream interval: 07:00 - 6h =
-    # 01:00, which is not a 6-hourly window start.
-    result = repo.materialize(
-        ["downstream"],
-        partition_key=rs.PartitionKey.single("2024-01-01T07:00:00"),
-        raise_on_error=False,
-    )
-    assert not result.success
-
-    # An aligned downstream key shifts to a real upstream window and loads.
     repo.materialize(
-        ["upstream"], partition_key=rs.PartitionKey.single("2024-01-01T06:00:00")
+        ["upstream"], partition_key=rs.PartitionKey.single("2024-01-01T11:00:00")
     )
     handler.load_input_partitions.clear()
     result = repo.materialize(
@@ -738,7 +775,7 @@ def test_time_window_offset_off_grid_result_rejected():
     )
     assert result.success
     assert [p.key for p in handler.load_input_partitions] == [
-        rs.PartitionKey.single("2024-01-01T06:00:00")
+        rs.PartitionKey.single("2024-01-01T11:00:00")
     ]
 
 

--- a/python/tests/partitions/test_partition_mapping_materialize.py
+++ b/python/tests/partitions/test_partition_mapping_materialize.py
@@ -680,6 +680,62 @@ def test_time_window_offset_zero_is_identity():
     ]
 
 
+def test_time_window_offset_off_grid_result_rejected():
+    """A shifted key that parses under the upstream fmt but isn't on the
+    upstream grid (cross-cadence mapping) must error precisely instead of
+    silently loading a partition that doesn't exist."""
+    handler = TrackingHandler()
+    fmt = "%Y-%m-%dT%H:%M:%S"
+    six_hourly = rs.PartitionsDefinition.time_window(
+        start=datetime(2024, 1, 1), interval_seconds=21600, end=datetime(2024, 1, 3), fmt=fmt
+    )
+    hourly = rs.PartitionsDefinition.time_window(
+        start=datetime(2024, 1, 1), interval_seconds=3600, end=datetime(2024, 1, 3), fmt=fmt
+    )
+
+    @rs.Asset(partitions_def=six_hourly, io_handler=handler)
+    def upstream(context: rs.AssetExecutionContext) -> int:
+        return 1
+
+    @rs.Asset(
+        partitions_def=hourly,
+        io_handler=handler,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.time_window(offset=-1),
+            )
+        ],
+    )
+    def downstream(upstream: int) -> int:
+        return upstream
+
+    repo = make_repo([upstream, downstream])
+    # 07:00 - 1h = 06:00? No: the offset shifts on the UPSTREAM grid only for
+    # cron; for intervals it shifts by the upstream interval: 07:00 - 6h =
+    # 01:00, which is not a 6-hourly window start.
+    result = repo.materialize(
+        ["downstream"],
+        partition_key=rs.PartitionKey.single("2024-01-01T07:00:00"),
+        raise_on_error=False,
+    )
+    assert not result.success
+
+    # An aligned downstream key shifts to a real upstream window and loads.
+    repo.materialize(
+        ["upstream"], partition_key=rs.PartitionKey.single("2024-01-01T06:00:00")
+    )
+    handler.load_input_partitions.clear()
+    result = repo.materialize(
+        ["downstream"],
+        partition_key=rs.PartitionKey.single("2024-01-01T12:00:00"),
+    )
+    assert result.success
+    assert [p.key for p in handler.load_input_partitions] == [
+        rs.PartitionKey.single("2024-01-01T06:00:00")
+    ]
+
+
 def test_time_window_offset_before_start_errors():
     """offset=-1 from the first partition maps before the upstream's start —
     a precise error, not a silent identity load."""

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -2762,6 +2762,45 @@ def test_forkeys_multi_keys_selector_unknown_key_rejected():
         make_repo([upstream, downstream])
 
 
+def test_forkeys_single_range_on_multi_def_rejected():
+    """A single-dim range can never match a Multi key (contains() returns
+    False for the shape) — the edge must be rejected at resolve, not left to
+    silently skip every dep load."""
+    parts = _multi_parts()
+
+    @rs.Asset
+    def upstream() -> Any:
+        return 1
+
+    @rs.Asset(
+        partitions_def=parts,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.for_keys(
+                    [
+                        rs.PartitionKeyRange.single(
+                            from_key="2024-01-01", to_key="2024-01-02"
+                        )
+                    ]
+                ),
+            )
+        ],
+    )
+    def downstream(upstream: Any) -> Any:
+        return upstream
+
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': a single-dimension "
+            "range cannot select from Multi partitions; use "
+            "PartitionKeyRange.multi() with dimensions: date, region"
+        ),
+    ):
+        make_repo([upstream, downstream])
+
+
 def test_forkeys_multi_valid_selectors_accepted():
     """Valid multi selectors (Range + Keys) pass the new validation."""
     parts = _multi_parts()

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -288,9 +288,7 @@ def test_time_window_mapping_differing_cron_rejected():
     down = rs.PartitionsDefinition.time_window(
         start=DAILY_START, cron_schedule="0 6 * * *", fmt=fmt
     )
-    with pytest.raises(
-        PartitionValidationError, match="is not on the upstream grid"
-    ):
+    with pytest.raises(PartitionValidationError, match="is not on the upstream grid"):
         make_repo(_tw_edge(down, up))
 
 

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -263,7 +263,8 @@ def test_time_window_mapping_misaligned_mixed_grid_kinds_rejected():
         start=datetime(2024, 1, 1, 0, 30), interval_seconds=86400, fmt=fmt
     )
     with pytest.raises(
-        PartitionValidationError, match="is not on the upstream grid"
+        PartitionValidationError,
+        match=re.escape("is not on the upstream grid (cron '0 0 * * *')"),
     ):
         make_repo(_tw_edge(down, up))
 

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -1,5 +1,6 @@
 """Tests for partition mapping validation during graph resolution."""
 
+import re
 from datetime import datetime
 from typing import Any
 
@@ -2336,8 +2337,9 @@ def test_forkeys_invalid_key_rejected():
         make_repo([upstream, downstream])
 
 
-def test_forkeys_range_not_validated_against_def():
-    """ForKeys with a range selector is accepted without validating range bounds."""
+def test_forkeys_range_unknown_endpoints_rejected():
+    """Range selector endpoints must be partition keys of the downstream def
+    — an unknown endpoint would otherwise silently match nothing."""
     parts = rs.PartitionsDefinition.static_(STATIC_KEYS)
 
     @rs.Asset
@@ -2358,8 +2360,47 @@ def test_forkeys_range_not_validated_against_def():
     def downstream(upstream: Any) -> Any:
         return upstream
 
-    # Range selectors are not validated — this should succeed
-    make_repo([upstream, downstream])
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': "
+            "Range endpoint 'x' is not a partition key"
+        ),
+    ):
+        make_repo([upstream, downstream])
+
+
+def test_forkeys_range_inverted_rejected():
+    """An inverted range would silently Skip every downstream key — surface
+    the swapped endpoints at resolve time instead."""
+    parts = rs.PartitionsDefinition.static_(STATIC_KEYS)
+
+    @rs.Asset
+    def upstream() -> Any:
+        return 1
+
+    @rs.Asset(
+        partitions_def=parts,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.for_keys(
+                    [rs.PartitionKeyRange.single(from_key="c", to_key="a")]
+                ),
+            )
+        ],
+    )
+    def downstream(upstream: Any) -> Any:
+        return upstream
+
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': "
+            "from_key 'c' is after to_key 'a'"
+        ),
+    ):
+        make_repo([upstream, downstream])
 
 
 def test_forkeys_multiple_valid_keys():

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -179,6 +179,117 @@ def test_time_window_mapping_upstream_not_time_window():
         make_repo([upstream, downstream])
 
 
+def _tw_edge(down_def, up_def):
+    """Upstream→downstream pair joined by time_window(offset=-1)."""
+
+    @rs.Asset(partitions_def=up_def)
+    def upstream() -> Any:
+        return 1
+
+    @rs.Asset(
+        partitions_def=down_def,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.time_window(offset=-1),
+            )
+        ],
+    )
+    def downstream(upstream: Any) -> Any:
+        return upstream
+
+    return [upstream, downstream]
+
+
+def test_time_window_mapping_fmt_mismatch_rejected():
+    """Differing key formats: downstream keys can't reliably parse under the
+    upstream fmt — the eval path would silently drop them."""
+    down = rs.PartitionsDefinition.daily(start=DAILY_START)
+    up = rs.PartitionsDefinition.daily(start=DAILY_START, fmt="%d/%m/%Y")
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': time_window mapping "
+            "requires matching key formats: downstream fmt '%Y-%m-%d' != "
+            "upstream fmt '%d/%m/%Y'"
+        ),
+    ):
+        make_repo(_tw_edge(down, up))
+
+
+def test_time_window_mapping_phase_mismatch_rejected():
+    """Same interval but offset starts: every downstream key is off the
+    upstream grid even though the cadences match."""
+    fmt = "%Y-%m-%dT%H:%M:%S"
+    up = rs.PartitionsDefinition.time_window(
+        start=datetime(2024, 1, 1), interval_seconds=3600, fmt=fmt
+    )
+    down = rs.PartitionsDefinition.time_window(
+        start=datetime(2024, 1, 1, 0, 30), interval_seconds=3600, fmt=fmt
+    )
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': time_window mapping "
+            "requires the downstream grid to be a subgrid of the upstream "
+            "grid: downstream start 2024-01-01 00:30:00 is not aligned to "
+            "the upstream grid (start 2024-01-01 00:00:00, interval 3600s)"
+        ),
+    ):
+        make_repo(_tw_edge(down, up))
+
+
+def test_time_window_mapping_mixed_grid_kinds_rejected():
+    """One cron grid, one interval grid: subgrid alignment can't be proven."""
+    fmt = "%Y-%m-%d"
+    up = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, cron_schedule="0 0 * * *", fmt=fmt
+    )
+    down = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, interval_seconds=86400, fmt=fmt
+    )
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': time_window mapping "
+            "requires both definitions on the same grid kind "
+            "(both cron or both interval)"
+        ),
+    ):
+        make_repo(_tw_edge(down, up))
+
+
+def test_time_window_mapping_differing_cron_rejected():
+    fmt = "%Y-%m-%dT%H:00"
+    up = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, cron_schedule="0 0 * * *", fmt=fmt
+    )
+    down = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, cron_schedule="0 6 * * *", fmt=fmt
+    )
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': time_window mapping "
+            "requires identical cron schedules: downstream '0 6 * * *' != "
+            "upstream '0 0 * * *'"
+        ),
+    ):
+        make_repo(_tw_edge(down, up))
+
+
+def test_time_window_mapping_differing_ranges_allowed():
+    """Same grid with different start/end ranges is fine — range edges are a
+    per-key concern, not an edge-validity one."""
+    up = rs.PartitionsDefinition.daily(
+        start=datetime(2024, 1, 1), end=datetime(2024, 12, 31)
+    )
+    down = rs.PartitionsDefinition.daily(
+        start=datetime(2024, 2, 1), end=datetime(2024, 6, 30)
+    )
+    assert make_repo(_tw_edge(down, up)) is not None
+
+
 # ---------------------------------------------------------------------------
 # Both partitioned — Static mapping
 # ---------------------------------------------------------------------------

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -2396,8 +2396,7 @@ def test_forkeys_range_inverted_rejected():
     with pytest.raises(
         PartitionValidationError,
         match=re.escape(
-            "Asset 'downstream' depends on 'upstream': "
-            "from_key 'c' is after to_key 'a'"
+            "Asset 'downstream' depends on 'upstream': from_key 'c' is after to_key 'a'"
         ),
     ):
         make_repo([upstream, downstream])

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -2402,6 +2402,115 @@ def test_forkeys_range_inverted_rejected():
         make_repo([upstream, downstream])
 
 
+def _multi_parts():
+    return rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.static_(["2024-01-01", "2024-01-02"]),
+            "region": rs.PartitionsDefinition.static_(["us", "eu"]),
+        }
+    )
+
+
+def test_forkeys_multi_unknown_dimension_rejected():
+    """A multi-range selector naming a dimension the downstream doesn't have
+    can never match a key — every downstream partition would silently Skip
+    its dep. Surface the typo at resolve time."""
+    parts = _multi_parts()
+
+    @rs.Asset
+    def upstream() -> Any:
+        return 1
+
+    @rs.Asset(
+        partitions_def=parts,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.for_keys(
+                    [rs.PartitionKeyRange.multi({"regon": ["us"]})]
+                ),
+            )
+        ],
+    )
+    def downstream(upstream: Any) -> Any:
+        return upstream
+
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': "
+            "Unknown dimension 'regon' in partition range; "
+            "available dimensions: 'date', 'region'"
+        ),
+    ):
+        make_repo([upstream, downstream])
+
+
+def test_forkeys_multi_keys_selector_unknown_key_rejected():
+    """Keys sub-selectors must be validated like Range endpoints — a bogus
+    key silently matches nothing."""
+    parts = _multi_parts()
+
+    @rs.Asset
+    def upstream() -> Any:
+        return 1
+
+    @rs.Asset(
+        partitions_def=parts,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.for_keys(
+                    [rs.PartitionKeyRange.multi({"region": ["mars"]})]
+                ),
+            )
+        ],
+    )
+    def downstream(upstream: Any) -> Any:
+        return upstream
+
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': "
+            "'mars' is not a partition key of dimension 'region'"
+        ),
+    ):
+        make_repo([upstream, downstream])
+
+
+def test_forkeys_multi_valid_selectors_accepted():
+    """Valid multi selectors (Range + Keys) pass the new validation."""
+    parts = _multi_parts()
+
+    @rs.Asset
+    def upstream() -> Any:
+        return 1
+
+    @rs.Asset(
+        partitions_def=parts,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.for_keys(
+                    [
+                        rs.PartitionKeyRange.multi(
+                            {
+                                "date": ("2024-01-01", "2024-01-02"),
+                                "region": ["us"],
+                            }
+                        )
+                    ]
+                ),
+            )
+        ],
+    )
+    def downstream(upstream: Any) -> Any:
+        return upstream
+
+    make_repo([upstream, downstream])
+
+
 def test_forkeys_multiple_valid_keys():
     """ForKeys with multiple valid keys is accepted."""
     parts = rs.PartitionsDefinition.static_(STATIC_KEYS)

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -2115,6 +2115,89 @@ def test_multi_to_single_downstream_multi_upstream_single():
     make_repo([upstream, downstream])
 
 
+def test_multi_to_single_downstream_multi_inner_orientation():
+    """Downstream-Multi: the inner mapping's downstream is the named DIM and
+    its upstream is the single def — a coarser dim over a finer upstream is
+    a valid subgrid and must validate."""
+    fmt = "%Y-%m-%dT%H:00"
+    multi_parts = rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.time_window(
+                start=DAILY_START, interval_seconds=21600, fmt=fmt
+            ),
+            "region": rs.PartitionsDefinition.static_(STATIC_KEYS),
+        }
+    )
+    hourly = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, interval_seconds=3600, fmt=fmt
+    )
+
+    @rs.Asset(partitions_def=hourly)
+    def upstream() -> Any:
+        return 1
+
+    @rs.Asset(
+        partitions_def=multi_parts,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.multi_to_single(
+                    dimension_name="date",
+                    partition_mapping=rs.PartitionMapping.time_window(offset=-1),
+                ),
+            )
+        ],
+    )
+    def downstream(upstream: Any) -> Any:
+        return upstream + 1
+
+    assert make_repo([upstream, downstream]) is not None
+
+
+def test_multi_to_single_downstream_multi_finer_dim_rejected():
+    """Downstream-Multi with a FINER time dim than the single upstream: the
+    inner subgrid check must reject it in the true orientation."""
+    fmt = "%Y-%m-%dT%H:00"
+    multi_parts = rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.time_window(
+                start=DAILY_START, interval_seconds=3600, fmt=fmt
+            ),
+            "region": rs.PartitionsDefinition.static_(STATIC_KEYS),
+        }
+    )
+    six_hourly = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, interval_seconds=21600, fmt=fmt
+    )
+
+    @rs.Asset(partitions_def=six_hourly)
+    def upstream() -> Any:
+        return 1
+
+    @rs.Asset(
+        partitions_def=multi_parts,
+        deps=[
+            rs.AssetDef.input(
+                "upstream",
+                partition_mapping=rs.PartitionMapping.multi_to_single(
+                    dimension_name="date",
+                    partition_mapping=rs.PartitionMapping.time_window(offset=-1),
+                ),
+            )
+        ],
+    )
+    def downstream(upstream: Any) -> Any:
+        return upstream + 1
+
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "downstream interval 3600s is not a multiple of upstream interval 21600s"
+        ),
+    ):
+        make_repo([upstream, downstream])
+
+
 def test_multi_to_single_dimension_not_found():
     """MultiToSingle fails when the named dimension doesn't exist."""
     multi_parts = rs.PartitionsDefinition.multi(

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -291,6 +291,95 @@ def test_time_window_mapping_differing_ranges_allowed():
 
 
 # ---------------------------------------------------------------------------
+# Both partitioned — Identity (default) grid compatibility
+# ---------------------------------------------------------------------------
+
+
+def _identity_edge(down_def, up_def):
+    """Upstream→downstream pair with no explicit mapping (Identity default)."""
+
+    @rs.Asset(partitions_def=up_def)
+    def upstream() -> Any:
+        return 1
+
+    @rs.Asset(partitions_def=down_def)
+    def downstream(upstream: Any) -> Any:
+        return upstream
+
+    return [upstream, downstream]
+
+
+def test_identity_mapping_cross_cadence_rejected():
+    """Finer downstream over coarser upstream: most downstream keys don't
+    exist upstream — the persist-then-fail hole time_window(offset) had."""
+    fmt = "%Y-%m-%dT%H:00"
+    down = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, interval_seconds=3600, fmt=fmt
+    )
+    up = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, interval_seconds=21600, fmt=fmt
+    )
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': Identity mapping "
+            "requires the downstream grid to be a subgrid of the upstream "
+            "grid: downstream interval 3600s is not a multiple of upstream "
+            "interval 21600s"
+        ),
+    ):
+        make_repo(_identity_edge(down, up))
+
+
+def test_identity_mapping_fmt_mismatch_rejected():
+    down = rs.PartitionsDefinition.daily(start=DAILY_START)
+    up = rs.PartitionsDefinition.daily(start=DAILY_START, fmt="%d/%m/%Y")
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': Identity mapping "
+            "requires matching key formats: downstream fmt '%Y-%m-%d' != "
+            "upstream fmt '%d/%m/%Y'"
+        ),
+    ):
+        make_repo(_identity_edge(down, up))
+
+
+def test_identity_mapping_coarser_downstream_allowed():
+    """Coarser downstream over finer upstream is a valid subgrid: every
+    downstream key exists upstream."""
+    fmt = "%Y-%m-%dT%H:00"
+    down = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, interval_seconds=21600, fmt=fmt
+    )
+    up = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, interval_seconds=3600, fmt=fmt
+    )
+    assert make_repo(_identity_edge(down, up)) is not None
+
+
+def test_identity_mapping_static_disjoint_keys_rejected():
+    """A downstream static key the upstream lacks can never load its dep."""
+    down = rs.PartitionsDefinition.static_(["a", "x"])
+    up = rs.PartitionsDefinition.static_(["a", "b"])
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': Identity mapping "
+            "requires every downstream key to exist upstream; missing "
+            "upstream: x"
+        ),
+    ):
+        make_repo(_identity_edge(down, up))
+
+
+def test_identity_mapping_static_subset_allowed():
+    down = rs.PartitionsDefinition.static_(["a"])
+    up = rs.PartitionsDefinition.static_(["a", "b"])
+    assert make_repo(_identity_edge(down, up)) is not None
+
+
+# ---------------------------------------------------------------------------
 # Both partitioned — Static mapping
 # ---------------------------------------------------------------------------
 

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -1232,6 +1232,73 @@ def test_multi_partitions_identity():
     assert repo is not None
 
 
+def test_identity_multi_mismatched_dim_names_rejected():
+    """Identity between Multi defs with different dimension names must fail resolve."""
+    down = rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.static_(["2024-01"]),
+            "country": rs.PartitionsDefinition.static_(["us", "eu"]),
+        }
+    )
+    up = rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.static_(["2024-01"]),
+            "region": rs.PartitionsDefinition.static_(["us", "eu"]),
+        }
+    )
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': Identity mapping requires "
+            "matching Multi dimensions: downstream [country, date] != upstream "
+            "[date, region]"
+        ),
+    ):
+        make_repo(_identity_edge(down, up))
+
+
+def test_identity_multi_incompatible_dim_def_rejected():
+    """Identity between Multi defs recurses into each dimension's pair."""
+    down = rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.static_(["2024-01"]),
+            "region": rs.PartitionsDefinition.static_(["us", "mars"]),
+        }
+    )
+    up = rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.static_(["2024-01"]),
+            "region": rs.PartitionsDefinition.static_(["us", "eu"]),
+        }
+    )
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "in dimension 'region': Identity mapping requires every downstream "
+            "key to exist upstream; missing upstream: mars"
+        ),
+    ):
+        make_repo(_identity_edge(down, up))
+
+
+def test_identity_multi_cross_grid_dim_rejected():
+    """Per-dimension recursion applies grid compatibility to time dims."""
+    down = rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.daily(start=DAILY_START),
+            "region": rs.PartitionsDefinition.static_(["us"]),
+        }
+    )
+    up = rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.hourly(start=DAILY_START),
+            "region": rs.PartitionsDefinition.static_(["us"]),
+        }
+    )
+    with pytest.raises(PartitionValidationError, match="in dimension 'date'"):
+        make_repo(_identity_edge(down, up))
+
+
 def test_multi_partitions_explicit_identity_mapping():
     """Multi-dimensional partitions with explicit Identity mapping should work."""
     parts = rs.PartitionsDefinition.multi(

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -379,6 +379,28 @@ def test_identity_mapping_static_subset_allowed():
     assert make_repo(_identity_edge(down, up)) is not None
 
 
+def test_identity_mapping_dynamic_namespace_mismatch_rejected():
+    """Identity between different dynamic namespaces would look every
+    downstream key up in the wrong namespace — silently never matching."""
+    down = rs.PartitionsDefinition.dynamic("colors")
+    up = rs.PartitionsDefinition.dynamic("shapes")
+    with pytest.raises(
+        PartitionValidationError,
+        match=re.escape(
+            "Asset 'downstream' depends on 'upstream': Identity mapping "
+            "requires matching dynamic namespaces: downstream 'colors' != "
+            "upstream 'shapes'"
+        ),
+    ):
+        make_repo(_identity_edge(down, up))
+
+
+def test_identity_mapping_same_dynamic_namespace_allowed():
+    down = rs.PartitionsDefinition.dynamic("colors")
+    up = rs.PartitionsDefinition.dynamic("colors")
+    assert make_repo(_identity_edge(down, up)) is not None
+
+
 # ---------------------------------------------------------------------------
 # Both partitioned — Static mapping
 # ---------------------------------------------------------------------------

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -239,8 +239,9 @@ def test_time_window_mapping_phase_mismatch_rejected():
         make_repo(_tw_edge(down, up))
 
 
-def test_time_window_mapping_mixed_grid_kinds_rejected():
-    """One cron grid, one interval grid: subgrid alignment can't be proven."""
+def test_time_window_mapping_aligned_mixed_grid_kinds_allowed():
+    """A daily cron grid and an 86400s interval grid with the same anchor mint
+    identical keys — grid kind alone is no reason to reject the edge."""
     fmt = "%Y-%m-%d"
     up = rs.PartitionsDefinition.time_window(
         start=DAILY_START, cron_schedule="0 0 * * *", fmt=fmt
@@ -248,15 +249,34 @@ def test_time_window_mapping_mixed_grid_kinds_rejected():
     down = rs.PartitionsDefinition.time_window(
         start=DAILY_START, interval_seconds=86400, fmt=fmt
     )
+    assert make_repo(_tw_edge(down, up)) is not None
+
+
+def test_time_window_mapping_misaligned_mixed_grid_kinds_rejected():
+    """An interval grid anchored off the cron grid's ticks mints keys that
+    never exist upstream."""
+    fmt = "%Y-%m-%dT%H:%M"
+    up = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, cron_schedule="0 0 * * *", fmt=fmt
+    )
+    down = rs.PartitionsDefinition.time_window(
+        start=datetime(2024, 1, 1, 0, 30), interval_seconds=86400, fmt=fmt
+    )
     with pytest.raises(
-        PartitionValidationError,
-        match=re.escape(
-            "Asset 'downstream' depends on 'upstream': time_window mapping "
-            "requires both definitions on the same grid kind "
-            "(both cron or both interval)"
-        ),
+        PartitionValidationError, match="is not on the upstream grid"
     ):
         make_repo(_tw_edge(down, up))
+
+
+def test_equivalent_cron_spellings_allowed():
+    """'0 0 * * *' and its 6-field spelling '0 0 0 * * *' are one schedule;
+    textual comparison must not reject them."""
+    fmt = "%Y-%m-%d"
+    up = rs.PartitionsDefinition.daily(start=DAILY_START)
+    down = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, cron_schedule="0 0 0 * * *", fmt=fmt
+    )
+    assert make_repo(_identity_edge(down, up)) is not None
 
 
 def test_time_window_mapping_differing_cron_rejected():
@@ -268,12 +288,7 @@ def test_time_window_mapping_differing_cron_rejected():
         start=DAILY_START, cron_schedule="0 6 * * *", fmt=fmt
     )
     with pytest.raises(
-        PartitionValidationError,
-        match=re.escape(
-            "Asset 'downstream' depends on 'upstream': time_window mapping "
-            "requires identical cron schedules: downstream '0 6 * * *' != "
-            "upstream '0 0 * * *'"
-        ),
+        PartitionValidationError, match="is not on the upstream grid"
     ):
         make_repo(_tw_edge(down, up))
 

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -1207,6 +1207,72 @@ def test_task_partitioned_with_unpartitioned_upstream():
 
 
 # ---------------------------------------------------------------------------
+# Definitions are re-validated at resolve — the PyO3 per-variant constructors
+# (PartitionsDefinition.TimeWindow(...) etc.) bypass the factory staticmethods
+# and every construction-time guard with them.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rejects_variant_constructed_def_bypassing_fmt_validation():
+    bad = rs.PartitionsDefinition.TimeWindow(
+        cron_schedule="0 * * * *",
+        interval_seconds=None,
+        start=datetime(2024, 1, 1),
+        end=None,
+        fmt="%Y-%m-%d",
+    )
+
+    @rs.Asset(partitions_def=bad)
+    def standalone() -> Any:
+        return 1
+
+    with pytest.raises(
+        PartitionValidationError, match="cannot represent the partition grid"
+    ):
+        make_repo([standalone])
+
+
+def test_resolve_rejects_variant_constructed_static_with_reserved_key():
+    bad = rs.PartitionsDefinition.Static(keys=["us|eu"])
+
+    @rs.Asset(partitions_def=bad)
+    def standalone() -> Any:
+        return 1
+
+    with pytest.raises(PartitionValidationError, match="reserved character"):
+        make_repo([standalone])
+
+
+def test_resolve_rejects_variant_constructed_multi_with_bad_dim_name():
+    bad = rs.PartitionsDefinition.Multi(
+        dimensions=[("a=b", rs.PartitionsDefinition.static_(["x"]))]
+    )
+
+    @rs.Asset(partitions_def=bad)
+    def standalone() -> Any:
+        return 1
+
+    with pytest.raises(PartitionValidationError, match="reserved character"):
+        make_repo([standalone])
+
+
+def test_factory_constructed_defs_resolve_fine():
+    """The re-validation must not reject anything the factories produce."""
+    pd = rs.PartitionsDefinition.multi(
+        {
+            "date": rs.PartitionsDefinition.daily(start=DAILY_START),
+            "region": rs.PartitionsDefinition.static_(["us", "eu"]),
+        }
+    )
+
+    @rs.Asset(partitions_def=pd)
+    def standalone() -> Any:
+        return 1
+
+    assert make_repo([standalone]) is not None
+
+
+# ---------------------------------------------------------------------------
 # Multi-dimensional partitions
 # ---------------------------------------------------------------------------
 

--- a/python/tests/partitions/test_partition_submit_validation.py
+++ b/python/tests/partitions/test_partition_submit_validation.py
@@ -434,3 +434,148 @@ def test_grpc_execute_job_multi_partition_invalid_dimension_value_rejected(
 
     # No new run got queued.
     assert len(storage.get_runs(limit=10)) == runs_before
+
+
+# ---------------------------------------------------------------------------
+# Backfill boundary validation — explicit partition_keys must be validated
+# synchronously like `materialize` does, instead of persisting a
+# BackfillRecord that counts bogus keys and fails per-run later.
+# ---------------------------------------------------------------------------
+
+INVALID_BACKFILL_NOPE_MSG = (
+    'Invalid partition_key Single { key: ["nope"] } for asset '
+    "'part': not a member of its partition definition."
+)
+
+
+def test_backfill_invalid_explicit_key_raises():
+    pd = rs.PartitionsDefinition.static_(["a", "b"])
+
+    @rs.Asset(io_handler=rs.InMemoryIOHandler(), partitions_def=pd)
+    def part():
+        return 1
+
+    repo = rs.CodeRepository(assets=[part], default_executor=rs.Executor.in_process())
+
+    with pytest.raises(ExecutionError) as exc:
+        repo.backfill(
+            selection=["part"],
+            partition_keys=[rs.PartitionKey.single("a"), rs.PartitionKey.single("nope")],
+        )
+    assert str(exc.value) == INVALID_BACKFILL_NOPE_MSG
+
+    # Rejected synchronously — nothing materialized, no runs created.
+    assert repo.storage.get_materialized_partitions("part") == []
+    assert repo.storage.get_runs(limit=10) == []
+
+
+def test_backfill_valid_explicit_keys_still_succeed():
+    pd = rs.PartitionsDefinition.static_(["a", "b"])
+
+    @rs.Asset(io_handler=rs.InMemoryIOHandler(), partitions_def=pd)
+    def part():
+        return 1
+
+    repo = rs.CodeRepository(assets=[part], default_executor=rs.Executor.in_process())
+    result = repo.backfill(
+        selection=["part"],
+        partition_keys=[rs.PartitionKey.single("a"), rs.PartitionKey.single("b")],
+    )
+    assert result.completed == 2
+
+
+def test_backfill_dry_run_also_validates():
+    pd = rs.PartitionsDefinition.static_(["a", "b"])
+
+    @rs.Asset(io_handler=rs.InMemoryIOHandler(), partitions_def=pd)
+    def part():
+        return 1
+
+    repo = rs.CodeRepository(assets=[part], default_executor=rs.Executor.in_process())
+    with pytest.raises(ExecutionError) as exc:
+        repo.backfill(
+            selection=["part"],
+            partition_keys=[rs.PartitionKey.single("nope")],
+            dry_run=True,
+        )
+    assert str(exc.value) == INVALID_BACKFILL_NOPE_MSG
+
+
+# ---------------------------------------------------------------------------
+# gRPC conversion strictness — malformed partition input is rejected with
+# INVALID_ARGUMENT at the boundary instead of being silently dropped
+# (kind-less keys), collapsed (duplicate dims), or coerced (unknown strategy
+# shorthand → MultiRun fan-out).
+# ---------------------------------------------------------------------------
+
+
+def test_grpc_unknown_strategy_shorthand_rejected(partitioned_grpc_channel):
+    channel, pb2, pb2_grpc, _, _ = partitioned_grpc_channel
+    stub = pb2_grpc.CodeLocationServiceStub(channel)
+
+    with pytest.raises(grpc.RpcError) as exc:
+        stub.LaunchBackfill(
+            pb2.LaunchBackfillRequest(
+                selection=["part_alpha"],
+                partition_keys=[_single_pk(pb2, "a")],
+                strategy=pb2.BackfillStrategyProto(shorthand="Single_Run"),
+            )
+        )
+    assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert "unknown backfill strategy" in exc.value.details()
+
+
+def test_grpc_kindless_partition_key_rejected(partitioned_grpc_channel):
+    channel, pb2, pb2_grpc, _, _ = partitioned_grpc_channel
+    stub = pb2_grpc.CodeLocationServiceStub(channel)
+
+    with pytest.raises(grpc.RpcError) as exc:
+        stub.LaunchBackfill(
+            pb2.LaunchBackfillRequest(
+                selection=["part_alpha"],
+                # One valid key plus a kind-less one — previously the latter
+                # was silently filter_map'd away, shrinking the backfill.
+                partition_keys=[_single_pk(pb2, "a"), pb2.ProtoPartitionKey()],
+            )
+        )
+    assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert "no kind set" in exc.value.details()
+
+
+def test_grpc_empty_single_partition_key_rejected(partitioned_grpc_channel):
+    channel, pb2, pb2_grpc, _, _ = partitioned_grpc_channel
+    stub = pb2_grpc.CodeLocationServiceStub(channel)
+
+    with pytest.raises(grpc.RpcError) as exc:
+        stub.Materialize(
+            pb2.MaterializeRequest(
+                selection=["part_alpha"],
+                partition_key=pb2.ProtoPartitionKey(
+                    single=pb2.SinglePartitionKey(keys=[])
+                ),
+            )
+        )
+    assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert "must not be empty" in exc.value.details()
+
+
+def test_grpc_duplicate_multi_dimension_rejected(partitioned_grpc_channel):
+    channel, pb2, pb2_grpc, _, _ = partitioned_grpc_channel
+    stub = pb2_grpc.CodeLocationServiceStub(channel)
+
+    with pytest.raises(grpc.RpcError) as exc:
+        stub.Materialize(
+            pb2.MaterializeRequest(
+                selection=["part_alpha"],
+                partition_key=pb2.ProtoPartitionKey(
+                    multi=pb2.MultiPartitionKey(
+                        dimensions=[
+                            pb2.MultiPartitionDimension(name="region", keys=["us"]),
+                            pb2.MultiPartitionDimension(name="region", keys=["eu"]),
+                        ]
+                    )
+                ),
+            )
+        )
+    assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert "duplicate" in exc.value.details()

--- a/python/tests/partitions/test_partition_submit_validation.py
+++ b/python/tests/partitions/test_partition_submit_validation.py
@@ -463,9 +463,7 @@ def test_backfill_keys_on_unpartitioned_selection_rejected():
 
     repo = rs.CodeRepository(assets=[plain], default_executor=rs.Executor.in_process())
     with pytest.raises(ExecutionError) as exc:
-        repo.backfill(
-            selection=["plain"], partition_keys=[rs.PartitionKey.single("a")]
-        )
+        repo.backfill(selection=["plain"], partition_keys=[rs.PartitionKey.single("a")])
     assert str(exc.value) == UNPARTITIONED_BACKFILL_MSG
     assert repo.storage.get_runs(limit=10) == []
 
@@ -499,7 +497,10 @@ def test_backfill_invalid_explicit_key_raises():
     with pytest.raises(ExecutionError) as exc:
         repo.backfill(
             selection=["part"],
-            partition_keys=[rs.PartitionKey.single("a"), rs.PartitionKey.single("nope")],
+            partition_keys=[
+                rs.PartitionKey.single("a"),
+                rs.PartitionKey.single("nope"),
+            ],
         )
     assert str(exc.value) == INVALID_BACKFILL_NOPE_MSG
 

--- a/python/tests/partitions/test_partition_submit_validation.py
+++ b/python/tests/partitions/test_partition_submit_validation.py
@@ -446,6 +446,45 @@ INVALID_BACKFILL_NOPE_MSG = (
     'Invalid partition_key Single { key: ["nope"] } for asset '
     "'part': not a member of its partition definition."
 )
+UNPARTITIONED_BACKFILL_MSG = (
+    "Backfill partition_keys/partition_range require a partitioned selection; "
+    "no asset in the selection is partitioned."
+)
+
+
+def test_backfill_keys_on_unpartitioned_selection_rejected():
+    """partition_keys against an unpartitioned selection would bypass every
+    def-aware check (and PerDimension grouping would silently collapse to one
+    run) — reject it outright."""
+
+    @rs.Asset(io_handler=rs.InMemoryIOHandler())
+    def plain():
+        return 1
+
+    repo = rs.CodeRepository(assets=[plain], default_executor=rs.Executor.in_process())
+    with pytest.raises(ExecutionError) as exc:
+        repo.backfill(
+            selection=["plain"], partition_keys=[rs.PartitionKey.single("a")]
+        )
+    assert str(exc.value) == UNPARTITIONED_BACKFILL_MSG
+    assert repo.storage.get_runs(limit=10) == []
+
+
+def test_per_dimension_on_unpartitioned_selection_rejected():
+    @rs.Asset(io_handler=rs.InMemoryIOHandler())
+    def plain():
+        return 1
+
+    repo = rs.CodeRepository(assets=[plain], default_executor=rs.Executor.in_process())
+    with pytest.raises(ExecutionError) as exc:
+        repo.backfill(
+            selection=["plain"],
+            partition_keys=[rs.PartitionKey.single("a")],
+            strategy=rs.BackfillStrategy.per_dimension(
+                multi_run=["x"], single_run=["y"]
+            ),
+        )
+    assert str(exc.value) == UNPARTITIONED_BACKFILL_MSG
 
 
 def test_backfill_invalid_explicit_key_raises():

--- a/python/tests/partitions/test_partition_submit_validation.py
+++ b/python/tests/partitions/test_partition_submit_validation.py
@@ -28,12 +28,12 @@ MISSING_KEY_MSG = (
 )
 
 INVALID_STATIC_GARBAGE_MSG = (
-    "Invalid partition_key Single { key: [\"garbage\"] } for asset 'part': "
+    "Invalid partition_key 'garbage' for asset 'part': "
     "not a member of its partition definition."
 )
 
 INVALID_TIMEWINDOW_MSG = (
-    "Invalid partition_key Single { key: [\"2023-12-25\"] } for asset 'part': "
+    "Invalid partition_key '2023-12-25' for asset 'part': "
     "not a member of its partition definition."
 )
 
@@ -214,7 +214,7 @@ GRPC_MISSING_KEY_MSG = _grpc_msg(
     "exclude them from selection."
 )
 GRPC_BAD_KEY_PART_ALPHA = _grpc_msg(
-    'Invalid partition_key Single { key: ["garbage"] } for asset '
+    "Invalid partition_key 'garbage' for asset "
     "'part_alpha': not a member of its partition definition."
 )
 
@@ -443,7 +443,7 @@ def test_grpc_execute_job_multi_partition_invalid_dimension_value_rejected(
 # ---------------------------------------------------------------------------
 
 INVALID_BACKFILL_NOPE_MSG = (
-    'Invalid partition_key Single { key: ["nope"] } for asset '
+    "Invalid partition_key 'nope' for asset "
     "'part': not a member of its partition definition."
 )
 UNPARTITIONED_BACKFILL_MSG = (

--- a/python/tests/partitions/test_partition_submit_validation.py
+++ b/python/tests/partitions/test_partition_submit_validation.py
@@ -506,18 +506,23 @@ def test_backfill_dry_run_also_validates():
 # INVALID_ARGUMENT at the boundary instead of being silently dropped
 # (kind-less keys), collapsed (duplicate dims), or coerced (unknown strategy
 # shorthand → MultiRun fan-out).
+#
+# Only one gRPC server runs per process (`_start_grpc_server` supersedes the
+# previous one), so these use the LAST module fixture started in file order:
+# `multi_partitioned_grpc_channel`. Conversion runs before any asset/def
+# validation, so the selection content is incidental.
 # ---------------------------------------------------------------------------
 
 
-def test_grpc_unknown_strategy_shorthand_rejected(partitioned_grpc_channel):
-    channel, pb2, pb2_grpc, _, _ = partitioned_grpc_channel
+def test_grpc_unknown_strategy_shorthand_rejected(multi_partitioned_grpc_channel):
+    channel, pb2, pb2_grpc, _, _ = multi_partitioned_grpc_channel
     stub = pb2_grpc.CodeLocationServiceStub(channel)
 
     with pytest.raises(grpc.RpcError) as exc:
         stub.LaunchBackfill(
             pb2.LaunchBackfillRequest(
-                selection=["part_alpha"],
-                partition_keys=[_single_pk(pb2, "a")],
+                selection=["cell"],
+                partition_keys=[_multi_pk(pb2, color="r", size="s")],
                 strategy=pb2.BackfillStrategyProto(shorthand="Single_Run"),
             )
         )
@@ -525,31 +530,34 @@ def test_grpc_unknown_strategy_shorthand_rejected(partitioned_grpc_channel):
     assert "unknown backfill strategy" in exc.value.details()
 
 
-def test_grpc_kindless_partition_key_rejected(partitioned_grpc_channel):
-    channel, pb2, pb2_grpc, _, _ = partitioned_grpc_channel
+def test_grpc_kindless_partition_key_rejected(multi_partitioned_grpc_channel):
+    channel, pb2, pb2_grpc, _, _ = multi_partitioned_grpc_channel
     stub = pb2_grpc.CodeLocationServiceStub(channel)
 
     with pytest.raises(grpc.RpcError) as exc:
         stub.LaunchBackfill(
             pb2.LaunchBackfillRequest(
-                selection=["part_alpha"],
+                selection=["cell"],
                 # One valid key plus a kind-less one — previously the latter
                 # was silently filter_map'd away, shrinking the backfill.
-                partition_keys=[_single_pk(pb2, "a"), pb2.ProtoPartitionKey()],
+                partition_keys=[
+                    _multi_pk(pb2, color="r", size="s"),
+                    pb2.ProtoPartitionKey(),
+                ],
             )
         )
     assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
     assert "no kind set" in exc.value.details()
 
 
-def test_grpc_empty_single_partition_key_rejected(partitioned_grpc_channel):
-    channel, pb2, pb2_grpc, _, _ = partitioned_grpc_channel
+def test_grpc_empty_single_partition_key_rejected(multi_partitioned_grpc_channel):
+    channel, pb2, pb2_grpc, _, _ = multi_partitioned_grpc_channel
     stub = pb2_grpc.CodeLocationServiceStub(channel)
 
     with pytest.raises(grpc.RpcError) as exc:
         stub.Materialize(
             pb2.MaterializeRequest(
-                selection=["part_alpha"],
+                selection=["cell"],
                 partition_key=pb2.ProtoPartitionKey(
                     single=pb2.SinglePartitionKey(keys=[])
                 ),
@@ -559,19 +567,19 @@ def test_grpc_empty_single_partition_key_rejected(partitioned_grpc_channel):
     assert "must not be empty" in exc.value.details()
 
 
-def test_grpc_duplicate_multi_dimension_rejected(partitioned_grpc_channel):
-    channel, pb2, pb2_grpc, _, _ = partitioned_grpc_channel
+def test_grpc_duplicate_multi_dimension_rejected(multi_partitioned_grpc_channel):
+    channel, pb2, pb2_grpc, _, _ = multi_partitioned_grpc_channel
     stub = pb2_grpc.CodeLocationServiceStub(channel)
 
     with pytest.raises(grpc.RpcError) as exc:
         stub.Materialize(
             pb2.MaterializeRequest(
-                selection=["part_alpha"],
+                selection=["cell"],
                 partition_key=pb2.ProtoPartitionKey(
                     multi=pb2.MultiPartitionKey(
                         dimensions=[
-                            pb2.MultiPartitionDimension(name="region", keys=["us"]),
-                            pb2.MultiPartitionDimension(name="region", keys=["eu"]),
+                            pb2.MultiPartitionDimension(name="color", keys=["r"]),
+                            pb2.MultiPartitionDimension(name="color", keys=["g"]),
                         ]
                     )
                 ),

--- a/python/tests/partitions/test_partitions_def.py
+++ b/python/tests/partitions/test_partitions_def.py
@@ -169,7 +169,9 @@ def test_coarse_fmt_on_equally_coarse_grid_allowed():
         fmt="%Y-%m",
         end=datetime.datetime(2024, 4, 1),
     )
-    keys = [k.key for k in pd.get_partition_keys() if isinstance(k, rs.PartitionKey.Single)]
+    keys = [
+        k.key for k in pd.get_partition_keys() if isinstance(k, rs.PartitionKey.Single)
+    ]
     assert keys == [["2024-01"], ["2024-02"], ["2024-03"]]
 
 

--- a/python/tests/partitions/test_partitions_def.py
+++ b/python/tests/partitions/test_partitions_def.py
@@ -318,6 +318,14 @@ def test_static_key_with_reserved_char_rejected():
             rs.PartitionsDefinition.static_([key])
 
 
+def test_static_rejects_empty_string_key():
+    """Empty key strings render as nothing in the display form and are
+    unreachable via string lookups — same guard as the dynamic write path."""
+    for keys in ([""], ["a", ""]):
+        with pytest.raises(PartitionDefinitionError, match="must not be empty"):
+            rs.PartitionsDefinition.static_(keys)
+
+
 def test_multi_dim_name_with_reserved_char_rejected():
     """Dim names also sit left of '=' in `dim=value` segments, so '=' is
     reserved for them as well."""

--- a/python/tests/partitions/test_partitions_def.py
+++ b/python/tests/partitions/test_partitions_def.py
@@ -318,6 +318,32 @@ def test_static_key_with_reserved_char_rejected():
             rs.PartitionsDefinition.static_([key])
 
 
+def test_time_window_fmt_must_round_trip_beyond_first_ticks():
+    """A month-grain fmt over a 31-day interval survives the first two ticks
+    (Jan 1, Feb 1 both land on month starts) but drifts at tick 2 (Mar 3):
+    enumerate would mint '2024-03', which the definition's own key validation
+    rejects. Construction must catch drift past the first ticks."""
+    with pytest.raises(
+        PartitionDefinitionError, match="cannot represent the partition grid"
+    ):
+        rs.PartitionsDefinition.time_window(
+            start=datetime.datetime(2024, 1, 1),
+            interval_seconds=31.0 * 86400.0,
+            fmt="%Y-%m",
+        )
+
+
+def test_time_window_interval_coarser_than_horizon_accepted():
+    """No false rejection when ticks are sparse: a day-grain fmt represents
+    whole-day interval ticks exactly, however far apart they are."""
+    pd = rs.PartitionsDefinition.time_window(
+        start=datetime.datetime(2024, 1, 1),
+        interval_seconds=400.0 * 86400.0,
+        fmt="%Y-%m-%d",
+    )
+    assert pd is not None
+
+
 def test_static_rejects_empty_string_key():
     """Empty key strings render as nothing in the display form and are
     unreachable via string lookups — same guard as the dynamic write path."""

--- a/python/tests/partitions/test_partitions_def.py
+++ b/python/tests/partitions/test_partitions_def.py
@@ -306,6 +306,44 @@ def test_empty_set_key_invalid():
 
 
 # ---------------------------------------------------------------------------
+# '|' separates dimensions and ',' separates values in the canonical display
+# form (`dim=v|dim=v`); keys containing them cannot round-trip through
+# partition-string lookups, so they are rejected at construction.
+# ---------------------------------------------------------------------------
+
+
+def test_static_key_with_reserved_char_rejected():
+    for key in ("us|eu", "a,b"):
+        with pytest.raises(PartitionDefinitionError, match="reserved character"):
+            rs.PartitionsDefinition.static_([key])
+
+
+def test_multi_dim_name_with_reserved_char_rejected():
+    """Dim names also sit left of '=' in `dim=value` segments, so '=' is
+    reserved for them as well."""
+    inner = rs.PartitionsDefinition.static_(["x"])
+    for name in ("a|b", "a,b", "a=b"):
+        with pytest.raises(PartitionDefinitionError, match="reserved character"):
+            rs.PartitionsDefinition.multi({name: inner})
+
+
+def test_multi_empty_dim_name_rejected():
+    inner = rs.PartitionsDefinition.static_(["x"])
+    with pytest.raises(PartitionDefinitionError, match="cannot be empty"):
+        rs.PartitionsDefinition.multi({"": inner})
+
+
+def test_time_window_fmt_with_reserved_char_rejected():
+    """A fmt whose rendered keys contain '|' breaks display parsing."""
+    with pytest.raises(PartitionDefinitionError, match="reserved character"):
+        rs.PartitionsDefinition.time_window(
+            start=datetime.datetime(2024, 1, 1),
+            interval_seconds=3600.0,
+            fmt="%Y|%m-%dT%H:%M:%S",
+        )
+
+
+# ---------------------------------------------------------------------------
 # Non-positive / sub-nanosecond intervals are rejected at construction —
 # interval_ns == 0 would otherwise panic on `n % 0` during key validation.
 # ---------------------------------------------------------------------------

--- a/python/tests/partitions/test_partitions_def.py
+++ b/python/tests/partitions/test_partitions_def.py
@@ -210,3 +210,81 @@ def test_dynamic_construction():
     """Dynamic partitions can be created with a name."""
     dyn = rs.PartitionsDefinition.dynamic("my_set")
     assert isinstance(dyn, rs.PartitionsDefinition.Dynamic)
+
+
+# ---------------------------------------------------------------------------
+# Empty keys never validate — empty vectors otherwise pass via vacuous
+# iteration (`all()` / a never-entered loop) on every kind.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_single_key_invalid_for_static():
+    pd = rs.PartitionsDefinition.static_(["a", "b"])
+    pk = rs.PartitionKey.from_json('{"single":[]}')
+    assert pd.validate_partition_key(pk) is False
+
+
+def test_empty_single_key_invalid_for_timewindow():
+    pd = rs.PartitionsDefinition.daily(
+        start=datetime.datetime(2024, 1, 1), end=datetime.datetime(2024, 1, 5)
+    )
+    pk = rs.PartitionKey.from_json('{"single":[]}')
+    assert pd.validate_partition_key(pk) is False
+
+
+def test_empty_single_key_invalid_for_dynamic():
+    pd = rs.PartitionsDefinition.dynamic("users")
+    pk = rs.PartitionKey.from_json('{"single":[]}')
+    assert pd.validate_partition_key(pk) is False
+
+
+def test_empty_dim_values_invalid_for_multi():
+    pd = rs.PartitionsDefinition.multi(
+        {"region": rs.PartitionsDefinition.static_(["us"])}
+    )
+    pk = rs.PartitionKey.from_json('{"multi":{"region":[]}}')
+    assert pd.validate_partition_key(pk) is False
+
+
+def test_multi_key_with_extra_dimension_invalid():
+    """A key carrying a dimension the def doesn't declare must not validate —
+    the def-dims loop can't see extra dims."""
+    pd = rs.PartitionsDefinition.multi(
+        {"region": rs.PartitionsDefinition.static_(["us"])}
+    )
+    key = rs.PartitionKey.multi({"region": "us", "bogus": "x"})
+    assert pd.validate_partition_key(key) is False
+
+
+def test_empty_set_key_invalid():
+    pd = rs.PartitionsDefinition.static_(["a"])
+    pk = rs.PartitionKey.from_json('{"set":[]}')
+    assert pd.validate_partition_key(pk) is False
+
+
+# ---------------------------------------------------------------------------
+# Non-positive / sub-nanosecond intervals are rejected at construction —
+# interval_ns == 0 would otherwise panic on `n % 0` during key validation.
+# ---------------------------------------------------------------------------
+
+
+def test_time_window_zero_interval_rejected():
+    with pytest.raises(PartitionDefinitionError, match="interval_seconds"):
+        rs.PartitionsDefinition.time_window(
+            start=datetime.datetime(2024, 1, 1), interval_seconds=0.0
+        )
+
+
+def test_time_window_negative_interval_rejected():
+    with pytest.raises(PartitionDefinitionError, match="interval_seconds"):
+        rs.PartitionsDefinition.time_window(
+            start=datetime.datetime(2024, 1, 1), interval_seconds=-3600.0
+        )
+
+
+def test_time_window_sub_nanosecond_interval_rejected():
+    """1e-12 seconds is positive but truncates to 0 nanoseconds internally."""
+    with pytest.raises(PartitionDefinitionError, match="interval_seconds"):
+        rs.PartitionsDefinition.time_window(
+            start=datetime.datetime(2024, 1, 1), interval_seconds=1e-12
+        )

--- a/python/tests/partitions/test_partitions_def.py
+++ b/python/tests/partitions/test_partitions_def.py
@@ -405,14 +405,24 @@ def test_time_window_sub_nanosecond_interval_rejected():
         )
 
 
+def test_time_window_subsecond_cron_start_rejected_despite_fraction_fmt():
+    """A fraction-preserving fmt round-trips sub-second cron ticks, so the
+    fmt check alone cannot catch them — but the condition engine's cron grid
+    walks whole seconds and would never match the minted keys. The guard must
+    be explicit, not an artifact of the fmt."""
+    with pytest.raises(PartitionDefinitionError, match="whole second"):
+        rs.PartitionsDefinition.time_window(
+            start=datetime.datetime(2024, 1, 1, microsecond=500),
+            cron_schedule="0 * * * *",
+            fmt="%Y-%m-%dT%H:%M:%S%.f",
+        )
+
+
 def test_time_window_subsecond_cron_start_rejected():
     """A start with sub-second precision puts every cron tick off the whole-
-    second grid; a second-grained fmt cannot round-trip those keys. The fmt
-    check walks the same grid enumerate uses, so this fails at construction
-    instead of minting keys that fail their own validation."""
-    with pytest.raises(
-        PartitionDefinitionError, match="cannot represent the partition grid"
-    ):
+    second grid; cron schedules are second-granular, so construction rejects
+    the start outright."""
+    with pytest.raises(PartitionDefinitionError, match="whole second"):
         rs.PartitionsDefinition.time_window(
             start=datetime.datetime(2024, 1, 1, microsecond=500),
             cron_schedule="0 * * * *",

--- a/python/tests/partitions/test_partitions_def.py
+++ b/python/tests/partitions/test_partitions_def.py
@@ -132,6 +132,47 @@ def test_time_window_six_field_cron():
     ]
 
 
+def test_time_window_fmt_must_roundtrip_grid():
+    """A fmt coarser than the grid collapses distinct windows into one key
+    string — enumerate yields duplicates and backfills double-dispatch."""
+    # Hourly cron with a date-only fmt: 24 windows share each key.
+    with pytest.raises(
+        PartitionDefinitionError, match="cannot represent the partition grid"
+    ):
+        rs.PartitionsDefinition.time_window(
+            datetime.datetime(2024, 1, 1),
+            cron_schedule="0 * * * *",
+            fmt="%Y-%m-%d",
+        )
+    # Sub-second interval with the second-grained default fmt.
+    with pytest.raises(
+        PartitionDefinitionError, match="cannot represent the partition grid"
+    ):
+        rs.PartitionsDefinition.time_window(
+            datetime.datetime(2024, 1, 1), interval_seconds=0.5
+        )
+
+
+def test_daily_fmt_override_must_roundtrip():
+    """daily(fmt='%Y-%m') collapses ~30 windows per key."""
+    with pytest.raises(
+        PartitionDefinitionError, match="cannot represent the partition grid"
+    ):
+        rs.PartitionsDefinition.daily(datetime.datetime(2024, 1, 1), fmt="%Y-%m")
+
+
+def test_coarse_fmt_on_equally_coarse_grid_allowed():
+    """A coarse fmt is fine when the grid is equally coarse."""
+    pd = rs.PartitionsDefinition.time_window(
+        datetime.datetime(2024, 1, 1),
+        cron_schedule="0 0 1 * *",
+        fmt="%Y-%m",
+        end=datetime.datetime(2024, 4, 1),
+    )
+    keys = [k.key for k in pd.get_partition_keys() if isinstance(k, rs.PartitionKey.Single)]
+    assert keys == [["2024-01"], ["2024-02"], ["2024-03"]]
+
+
 def test_time_window_requires_schedule_or_interval():
     """TimeWindow requires either cron_schedule or interval_seconds."""
     with pytest.raises(PartitionDefinitionError):

--- a/python/tests/partitions/test_partitions_def.py
+++ b/python/tests/partitions/test_partitions_def.py
@@ -369,3 +369,17 @@ def test_time_window_sub_nanosecond_interval_rejected():
         rs.PartitionsDefinition.time_window(
             start=datetime.datetime(2024, 1, 1), interval_seconds=1e-12
         )
+
+
+def test_time_window_subsecond_cron_start_rejected():
+    """A start with sub-second precision puts every cron tick off the whole-
+    second grid; a second-grained fmt cannot round-trip those keys. The fmt
+    check walks the same grid enumerate uses, so this fails at construction
+    instead of minting keys that fail their own validation."""
+    with pytest.raises(
+        PartitionDefinitionError, match="cannot represent the partition grid"
+    ):
+        rs.PartitionsDefinition.time_window(
+            start=datetime.datetime(2024, 1, 1, microsecond=500),
+            cron_schedule="0 * * * *",
+        )

--- a/rust/rivers-core/Cargo.toml
+++ b/rust/rivers-core/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+ordermap = "1"
 chrono.workspace = true
 croner.workspace = true
 futures-util = { workspace = true }

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -1281,7 +1281,7 @@ fn eval_partitioned_on_dep(
         in_progress: &upstream_status.in_progress,
         failed: &upstream_status.failed,
         timestamps: &upstream_status.timestamps,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: pctx.all_partition_statuses,
     };

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -1104,7 +1104,7 @@ fn eval_partitioned<O: PartEvalOutput>(
                 .cloned()
                 .unwrap_or(PartitionSelection::Empty);
             // First-tick behavior handled via InitialEvaluation composition.
-            let result = current.difference(&previous);
+            let result = current.difference(&previous, pctx.all_keys);
             sub_selections.insert(my_idx, current);
             O::composite(result, my_idx, node, total, vec![child_part])
         }
@@ -1122,7 +1122,9 @@ fn eval_partitioned<O: PartEvalOutput>(
                 .cloned()
                 .unwrap_or(PartitionSelection::Empty);
             // (prev_latched ∪ trigger) - reset
-            let result = prev_latch.union(&trigger_sel).difference(&reset_sel);
+            let result = prev_latch
+                .union(&trigger_sel)
+                .difference(&reset_sel, pctx.all_keys);
             sub_selections.insert(my_idx, result.clone());
             O::composite(result, my_idx, node, total, vec![trigger_part, reset_part])
         }
@@ -1159,7 +1161,7 @@ fn eval_partitioned<O: PartEvalOutput>(
                             } else {
                                 PartitionSelection::Keys(handled_set.clone())
                             };
-                            current.difference(&handled_sel)
+                            current.difference(&handled_sel, pctx.all_keys)
                         } else {
                             current
                         }

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -881,15 +881,32 @@ fn eval_partitioned<O: PartEvalOutput>(
                 .partition_state
                 .as_ref()
                 .map(|ps| &ps.timestamps);
+            // In a dep pivot (target ≠ root) observation baselines are
+            // unsound both ways: async event drains re-surface already-
+            // acted-on events (double fire), and a fire can baseline a key
+            // that a sibling clause suppressed that tick (lost fire,
+            // forever). Compare staleness instead: a dep key counts as
+            // updated while it is strictly newer than the root's own
+            // materialization of that key — the dispatched run advances the
+            // root past the dep so the trigger self-suppresses, and a missed
+            // tick simply retries. Keys the root never materialized pass;
+            // roots without partition status keep the baseline behavior.
+            let root_floor = if ctx.target_key != ctx.root_key {
+                pctx.all_partition_statuses
+                    .get(ctx.root_key)
+                    .map(|s| &s.timestamps)
+            } else {
+                None
+            };
             let updated: HashSet<PartitionKey> = pctx
                 .timestamps
                 .iter()
-                .filter(|&(pk, &ts)| {
-                    let prev_ts = prev_timestamps.and_then(|pt| pt.get(pk));
-                    match prev_ts {
+                .filter(|&(pk, &ts)| match root_floor {
+                    Some(floor) => floor.get(pk).is_none_or(|&root_ts| ts > root_ts),
+                    None => match prev_timestamps.and_then(|pt| pt.get(pk)) {
                         Some(&prev) => ts > prev,
                         None => true, // newly appeared partition
-                    }
+                    },
                 })
                 .map(|(pk, _)| pk.clone())
                 .collect();

--- a/rust/rivers-core/src/condition/partition.rs
+++ b/rust/rivers-core/src/condition/partition.rs
@@ -143,6 +143,12 @@ pub enum PartitionMappingKind {
     },
     TimeWindow {
         offset: i64,
+        /// The upstream definition's time grid, captured at conversion so
+        /// eval can shift keys the same way the runtime does. `None` for
+        /// mappings serialized before the grid existed — degrades to
+        /// pass-through.
+        #[serde(default)]
+        grid: Option<crate::timegrid::TimeGrid>,
     },
     SpecificPartitions {
         keys: Vec<String>,
@@ -165,6 +171,43 @@ pub enum PartitionMappingKind {
     /// Subset mapping: upstream has a subset of downstream's partition keys.
     /// Non-matching downstream keys skip the upstream.
     Subset,
+}
+
+/// Shift every single-dimension key in a selection by `offset` grid windows.
+/// Keys whose shift falls outside the grid's `[start, end)` have no
+/// counterpart partition and are dropped. Without a grid (mappings
+/// serialized before it existed) the selection passes through unchanged.
+fn shift_selection(
+    sel: &PartitionSelection,
+    offset: i64,
+    grid: Option<&crate::timegrid::TimeGrid>,
+) -> PartitionSelection {
+    let Some(grid) = grid else {
+        return sel.clone();
+    };
+    if offset == 0 {
+        return sel.clone();
+    }
+    match sel {
+        PartitionSelection::All | PartitionSelection::Empty => sel.clone(),
+        PartitionSelection::Keys(keys) => {
+            let shifted: HashSet<PartitionKey> = keys
+                .iter()
+                .filter_map(|k| match k {
+                    PartitionKey::Single { keys } if keys.len() == 1 => grid
+                        .shift_key(&keys[0], offset)
+                        .ok()
+                        .map(|s| PartitionKey::Single { keys: vec![s] }),
+                    _ => None,
+                })
+                .collect();
+            if shifted.is_empty() {
+                PartitionSelection::Empty
+            } else {
+                PartitionSelection::Keys(shifted)
+            }
+        }
+    }
 }
 
 impl PartitionMappingKind {
@@ -196,7 +239,12 @@ impl PartitionMappingKind {
                     }
                 }
             },
-            Self::TimeWindow { .. } => downstream_keys.clone(), // TODO: time offset logic
+            // Downstream key K reads upstream K+offset (runtime map_key
+            // semantics) — mirror it here so conditions fire the partitions
+            // the runtime will actually load.
+            Self::TimeWindow { offset, grid } => {
+                shift_selection(downstream_keys, *offset, grid.as_ref())
+            }
             Self::SpecificPartitions { keys } => {
                 if downstream_keys.is_empty() {
                     PartitionSelection::Empty
@@ -323,7 +371,11 @@ impl PartitionMappingKind {
                     }
                 }
             },
-            Self::TimeWindow { .. } => upstream_keys.clone(), // TODO: time offset logic
+            // Inverse of map_to_upstream: the downstream that reads
+            // upstream U is U-offset.
+            Self::TimeWindow { offset, grid } => {
+                shift_selection(upstream_keys, -*offset, grid.as_ref())
+            }
             Self::SpecificPartitions { .. } => {
                 if upstream_keys.is_empty() {
                     PartitionSelection::Empty

--- a/rust/rivers-core/src/condition/partition.rs
+++ b/rust/rivers-core/src/condition/partition.rs
@@ -349,22 +349,37 @@ impl PartitionMappingKind {
     }
 }
 
-/// Resolves partition key mappings between connected assets.
-pub struct PartitionResolver {
+/// Resolves partition key mappings between connected assets. Borrows the
+/// long-lived maps — constructed per asset per tick on the hot loop.
+pub struct PartitionResolver<'a> {
     /// Per-edge mapping kind. Key = (downstream_asset, upstream_asset).
-    mappings: HashMap<(String, String), PartitionMappingKind>,
+    mappings: &'a HashMap<(String, String), PartitionMappingKind>,
     /// Upstream asset → its valid partition keys.
-    pub(crate) upstream_partition_keys: HashMap<String, HashSet<PartitionKey>>,
+    pub(crate) upstream_partition_keys: &'a HashMap<String, HashSet<PartitionKey>>,
 }
 
-impl PartitionResolver {
+impl<'a> PartitionResolver<'a> {
     pub fn new(
-        mappings: HashMap<(String, String), PartitionMappingKind>,
-        upstream_partition_keys: HashMap<String, HashSet<PartitionKey>>,
+        mappings: &'a HashMap<(String, String), PartitionMappingKind>,
+        upstream_partition_keys: &'a HashMap<String, HashSet<PartitionKey>>,
     ) -> Self {
         Self {
             mappings,
             upstream_partition_keys,
+        }
+    }
+
+    /// A resolver with no mappings and no upstream keys — identity for
+    /// every edge. Used where a context is built without dep traversal.
+    pub fn empty() -> PartitionResolver<'static> {
+        static EMPTY_MAPPINGS: std::sync::OnceLock<
+            HashMap<(String, String), PartitionMappingKind>,
+        > = std::sync::OnceLock::new();
+        static EMPTY_KEYS: std::sync::OnceLock<HashMap<String, HashSet<PartitionKey>>> =
+            std::sync::OnceLock::new();
+        PartitionResolver {
+            mappings: EMPTY_MAPPINGS.get_or_init(HashMap::new),
+            upstream_partition_keys: EMPTY_KEYS.get_or_init(HashMap::new),
         }
     }
 
@@ -398,7 +413,7 @@ pub struct PartitionEvalContext<'a> {
     /// Per-partition last materialization timestamp.
     pub timestamps: &'a HashMap<PartitionKey, i64>,
     /// Partition mapping resolver for upstream deps.
-    pub resolver: PartitionResolver,
+    pub resolver: PartitionResolver<'a>,
     /// Partition keys in the latest time window (for `InLatestTimeWindow` condition).
     /// `None` for non-time-windowed partitions (treated as all keys).
     pub latest_time_window_keys: Option<&'a HashSet<PartitionKey>>,

--- a/rust/rivers-core/src/condition/partition.rs
+++ b/rust/rivers-core/src/condition/partition.rs
@@ -211,132 +211,6 @@ fn shift_selection(
 }
 
 impl PartitionMappingKind {
-    /// Map downstream partition keys to upstream partition keys.
-    pub fn map_to_upstream(&self, downstream_keys: &PartitionSelection) -> PartitionSelection {
-        match self {
-            Self::Identity => downstream_keys.clone(),
-            Self::AllPartitions => PartitionSelection::All,
-            Self::Static { mapping } => match downstream_keys {
-                PartitionSelection::Empty => PartitionSelection::Empty,
-                PartitionSelection::All => PartitionSelection::All,
-                PartitionSelection::Keys(keys) => {
-                    let mapped: HashSet<PartitionKey> = keys
-                        .iter()
-                        .filter_map(|k| {
-                            if let PartitionKey::Single { keys: kv } = k {
-                                mapping.get(kv.first()?).map(|v| PartitionKey::Single {
-                                    keys: vec![v.clone()],
-                                })
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    if mapped.is_empty() {
-                        PartitionSelection::Empty
-                    } else {
-                        PartitionSelection::Keys(mapped)
-                    }
-                }
-            },
-            // Downstream key K reads upstream K+offset (runtime map_key
-            // semantics) — mirror it here so conditions fire the partitions
-            // the runtime will actually load.
-            Self::TimeWindow { offset, grid } => {
-                shift_selection(downstream_keys, *offset, grid.as_ref())
-            }
-            Self::SpecificPartitions { keys } => {
-                if downstream_keys.is_empty() {
-                    PartitionSelection::Empty
-                } else {
-                    PartitionSelection::Keys(
-                        keys.iter()
-                            .map(|k| PartitionKey::Single {
-                                keys: vec![k.clone()],
-                            })
-                            .collect(),
-                    )
-                }
-            }
-            Self::Multi { dimension_mappings } => match downstream_keys {
-                PartitionSelection::Empty => PartitionSelection::Empty,
-                PartitionSelection::All => PartitionSelection::All,
-                PartitionSelection::Keys(keys) => {
-                    let map_key_upstream = |pk: &PartitionKey| -> Option<PartitionKey> {
-                        let dims = match pk {
-                            PartitionKey::Multi { dims } => dims,
-                            _ => return None,
-                        };
-                        let downstream_dims: HashMap<&str, &[String]> = dims
-                            .iter()
-                            .map(|(d, v)| (d.as_str(), v.as_slice()))
-                            .collect();
-                        let mut upstream_dims = Vec::new();
-                        for (upstream_dim, (downstream_dim, per_dim_mapping)) in dimension_mappings
-                        {
-                            let val = downstream_dims.get(downstream_dim.as_str())?;
-                            let single_key = PartitionKey::Single { keys: val.to_vec() };
-                            let mapped = per_dim_mapping.map_to_upstream(
-                                &PartitionSelection::Keys(std::iter::once(single_key).collect()),
-                            );
-                            match mapped {
-                                PartitionSelection::Keys(ks) => {
-                                    let first = ks.into_iter().next()?;
-                                    if let PartitionKey::Single { keys: kv } = first {
-                                        upstream_dims.push((upstream_dim.clone(), kv));
-                                    } else {
-                                        return None;
-                                    }
-                                }
-                                _ => return None,
-                            }
-                        }
-                        Some(PartitionKey::Multi {
-                            dims: upstream_dims,
-                        })
-                    };
-                    let mapped: HashSet<PartitionKey> =
-                        keys.iter().filter_map(map_key_upstream).collect();
-                    if mapped.is_empty() {
-                        PartitionSelection::Empty
-                    } else {
-                        PartitionSelection::Keys(mapped)
-                    }
-                }
-            },
-            Self::MultiToSingle {
-                dimension_name: _,
-                inner,
-            } => match downstream_keys {
-                PartitionSelection::Empty => PartitionSelection::Empty,
-                PartitionSelection::All => PartitionSelection::All,
-                PartitionSelection::Keys(keys) => {
-                    let mapped: HashSet<PartitionKey> = keys
-                        .iter()
-                        .map(|k| {
-                            let inner_sel =
-                                PartitionSelection::Keys(std::iter::once(k.clone()).collect());
-                            inner.map_to_upstream(&inner_sel)
-                        })
-                        .flat_map(|sel| match sel {
-                            PartitionSelection::Keys(ks) => ks.into_iter().collect::<Vec<_>>(),
-                            PartitionSelection::All => vec![],
-                            PartitionSelection::Empty => vec![],
-                        })
-                        .collect();
-                    if mapped.is_empty() {
-                        PartitionSelection::Empty
-                    } else {
-                        PartitionSelection::Keys(mapped)
-                    }
-                }
-            },
-            Self::ForKeys => PartitionSelection::All,
-            // Non-existent keys filtered at execution time.
-            Self::Subset => downstream_keys.clone(),
-        }
-    }
-
     /// Map upstream partition keys to downstream partition keys.
     pub fn map_to_downstream(&self, upstream_keys: &PartitionSelection) -> PartitionSelection {
         match self {
@@ -371,8 +245,8 @@ impl PartitionMappingKind {
                     }
                 }
             },
-            // Inverse of map_to_upstream: the downstream that reads
-            // upstream U is U-offset.
+            // Downstream key K reads upstream K+offset, so the downstream
+            // that reads upstream U is U-offset.
             Self::TimeWindow { offset, grid } => {
                 shift_selection(upstream_keys, -*offset, grid.as_ref())
             }
@@ -491,33 +365,6 @@ impl PartitionResolver {
         Self {
             mappings,
             upstream_partition_keys,
-        }
-    }
-
-    /// Map downstream partition keys to upstream partition keys.
-    pub fn map_upstream(
-        &self,
-        downstream_asset: &str,
-        upstream_asset: &str,
-        downstream_keys: &PartitionSelection,
-    ) -> PartitionSelection {
-        let key = (downstream_asset.to_string(), upstream_asset.to_string());
-        let mapping = match self.mappings.get(&key) {
-            Some(m) => m,
-            None => return downstream_keys.clone(), // no mapping = identity
-        };
-        match mapping {
-            PartitionMappingKind::AllPartitions => {
-                if downstream_keys.is_empty() {
-                    PartitionSelection::Empty
-                } else {
-                    match self.upstream_partition_keys.get(upstream_asset) {
-                        Some(keys) => PartitionSelection::Keys(keys.clone()),
-                        None => PartitionSelection::All,
-                    }
-                }
-            }
-            _ => mapping.map_to_upstream(downstream_keys),
         }
     }
 

--- a/rust/rivers-core/src/condition/partition.rs
+++ b/rust/rivers-core/src/condition/partition.rs
@@ -75,18 +75,15 @@ impl PartitionSelection {
         }
     }
 
-    /// Set difference (self - other).
-    pub fn difference(&self, other: &Self) -> Self {
+    /// Set difference (self - other) — takes the universe of all valid keys
+    /// so `All - Keys` resolves to the concrete complement (mirrors
+    /// [`Self::complement`]).
+    pub fn difference(&self, other: &Self, all_keys: &HashSet<PartitionKey>) -> Self {
         match (self, other) {
             (Self::Empty, _) => Self::Empty,
             (_, Self::All) => Self::Empty,
             (x, Self::Empty) => x.clone(),
-            (Self::All, Self::Keys(_)) => {
-                // Can't resolve `All - Keys` without the universe; shouldn't
-                // arise in practice (All only appears for unpartitioned assets
-                // or universal conditions). Fall back to All.
-                Self::All
-            }
+            (Self::All, Self::Keys(_)) => other.complement(all_keys),
             (Self::Keys(a), Self::Keys(b)) => {
                 let diff: HashSet<PartitionKey> = a.difference(b).cloned().collect();
                 if diff.is_empty() {

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -768,7 +768,10 @@ impl ConditionPass {
 
         let mut single_partition_groups: HashMap<PartitionKey, Vec<String>> = HashMap::new();
         let mut multi_partition_backfills: Vec<(String, Vec<PartitionKey>)> = Vec::new();
-        for (asset_key, partition_keys) in partitioned_mats {
+        for (asset_key, mut partition_keys) in partitioned_mats {
+            // Selections come out of HashSets (per-process random order); the
+            // list persists into backfill records and drives dispatch order.
+            partition_keys.sort_by_cached_key(|k| k.to_display());
             if partition_keys.len() == 1 {
                 single_partition_groups
                     .entry(partition_keys.into_iter().next().unwrap())
@@ -1158,6 +1161,45 @@ mod tests {
             !handled.contains(&spk("2024-08-16")),
             "dropped keys must not be marked handled"
         );
+    }
+
+    #[test]
+    fn classify_orders_partition_keys_canonically() {
+        // HashSet iteration order is per-process random; the dispatched key
+        // list persists into durable backfill records and drives run order,
+        // so it must come out in canonical display order.
+        let days: Vec<String> = (1..=12).map(|d| format!("2024-01-{d:02}")).collect();
+        let day_refs: Vec<&str> = days.iter().map(String::as_str).collect();
+        let mut pass = ConditionPass::new(
+            AssetConditionCache::default(),
+            ConditionEvalState::default(),
+            vec![AssetConditionInfo {
+                asset_key: "down".to_string(),
+                condition: ConditionNode::InProgress,
+                partition_info: Some(PartitionInfo {
+                    all_keys: make_daily_keys(&day_refs),
+                    mappings: HashMap::new(),
+                    time_window_fmt: None,
+                    universe: PartitionUniverse::Frozen,
+                }),
+                backfill_strategy: None,
+            }],
+            HashMap::new(),
+        );
+        pass.eval_state.assets.insert(
+            "down".to_string(),
+            crate::condition::state::AssetConditionState::default(),
+        );
+        let plan = pass.classify_materializations(vec![ToMaterialize {
+            asset_key: "down".to_string(),
+            selection: Some(PartitionSelection::All),
+        }]);
+        let mut backfills = plan.multi_partition_backfills;
+        let (_, keys) = backfills.pop().unwrap();
+        let display: Vec<String> = keys.iter().map(|k| k.to_display()).collect();
+        let mut sorted = display.clone();
+        sorted.sort_unstable();
+        assert_eq!(display, sorted, "dispatched keys must be display-ordered");
     }
 
     #[test]

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -286,10 +286,13 @@ pub struct PassOutput {
 /// Compute partition keys that fall within the latest time window.
 ///
 /// Partition keys are wall-clock labels, so the comparison happens on the
-/// wall-clock timeline: `now_local` is the current local naive datetime, and
-/// keys within `[now_local - lookback_delta, now_local]` are selected
-/// (`lookback_delta` is in seconds). If `lookback_delta` is `None`, only the
-/// single latest started window is returned.
+/// wall-clock timeline: `now_local` is the current local naive datetime. If
+/// `lookback_delta` is `None`, only the single latest started window is
+/// returned. With a lookback the cutoff anchors at that latest window's
+/// START — keys within `[latest_start - lookback_delta, latest_start]` are
+/// selected (`lookback_delta` in seconds) — so the selection never depends
+/// on how far into the current window `now` falls, and a lookback of one
+/// period reaches exactly one window back.
 pub fn compute_latest_time_window_keys(
     all_keys: &HashSet<PartitionKey>,
     fmt: &str,
@@ -320,10 +323,11 @@ pub fn compute_latest_time_window_keys(
 
     match lookback_delta {
         Some(delta_secs) => {
+            let latest_start = parsed[0].1;
             let lookback_nanos = (delta_secs * 1_000_000_000.0) as i64;
             // A lookback too large to subtract means "no cutoff".
             let cutoff =
-                now_local.checked_sub_signed(chrono::Duration::nanoseconds(lookback_nanos));
+                latest_start.checked_sub_signed(chrono::Duration::nanoseconds(lookback_nanos));
             parsed
                 .into_iter()
                 .filter(|(_, dt)| cutoff.is_none_or(|c| *dt >= c))
@@ -1225,8 +1229,9 @@ mod tests {
         let lookback_secs = 3.0 * 86400.0;
         let result =
             compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now, Some(lookback_secs));
-        // cutoff = 2026-03-23 01:00. 03-23 at midnight is before cutoff, excluded.
-        assert_eq!(result.len(), 3);
+        // cutoff = latest start (03-26) - 3d = 2026-03-23 00:00, inclusive.
+        assert_eq!(result.len(), 4);
+        assert!(result.contains(&spk("2026-03-23")));
         assert!(result.contains(&spk("2026-03-24")));
         assert!(result.contains(&spk("2026-03-25")));
         assert!(result.contains(&spk("2026-03-26")));
@@ -1247,10 +1252,35 @@ mod tests {
         let lookback_secs = 3.0 * 86400.0;
         let result =
             compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now, Some(lookback_secs));
-        assert_eq!(result.len(), 3);
+        assert_eq!(result.len(), 4);
+        assert!(result.contains(&spk("2026-03-18")));
         assert!(result.contains(&spk("2026-03-19")));
         assert!(result.contains(&spk("2026-03-20")));
         assert!(result.contains(&spk("2026-03-21")));
+    }
+
+    #[test]
+    fn lookback_smaller_than_period_still_selects_latest_window() {
+        // The cutoff anchors at the latest window START, not `now`: a lookback
+        // smaller than the period must select exactly the latest window (same
+        // as lookback=None), never an empty set.
+        let all_keys = make_daily_keys(&["2026-03-24", "2026-03-25", "2026-03-26"]);
+        let now = to_wall("2026-03-26 12:00");
+        let result = compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now, Some(3600.0));
+        assert_eq!(result.len(), 1, "1h lookback at 12:00 must not go empty");
+        assert!(result.contains(&spk("2026-03-26")));
+    }
+
+    #[test]
+    fn lookback_of_one_period_selects_previous_window_all_day() {
+        // lookback = one period reaches exactly one window back regardless of
+        // where inside the latest window `now` falls.
+        let all_keys = make_daily_keys(&["2026-03-24", "2026-03-25", "2026-03-26"]);
+        let now = to_wall("2026-03-26 23:59");
+        let result = compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now, Some(86400.0));
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&spk("2026-03-25")));
+        assert!(result.contains(&spk("2026-03-26")));
     }
 
     #[test]
@@ -1284,8 +1314,9 @@ mod tests {
         let lookback_secs = 3.0 * 3600.0;
         let result =
             compute_latest_time_window_keys(&all_keys, "%Y-%m-%dT%H:%M", now, Some(lookback_secs));
-        // cutoff = 09:30; keys >= 09:30: 10:00, 11:00, 12:00.
-        assert_eq!(result.len(), 3);
+        // cutoff = latest start (12:00) - 3h = 09:00, inclusive.
+        assert_eq!(result.len(), 4);
+        assert!(result.contains(&spk("2026-03-25T09:00")));
         assert!(result.contains(&spk("2026-03-25T10:00")));
         assert!(result.contains(&spk("2026-03-25T11:00")));
         assert!(result.contains(&spk("2026-03-25T12:00")));

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -193,26 +193,35 @@ fn refresh_universe(
 }
 
 /// Cartesian product of dimension key lists as `Multi` keys (def order).
+/// Walks an index odometer so each key is built exactly once — no
+/// intermediate combo vectors.
 fn cartesian_universe(dims: &[(String, DimensionUniverse)]) -> HashSet<PartitionKey> {
-    if dims.is_empty() {
+    if dims.is_empty() || dims.iter().any(|(_, du)| du.keys.is_empty()) {
         return HashSet::new();
     }
-    let mut combos: Vec<Vec<(String, Vec<String>)>> = vec![Vec::new()];
-    for (name, du) in dims {
-        let mut next = Vec::with_capacity(combos.len() * du.keys.len().max(1));
-        for combo in &combos {
-            for v in &du.keys {
-                let mut c = combo.clone();
-                c.push((name.clone(), vec![v.clone()]));
-                next.push(c);
+    let mut out = HashSet::new();
+    let mut idx = vec![0usize; dims.len()];
+    loop {
+        out.insert(PartitionKey::Multi {
+            dims: dims
+                .iter()
+                .zip(&idx)
+                .map(|((name, du), &i)| (name.clone(), vec![du.keys[i].clone()]))
+                .collect(),
+        });
+        let mut d = dims.len();
+        loop {
+            if d == 0 {
+                return out;
             }
+            d -= 1;
+            idx[d] += 1;
+            if idx[d] < dims[d].1.keys.len() {
+                break;
+            }
+            idx[d] = 0;
         }
-        combos = next;
     }
-    combos
-        .into_iter()
-        .map(|dims| PartitionKey::Multi { dims })
-        .collect()
 }
 
 /// Collect the dynamic namespaces a universe depends on.

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -677,6 +677,17 @@ impl ConditionPass {
         to_materialize
     }
 
+    /// Record dispatched partition keys in the asset's `handled` set so
+    /// since-last-handled semantics don't re-fire them on the next tick.
+    fn mark_partitions_handled(&mut self, asset_key: &str, keys: &[PartitionKey]) {
+        if let Some(prev) = self.eval_state.assets.get_mut(asset_key) {
+            prev.partition_state
+                .get_or_insert_with(PartitionState::default)
+                .handled
+                .extend(keys.iter().cloned());
+        }
+    }
+
     /// Split the materialization list into the three dispatch shapes:
     /// * unpartitioned bulk
     /// * single-partition groups (bucketed by partition key)
@@ -689,17 +700,6 @@ impl ConditionPass {
     /// in-progress before the dispatch loop pushes any run ids, and records
     /// the surviving keys in the asset's `handled` set — only keys actually
     /// dispatched may suppress future fires.
-    /// Record dispatched partition keys in the asset's `handled` set so
-    /// since-last-handled semantics don't re-fire them on the next tick.
-    fn mark_partitions_handled(&mut self, asset_key: &str, keys: &[PartitionKey]) {
-        if let Some(prev) = self.eval_state.assets.get_mut(asset_key) {
-            prev.partition_state
-                .get_or_insert_with(PartitionState::default)
-                .handled
-                .extend(keys.iter().cloned());
-        }
-    }
-
     fn classify_materializations(
         &mut self,
         to_materialize: Vec<ToMaterialize>,

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -22,7 +22,7 @@ use crate::condition::state::{
 use crate::storage::{BackfillStrategy, PartitionKey, StorageBackend};
 use crate::timegrid::TimeGrid;
 use crate::util::parse_key_datetime;
-use chrono::NaiveDateTime;
+use chrono::{NaiveDateTime, TimeZone};
 
 /// Info about an asset with an automation condition, extracted at daemon
 /// start. Pure-Rust so the per-tick evaluation loop can run inside
@@ -273,37 +273,26 @@ pub struct PassOutput {
 
 /// Compute partition keys that fall within the latest time window.
 ///
-/// For time-windowed partitions (daily, hourly, etc.), parses each partition
-/// key as a datetime using `fmt`, then selects keys whose time is within
-/// `[now_nanos - lookback_delta * 1e9, now_nanos]` (`lookback_delta` is in
-/// seconds). If `lookback_delta` is `None`, only the single latest partition
-/// is returned.
+/// Partition keys are wall-clock labels, so the comparison happens on the
+/// wall-clock timeline: `now_local` is the current local naive datetime, and
+/// keys within `[now_local - lookback_delta, now_local]` are selected
+/// (`lookback_delta` is in seconds). If `lookback_delta` is `None`, only the
+/// single latest started window is returned.
 pub fn compute_latest_time_window_keys(
     all_keys: &HashSet<PartitionKey>,
     fmt: &str,
-    now_nanos: i64,
+    now_local: NaiveDateTime,
     lookback_delta: Option<f64>,
 ) -> HashSet<PartitionKey> {
-    let parse_nanos = |s: &str| -> Option<i64> {
-        parse_key_datetime(s, fmt)
-            .ok()?
-            .and_utc()
-            .timestamp_nanos_opt()
-    };
-
-    let mut parsed: Vec<(&PartitionKey, i64)> = all_keys
+    let mut parsed: Vec<(&PartitionKey, NaiveDateTime)> = all_keys
         .iter()
         .filter_map(|pk| {
             let key_str = match pk {
                 PartitionKey::Single { keys } if !keys.is_empty() => &keys[0],
                 _ => return None,
             };
-            let nanos = parse_nanos(key_str)?;
-            if nanos <= now_nanos {
-                Some((pk, nanos))
-            } else {
-                None
-            }
+            let dt = parse_key_datetime(key_str, fmt).ok()?;
+            if dt <= now_local { Some((pk, dt)) } else { None }
         })
         .collect();
 
@@ -316,10 +305,13 @@ pub fn compute_latest_time_window_keys(
     match lookback_delta {
         Some(delta_secs) => {
             let lookback_nanos = (delta_secs * 1_000_000_000.0) as i64;
-            let cutoff = now_nanos - lookback_nanos;
+            // A lookback too large to subtract means "no cutoff".
+            let cutoff = now_local.checked_sub_signed(chrono::Duration::nanoseconds(
+                lookback_nanos,
+            ));
             parsed
                 .into_iter()
-                .filter(|(_, ts)| *ts >= cutoff)
+                .filter(|(_, dt)| cutoff.is_none_or(|c| *dt >= c))
                 .map(|(pk, _)| pk.clone())
                 .collect()
         }
@@ -487,6 +479,11 @@ impl ConditionPass {
     }
 
     fn evaluate(&self, now: i64, selective: bool) -> Vec<EvalResultRow> {
+        // Partition keys are wall-clock labels; latest-window math compares
+        // them against the local naive reading of the tick instant.
+        let now_local = chrono::Local
+            .timestamp_nanos(now)
+            .naive_local();
         let in_progress_keys: HashSet<String> =
             self.cache.in_progress_assets.keys().cloned().collect();
 
@@ -513,7 +510,7 @@ impl ConditionPass {
                 Some(compute_latest_time_window_keys(
                     &pi.all_keys,
                     fmt,
-                    now,
+                    now_local,
                     lookback,
                 ))
             });
@@ -777,13 +774,9 @@ mod tests {
         keys.iter().map(|k| spk(k)).collect()
     }
 
-    /// Helper: convert "YYYY-MM-DD HH:MM" to nanos.
-    fn to_nanos(dt_str: &str) -> i64 {
-        chrono::NaiveDateTime::parse_from_str(dt_str, "%Y-%m-%d %H:%M")
-            .unwrap()
-            .and_utc()
-            .timestamp_nanos_opt()
-            .unwrap()
+    /// Helper: parse "YYYY-MM-DD HH:MM" as a wall-clock naive datetime.
+    fn to_wall(dt_str: &str) -> NaiveDateTime {
+        chrono::NaiveDateTime::parse_from_str(dt_str, "%Y-%m-%d %H:%M").unwrap()
     }
 
     #[test]
@@ -1083,9 +1076,28 @@ mod tests {
     }
 
     #[test]
+    fn latest_window_tracks_wall_clock_on_non_utc_hosts() {
+        // Partition keys are wall-clock labels. On a UTC+2 host at 10:30
+        // local, now_ts() reads 08:30Z — the latest window is still the
+        // 10:00 wall-clock one, not 08:00. `evaluate` converts the tick
+        // instant to local naive before calling this, so the helper itself
+        // compares wall clock to wall clock.
+        let all_keys = make_daily_keys(&[
+            "2026-06-11T08:00",
+            "2026-06-11T09:00",
+            "2026-06-11T10:00",
+        ]);
+        let now_local = to_wall("2026-06-11 10:30");
+        let result =
+            compute_latest_time_window_keys(&all_keys, "%Y-%m-%dT%H:%M", now_local, None);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&spk("2026-06-11T10:00")));
+    }
+
+    #[test]
     fn test_compute_at_start_date_includes_current() {
         let all_keys = make_daily_keys(&["2026-03-01"]);
-        let now = to_nanos("2026-03-01 00:00");
+        let now = to_wall("2026-03-01 00:00");
         let result = compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now, None);
         assert_eq!(result.len(), 1);
         assert!(result.contains(&spk("2026-03-01")));
@@ -1094,7 +1106,7 @@ mod tests {
     #[test]
     fn test_compute_latest_single_partition_no_lookback() {
         let all_keys = make_daily_keys(&["2026-03-20", "2026-03-21", "2026-03-22", "2026-03-23"]);
-        let now = to_nanos("2026-03-23 01:00");
+        let now = to_wall("2026-03-23 01:00");
         let result = compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now, None);
         assert_eq!(result.len(), 1);
         assert!(result.contains(&spk("2026-03-23")));
@@ -1111,12 +1123,12 @@ mod tests {
             "2026-03-25",
             "2026-03-26",
         ]);
-        let now1 = to_nanos("2026-03-22 01:00");
+        let now1 = to_wall("2026-03-22 01:00");
         let r1 = compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now1, None);
         assert_eq!(r1.len(), 1);
         assert!(r1.contains(&spk("2026-03-22")));
 
-        let now2 = to_nanos("2026-03-26 01:00");
+        let now2 = to_wall("2026-03-26 01:00");
         let r2 = compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now2, None);
         assert_eq!(r2.len(), 1);
         assert!(r2.contains(&spk("2026-03-26")));
@@ -1133,7 +1145,7 @@ mod tests {
             "2026-03-25",
             "2026-03-26",
         ]);
-        let now = to_nanos("2026-03-26 01:00");
+        let now = to_wall("2026-03-26 01:00");
         let lookback_secs = 3.0 * 86400.0;
         let result =
             compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now, Some(lookback_secs));
@@ -1155,7 +1167,7 @@ mod tests {
             "2026-03-20",
             "2026-03-21",
         ]);
-        let now = to_nanos("2026-03-21 01:00");
+        let now = to_wall("2026-03-21 01:00");
         let lookback_secs = 3.0 * 86400.0;
         let result =
             compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now, Some(lookback_secs));
@@ -1168,7 +1180,7 @@ mod tests {
     #[test]
     fn test_compute_future_partitions_excluded() {
         let all_keys = make_daily_keys(&["2026-03-24", "2026-03-25", "2027-12-31"]);
-        let now = to_nanos("2026-03-25 12:00");
+        let now = to_wall("2026-03-25 12:00");
         let result = compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now, None);
         assert_eq!(result.len(), 1);
         assert!(result.contains(&spk("2026-03-25")));
@@ -1178,7 +1190,7 @@ mod tests {
     #[test]
     fn test_compute_empty_keys() {
         let all_keys: HashSet<PartitionKey> = HashSet::new();
-        let now = to_nanos("2026-03-25 12:00");
+        let now = to_wall("2026-03-25 12:00");
         let result = compute_latest_time_window_keys(&all_keys, "%Y-%m-%d", now, None);
         assert!(result.is_empty());
     }
@@ -1192,7 +1204,7 @@ mod tests {
             "2026-03-25T11:00",
             "2026-03-25T12:00",
         ]);
-        let now = to_nanos("2026-03-25 12:30");
+        let now = to_wall("2026-03-25 12:30");
         let lookback_secs = 3.0 * 3600.0;
         let result =
             compute_latest_time_window_keys(&all_keys, "%Y-%m-%dT%H:%M", now, Some(lookback_secs));

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -119,12 +119,13 @@ fn refresh_universe(
                     for k in new_keys {
                         changed |= all_keys.insert(PartitionKey::Single { keys: vec![k] });
                     }
+                    *enumerated_to = bound;
                 }
                 Err(e) => {
+                    // Leave the watermark so the range is retried next tick.
                     tracing::warn!(target: "rivers::daemon", error = %e, "time-window universe refresh failed");
                 }
             }
-            *enumerated_to = bound;
             changed
         }
         PartitionUniverse::Dynamic { namespace } => {
@@ -157,16 +158,18 @@ fn refresh_universe(
                             continue;
                         }
                         match grid.window_starts_in(*enumerated_to, bound) {
-                            Ok(new_keys) if !new_keys.is_empty() => {
-                                du.keys.extend(new_keys);
-                                changed = true;
+                            Ok(new_keys) => {
+                                if !new_keys.is_empty() {
+                                    du.keys.extend(new_keys);
+                                    changed = true;
+                                }
+                                *enumerated_to = bound;
                             }
-                            Ok(_) => {}
                             Err(e) => {
+                                // Leave the watermark so the range is retried.
                                 tracing::warn!(target: "rivers::daemon", error = %e, "time-window dimension refresh failed");
                             }
                         }
-                        *enumerated_to = bound;
                     }
                     DimensionKind::Dynamic { namespace } => {
                         if let Some(keys) = dynamic_keys.get(namespace)
@@ -883,6 +886,66 @@ mod tests {
             &HashMap::new(),
         );
         assert_eq!(all_keys.len(), 4);
+    }
+
+    #[test]
+    fn refresh_universe_holds_watermark_on_enumeration_error() {
+        // A grid that can't enumerate must not advance `enumerated_to` past
+        // the failed range — those windows would be skipped forever once the
+        // grid recovers. Unreachable through validated constructors today;
+        // guards against a future Err source.
+        let broken = TimeGrid {
+            cron_schedule: None,
+            interval_seconds: None,
+            start: naive("2024-01-01T00:00:00"),
+            end: None,
+            fmt: "%Y-%m-%dT%H:%M:%S".into(),
+        };
+        let t0 = naive("2024-01-01T00:00:00");
+        let mut universe = PartitionUniverse::TimeWindow {
+            grid: broken.clone(),
+            enumerated_to: t0,
+        };
+        let mut all_keys: HashSet<PartitionKey> = HashSet::new();
+        let changed = refresh_universe(
+            &mut universe,
+            &mut all_keys,
+            naive("2024-01-01T05:00:00"),
+            &HashMap::new(),
+        );
+        assert!(!changed);
+        assert!(all_keys.is_empty());
+        let PartitionUniverse::TimeWindow { enumerated_to, .. } = &universe else {
+            unreachable!()
+        };
+        assert_eq!(*enumerated_to, t0, "failed ranges must be retried");
+
+        let mut multi = PartitionUniverse::Multi {
+            dims: vec![(
+                "date".to_string(),
+                DimensionUniverse {
+                    keys: vec![],
+                    kind: DimensionKind::TimeWindow {
+                        grid: broken,
+                        enumerated_to: t0,
+                    },
+                },
+            )],
+        };
+        let changed = refresh_universe(
+            &mut multi,
+            &mut all_keys,
+            naive("2024-01-01T05:00:00"),
+            &HashMap::new(),
+        );
+        assert!(!changed);
+        let PartitionUniverse::Multi { dims } = &multi else {
+            unreachable!()
+        };
+        let DimensionKind::TimeWindow { enumerated_to, .. } = &dims[0].1.kind else {
+            unreachable!()
+        };
+        assert_eq!(*enumerated_to, t0, "failed dim ranges must be retried");
     }
 
     #[test]

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -13,6 +13,7 @@ use crate::condition::eval::evaluate_with_tree;
 use crate::condition::node::ConditionNode;
 use crate::condition::partition::{
     PartitionEvalContext, PartitionMappingKind, PartitionResolver, PartitionSelection,
+    PartitionState,
 };
 use crate::condition::state::{
     CacheSnapshot, ConditionEvalState, EvalContext, EvalNodeResult, EvalResult, RunTagSnapshot,
@@ -421,7 +422,9 @@ impl ConditionPass {
     /// resolved to all of the asset's partition keys; for an unpartitioned
     /// asset they collapse to the bulk path. Marks each materialized asset
     /// present in `cache.in_progress_assets` so subsequent ticks see it as
-    /// in-progress before the dispatch loop pushes any run ids.
+    /// in-progress before the dispatch loop pushes any run ids, and records
+    /// the surviving keys in the asset's `handled` set — only keys actually
+    /// dispatched may suppress future fires.
     fn classify_materializations(
         &mut self,
         to_materialize: Vec<ToMaterialize>,
@@ -462,6 +465,12 @@ impl ConditionPass {
                         );
                     }
                     if !surviving.is_empty() {
+                        if let Some(prev) = self.eval_state.assets.get_mut(tm.asset_key.as_str()) {
+                            prev.partition_state
+                                .get_or_insert_with(PartitionState::default)
+                                .handled
+                                .extend(surviving.iter().cloned());
+                        }
                         partitioned_mats.push((tm.asset_key, surviving));
                     }
                 }
@@ -589,6 +598,76 @@ mod tests {
             )),
         }]);
         assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn update_state_leaves_handled_to_classification() {
+        // The raw selection may name keys classification will drop (mapped
+        // keys the asset doesn't have). Marking them handled here would
+        // suppress them forever once they become real.
+        let mut state = crate::condition::state::AssetConditionState::default();
+        let timestamps: HashMap<PartitionKey, i64> = HashMap::new();
+        let ctx = StateUpdateContext {
+            target_record_timestamp: None,
+            target_data_version: None,
+            now: 1,
+            is_initial: false,
+            partition_timestamps: Some(&timestamps),
+        };
+        let result = EvalResult {
+            fired: true,
+            selection: Some(PartitionSelection::Keys(
+                [spk("2024-08-16")].into_iter().collect(),
+            )),
+            sub_selections: Some(HashMap::new()),
+            ..Default::default()
+        };
+        update_condition_state(&mut state, &ctx, &result);
+        let ps = state.partition_state.as_ref().expect("partition state");
+        assert!(
+            ps.handled.is_empty(),
+            "handled must be extended from the classified plan, not the raw selection"
+        );
+    }
+
+    #[test]
+    fn classify_marks_only_surviving_keys_handled() {
+        let mut pass = ConditionPass::new(
+            AssetConditionCache::default(),
+            ConditionEvalState::default(),
+            vec![AssetConditionInfo {
+                asset_key: "down".to_string(),
+                condition: ConditionNode::InProgress,
+                partition_info: Some(PartitionInfo {
+                    all_keys: make_daily_keys(&["2024-01-01", "2024-01-02"]),
+                    mappings: HashMap::new(),
+                    time_window_fmt: None,
+                }),
+                backfill_strategy: None,
+            }],
+            HashMap::new(),
+        );
+        pass.eval_state.assets.insert(
+            "down".to_string(),
+            crate::condition::state::AssetConditionState::default(),
+        );
+        pass.classify_materializations(vec![ToMaterialize {
+            asset_key: "down".to_string(),
+            selection: Some(PartitionSelection::Keys(
+                [spk("2024-01-02"), spk("2024-08-16")].into_iter().collect(),
+            )),
+        }]);
+        let handled = pass.eval_state.assets["down"]
+            .partition_state
+            .as_ref()
+            .expect("partition state")
+            .handled
+            .clone();
+        assert!(handled.contains(&spk("2024-01-02")));
+        assert!(
+            !handled.contains(&spk("2024-08-16")),
+            "dropped keys must not be marked handled"
+        );
     }
 
     #[test]

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -665,6 +665,17 @@ impl ConditionPass {
     /// in-progress before the dispatch loop pushes any run ids, and records
     /// the surviving keys in the asset's `handled` set — only keys actually
     /// dispatched may suppress future fires.
+    /// Record dispatched partition keys in the asset's `handled` set so
+    /// since-last-handled semantics don't re-fire them on the next tick.
+    fn mark_partitions_handled(&mut self, asset_key: &str, keys: &[PartitionKey]) {
+        if let Some(prev) = self.eval_state.assets.get_mut(asset_key) {
+            prev.partition_state
+                .get_or_insert_with(PartitionState::default)
+                .handled
+                .extend(keys.iter().cloned());
+        }
+    }
+
     fn classify_materializations(
         &mut self,
         to_materialize: Vec<ToMaterialize>,
@@ -705,12 +716,7 @@ impl ConditionPass {
                         );
                     }
                     if !surviving.is_empty() {
-                        if let Some(prev) = self.eval_state.assets.get_mut(tm.asset_key.as_str()) {
-                            prev.partition_state
-                                .get_or_insert_with(PartitionState::default)
-                                .handled
-                                .extend(surviving.iter().cloned());
-                        }
+                        self.mark_partitions_handled(&tm.asset_key, &surviving);
                         partitioned_mats.push((tm.asset_key, surviving));
                     }
                 }
@@ -723,6 +729,7 @@ impl ConditionPass {
                         .map(|pi| pi.all_keys.iter().cloned().collect::<Vec<_>>());
                     match resolved {
                         Some(all_keys) if !all_keys.is_empty() => {
+                            self.mark_partitions_handled(&tm.asset_key, &all_keys);
                             partitioned_mats.push((tm.asset_key, all_keys));
                         }
                         Some(_) => {} // partitioned asset with zero keys — drop
@@ -1026,6 +1033,53 @@ mod tests {
             !handled.contains(&spk("2024-08-16")),
             "dropped keys must not be marked handled"
         );
+    }
+
+    #[test]
+    fn classify_marks_all_selection_keys_handled() {
+        // A partitioned asset can fire with `All` — e.g. an unpartitioned
+        // upstream dep evaluates to a bool selection that widens to every
+        // partition. The dispatched keys must land in `handled` exactly like
+        // a Keys selection, or since-last-handled semantics re-fire the
+        // whole asset on every tick.
+        let mut pass = ConditionPass::new(
+            AssetConditionCache::default(),
+            ConditionEvalState::default(),
+            vec![AssetConditionInfo {
+                asset_key: "down".to_string(),
+                condition: ConditionNode::InProgress,
+                partition_info: Some(PartitionInfo {
+                    all_keys: make_daily_keys(&["2024-01-01", "2024-01-02"]),
+                    mappings: HashMap::new(),
+                    time_window_fmt: None,
+                    universe: PartitionUniverse::Frozen,
+                }),
+                backfill_strategy: None,
+            }],
+            HashMap::new(),
+        );
+        pass.eval_state.assets.insert(
+            "down".to_string(),
+            crate::condition::state::AssetConditionState::default(),
+        );
+        let plan = pass.classify_materializations(vec![ToMaterialize {
+            asset_key: "down".to_string(),
+            selection: Some(PartitionSelection::All),
+        }]);
+        let mut backfills = plan.multi_partition_backfills;
+        assert_eq!(backfills.len(), 1, "All must dispatch the asset's partitions");
+        let (asset, mut keys) = backfills.pop().unwrap();
+        assert_eq!(asset, "down");
+        keys.sort_by_key(|k| format!("{k:?}"));
+        assert_eq!(keys, vec![spk("2024-01-01"), spk("2024-01-02")]);
+        let handled = pass.eval_state.assets["down"]
+            .partition_state
+            .as_ref()
+            .expect("partition state")
+            .handled
+            .clone();
+        assert!(handled.contains(&spk("2024-01-01")));
+        assert!(handled.contains(&spk("2024-01-02")));
     }
 
     #[test]

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -20,7 +20,9 @@ use crate::condition::state::{
     StateUpdateContext, update_condition_state, update_dep_baselines,
 };
 use crate::storage::{BackfillStrategy, PartitionKey, StorageBackend};
+use crate::timegrid::TimeGrid;
 use crate::util::parse_key_datetime;
+use chrono::NaiveDateTime;
 
 /// Info about an asset with an automation condition, extracted at daemon
 /// start. Pure-Rust so the per-tick evaluation loop can run inside
@@ -37,13 +39,194 @@ pub struct AssetConditionInfo {
 
 /// Partition-level info for a partitioned asset, extracted at daemon start.
 pub struct PartitionInfo {
-    /// All valid partition keys for this asset.
+    /// All valid partition keys for this asset, advanced per tick by
+    /// [`ConditionPass::refresh_partition_universes`].
     pub all_keys: HashSet<PartitionKey>,
     /// Partition mappings for upstream deps. Key = `(this_asset, upstream_asset)`.
     pub mappings: HashMap<(String, String), PartitionMappingKind>,
     /// For time-windowed partitions: the format string used to parse keys.
     /// Used by `InLatestTimeWindow` to select recent partitions per-tick.
     pub time_window_fmt: Option<String>,
+    /// How `all_keys` evolves after extraction.
+    pub universe: PartitionUniverse,
+}
+
+/// How an asset's partition universe evolves after extraction. A universe
+/// frozen at daemon start silently stops automation for open-ended time
+/// windows and never starts it for dynamic partitions.
+#[derive(Clone, Debug)]
+pub enum PartitionUniverse {
+    /// Fixed key set (Static definitions).
+    Frozen,
+    /// Window starts enter the universe as wall-clock time passes
+    /// (and stop at the grid's explicit end, when there is one).
+    TimeWindow {
+        grid: TimeGrid,
+        enumerated_to: NaiveDateTime,
+    },
+    /// Storage-managed: the key set mirrors the `dynamic_partitions`
+    /// namespace, including retirements.
+    Dynamic { namespace: String },
+    /// Cartesian product over dimensions; recomputed when any dimension's
+    /// key list changes.
+    Multi {
+        dims: Vec<(String, DimensionUniverse)>,
+    },
+}
+
+/// One dimension of a Multi universe: its current key list plus how it evolves.
+#[derive(Clone, Debug)]
+pub struct DimensionUniverse {
+    pub keys: Vec<String>,
+    pub kind: DimensionKind,
+}
+
+#[derive(Clone, Debug)]
+pub enum DimensionKind {
+    Frozen,
+    TimeWindow {
+        grid: TimeGrid,
+        enumerated_to: NaiveDateTime,
+    },
+    Dynamic {
+        namespace: String,
+    },
+}
+
+/// Advance one universe, mutating `all_keys` in place. Returns whether the
+/// key set changed. `dynamic_keys` maps namespace → currently registered
+/// keys; a namespace missing from the map (storage failure) leaves the
+/// previous set untouched — stale beats empty.
+fn refresh_universe(
+    universe: &mut PartitionUniverse,
+    all_keys: &mut HashSet<PartitionKey>,
+    now: NaiveDateTime,
+    dynamic_keys: &HashMap<String, HashSet<String>>,
+) -> bool {
+    match universe {
+        PartitionUniverse::Frozen => false,
+        PartitionUniverse::TimeWindow {
+            grid,
+            enumerated_to,
+        } => {
+            let bound = grid.end.map_or(now, |e| e.min(now));
+            if bound <= *enumerated_to {
+                return false;
+            }
+            let mut changed = false;
+            match grid.window_starts_in(*enumerated_to, bound) {
+                Ok(new_keys) => {
+                    for k in new_keys {
+                        changed |= all_keys.insert(PartitionKey::Single { keys: vec![k] });
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(target: "rivers::daemon", error = %e, "time-window universe refresh failed");
+                }
+            }
+            *enumerated_to = bound;
+            changed
+        }
+        PartitionUniverse::Dynamic { namespace } => {
+            let Some(keys) = dynamic_keys.get(namespace) else {
+                return false;
+            };
+            let new_set: HashSet<PartitionKey> = keys
+                .iter()
+                .map(|k| PartitionKey::Single {
+                    keys: vec![k.clone()],
+                })
+                .collect();
+            if new_set == *all_keys {
+                return false;
+            }
+            *all_keys = new_set;
+            true
+        }
+        PartitionUniverse::Multi { dims } => {
+            let mut changed = false;
+            for (_, du) in dims.iter_mut() {
+                match &mut du.kind {
+                    DimensionKind::Frozen => {}
+                    DimensionKind::TimeWindow {
+                        grid,
+                        enumerated_to,
+                    } => {
+                        let bound = grid.end.map_or(now, |e| e.min(now));
+                        if bound <= *enumerated_to {
+                            continue;
+                        }
+                        match grid.window_starts_in(*enumerated_to, bound) {
+                            Ok(new_keys) if !new_keys.is_empty() => {
+                                du.keys.extend(new_keys);
+                                changed = true;
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                tracing::warn!(target: "rivers::daemon", error = %e, "time-window dimension refresh failed");
+                            }
+                        }
+                        *enumerated_to = bound;
+                    }
+                    DimensionKind::Dynamic { namespace } => {
+                        if let Some(keys) = dynamic_keys.get(namespace)
+                            && (keys.len() != du.keys.len()
+                                || !du.keys.iter().all(|k| keys.contains(k)))
+                        {
+                            let mut sorted: Vec<String> = keys.iter().cloned().collect();
+                            sorted.sort();
+                            du.keys = sorted;
+                            changed = true;
+                        }
+                    }
+                }
+            }
+            if changed {
+                *all_keys = cartesian_universe(dims);
+            }
+            changed
+        }
+    }
+}
+
+/// Cartesian product of dimension key lists as `Multi` keys (def order).
+fn cartesian_universe(dims: &[(String, DimensionUniverse)]) -> HashSet<PartitionKey> {
+    if dims.is_empty() {
+        return HashSet::new();
+    }
+    let mut combos: Vec<Vec<(String, Vec<String>)>> = vec![Vec::new()];
+    for (name, du) in dims {
+        let mut next = Vec::with_capacity(combos.len() * du.keys.len().max(1));
+        for combo in &combos {
+            for v in &du.keys {
+                let mut c = combo.clone();
+                c.push((name.clone(), vec![v.clone()]));
+                next.push(c);
+            }
+        }
+        combos = next;
+    }
+    combos
+        .into_iter()
+        .map(|dims| PartitionKey::Multi { dims })
+        .collect()
+}
+
+/// Collect the dynamic namespaces a universe depends on.
+fn universe_namespaces(universe: &PartitionUniverse, out: &mut HashSet<String>) {
+    match universe {
+        PartitionUniverse::Dynamic { namespace } => {
+            out.insert(namespace.clone());
+        }
+        PartitionUniverse::Multi { dims } => {
+            for (_, du) in dims {
+                if let DimensionKind::Dynamic { namespace } = &du.kind {
+                    out.insert(namespace.clone());
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 /// One row of the per-asset evaluation result list, accumulated during
@@ -161,6 +344,9 @@ pub struct ConditionPass {
     /// when storage hasn't changed but time-based conditions need re-eval.
     pub time_based_eval_set: Option<HashSet<String>>,
     pub upstream_partition_keys: HashMap<String, HashSet<PartitionKey>>,
+    /// How each `upstream_partition_keys` entry evolves. Entries for
+    /// conditioned assets are re-synced from their `PartitionInfo` instead.
+    pub upstream_universes: HashMap<String, PartitionUniverse>,
 }
 
 impl ConditionPass {
@@ -171,7 +357,7 @@ impl ConditionPass {
         cache: AssetConditionCache,
         eval_state: ConditionEvalState,
         conditions: Vec<AssetConditionInfo>,
-        upstream_partition_keys: HashMap<String, HashSet<PartitionKey>>,
+        upstream_partition_keys: HashMap<String, (HashSet<PartitionKey>, PartitionUniverse)>,
     ) -> Self {
         let conditions_by_key: HashMap<String, usize> = conditions
             .iter()
@@ -182,6 +368,12 @@ impl ConditionPass {
         let has_time_based = conditions
             .iter()
             .any(|c| c.condition.has_time_based_conditions());
+        let mut keys_map = HashMap::with_capacity(upstream_partition_keys.len());
+        let mut universes_map = HashMap::with_capacity(upstream_partition_keys.len());
+        for (k, (keys, universe)) in upstream_partition_keys {
+            keys_map.insert(k.clone(), keys);
+            universes_map.insert(k, universe);
+        }
         Self {
             cache,
             eval_state,
@@ -190,8 +382,56 @@ impl ConditionPass {
             active,
             has_time_based,
             time_based_eval_set: None,
-            upstream_partition_keys,
+            upstream_partition_keys: keys_map,
+            upstream_universes: universes_map,
         }
+    }
+
+    /// Dynamic namespaces any tracked universe depends on — the caller
+    /// fetches their current key sets and passes them to
+    /// [`refresh_partition_universes`](Self::refresh_partition_universes).
+    pub fn dynamic_universe_namespaces(&self) -> HashSet<String> {
+        let mut out = HashSet::new();
+        for info in &self.conditions {
+            if let Some(pi) = &info.partition_info {
+                universe_namespaces(&pi.universe, &mut out);
+            }
+        }
+        for universe in self.upstream_universes.values() {
+            universe_namespaces(universe, &mut out);
+        }
+        out
+    }
+
+    /// Advance every tracked partition universe to `now`: open time grids
+    /// gain newly started windows, dynamic namespaces mirror storage, and
+    /// conditioned assets' upstream entries re-sync from their refreshed
+    /// `PartitionInfo`. Returns whether any universe changed, so the caller
+    /// can force an eval even when the storage cache reports no changes.
+    pub fn refresh_partition_universes(
+        &mut self,
+        now: NaiveDateTime,
+        dynamic_keys: &HashMap<String, HashSet<String>>,
+    ) -> bool {
+        let mut changed = false;
+        for info in &mut self.conditions {
+            if let Some(pi) = info.partition_info.as_mut() {
+                changed |= refresh_universe(&mut pi.universe, &mut pi.all_keys, now, dynamic_keys);
+            }
+        }
+        for (asset, universe) in &mut self.upstream_universes {
+            if let Some(keys) = self.upstream_partition_keys.get_mut(asset) {
+                changed |= refresh_universe(universe, keys, now, dynamic_keys);
+            }
+        }
+        for info in &self.conditions {
+            if let Some(pi) = &info.partition_info
+                && let Some(entry) = self.upstream_partition_keys.get_mut(&info.asset_key)
+            {
+                entry.clone_from(&pi.all_keys);
+            }
+        }
+        changed
     }
 
     /// Refresh `cache` from storage atomically. Returns whether anything
@@ -555,6 +795,7 @@ mod tests {
                     all_keys: make_daily_keys(&["2024-01-01", "2024-01-02"]),
                     mappings: HashMap::new(),
                     time_window_fmt: None,
+                    universe: PartitionUniverse::Frozen,
                 }),
                 backfill_strategy: None,
             }],
@@ -586,6 +827,7 @@ mod tests {
                     all_keys: make_daily_keys(&["2024-01-01", "2024-01-02"]),
                     mappings: HashMap::new(),
                     time_window_fmt: None,
+                    universe: PartitionUniverse::Frozen,
                 }),
                 backfill_strategy: None,
             }],
@@ -598,6 +840,121 @@ mod tests {
             )),
         }]);
         assert!(plan.is_empty());
+    }
+
+    fn naive(s: &str) -> NaiveDateTime {
+        chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").unwrap()
+    }
+
+    fn hourly_grid() -> TimeGrid {
+        TimeGrid {
+            cron_schedule: None,
+            interval_seconds: Some(3600.0),
+            start: naive("2024-01-01T00:00:00"),
+            end: None,
+            fmt: "%Y-%m-%dT%H:%M:%S".into(),
+        }
+    }
+
+    #[test]
+    fn time_window_universe_gains_new_windows() {
+        let mut universe = PartitionUniverse::TimeWindow {
+            grid: hourly_grid(),
+            enumerated_to: naive("2024-01-01T01:30:00"),
+        };
+        let mut all_keys: HashSet<PartitionKey> =
+            [spk("2024-01-01T00:00:00"), spk("2024-01-01T01:00:00")]
+                .into_iter()
+                .collect();
+        refresh_universe(
+            &mut universe,
+            &mut all_keys,
+            naive("2024-01-01T03:10:00"),
+            &HashMap::new(),
+        );
+        assert!(all_keys.contains(&spk("2024-01-01T02:00:00")));
+        assert!(all_keys.contains(&spk("2024-01-01T03:00:00")));
+        assert_eq!(all_keys.len(), 4);
+        // Idempotent: a second refresh at the same now adds nothing.
+        refresh_universe(
+            &mut universe,
+            &mut all_keys,
+            naive("2024-01-01T03:10:00"),
+            &HashMap::new(),
+        );
+        assert_eq!(all_keys.len(), 4);
+    }
+
+    #[test]
+    fn dynamic_universe_mirrors_storage_including_retirement() {
+        let mut universe = PartitionUniverse::Dynamic {
+            namespace: "colors".into(),
+        };
+        let mut all_keys: HashSet<PartitionKey> = HashSet::new();
+        let now = naive("2024-01-01T00:00:00");
+        let registered: HashMap<String, HashSet<String>> = [(
+            "colors".to_string(),
+            ["red".to_string(), "blue".to_string()]
+                .into_iter()
+                .collect(),
+        )]
+        .into_iter()
+        .collect();
+        refresh_universe(&mut universe, &mut all_keys, now, &registered);
+        assert_eq!(all_keys, [spk("red"), spk("blue")].into_iter().collect());
+        // Retirement: the set mirrors storage, it doesn't only grow.
+        let shrunk: HashMap<String, HashSet<String>> = [(
+            "colors".to_string(),
+            ["blue".to_string()].into_iter().collect(),
+        )]
+        .into_iter()
+        .collect();
+        refresh_universe(&mut universe, &mut all_keys, now, &shrunk);
+        assert_eq!(all_keys, [spk("blue")].into_iter().collect());
+        // A namespace missing from the fetch (storage failure) keeps the
+        // previous set — stale beats empty.
+        refresh_universe(&mut universe, &mut all_keys, now, &HashMap::new());
+        assert_eq!(all_keys, [spk("blue")].into_iter().collect());
+    }
+
+    #[test]
+    fn multi_universe_recomputes_cartesian_on_dimension_change() {
+        let mut universe = PartitionUniverse::Multi {
+            dims: vec![
+                (
+                    "date".to_string(),
+                    DimensionUniverse {
+                        keys: vec!["2024-01-01T00:00:00".to_string()],
+                        kind: DimensionKind::TimeWindow {
+                            grid: hourly_grid(),
+                            enumerated_to: naive("2024-01-01T00:30:00"),
+                        },
+                    },
+                ),
+                (
+                    "region".to_string(),
+                    DimensionUniverse {
+                        keys: vec!["eu".to_string(), "us".to_string()],
+                        kind: DimensionKind::Frozen,
+                    },
+                ),
+            ],
+        };
+        let mut all_keys: HashSet<PartitionKey> = HashSet::new();
+        refresh_universe(
+            &mut universe,
+            &mut all_keys,
+            naive("2024-01-01T01:10:00"),
+            &HashMap::new(),
+        );
+        assert_eq!(all_keys.len(), 4);
+        let expected = PartitionKey::Multi {
+            dims: vec![
+                ("date".to_string(), vec!["2024-01-01T01:00:00".to_string()]),
+                ("region".to_string(), vec!["eu".to_string()]),
+            ],
+        };
+        assert!(all_keys.contains(&expected));
     }
 
     #[test]
@@ -642,6 +999,7 @@ mod tests {
                     all_keys: make_daily_keys(&["2024-01-01", "2024-01-02"]),
                     mappings: HashMap::new(),
                     time_window_fmt: None,
+                    universe: PartitionUniverse::Frozen,
                 }),
                 backfill_strategy: None,
             }],

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -436,7 +436,34 @@ impl ConditionPass {
                 .or_default();
             match tm.selection {
                 Some(PartitionSelection::Keys(keys)) if !keys.is_empty() => {
-                    partitioned_mats.push((tm.asset_key, keys.into_iter().collect()));
+                    // A mapped selection can name keys this asset doesn't
+                    // have (e.g. a time_window shift when the upstream's
+                    // range extends past this asset's) — constrain to real
+                    // partitions instead of dispatching phantom ones.
+                    let total = keys.len();
+                    let surviving: Vec<PartitionKey> = match self
+                        .conditions_by_key
+                        .get(tm.asset_key.as_str())
+                        .map(|&idx| &self.conditions[idx])
+                        .and_then(|info| info.partition_info.as_ref())
+                    {
+                        Some(pi) => keys
+                            .into_iter()
+                            .filter(|k| pi.all_keys.contains(k))
+                            .collect(),
+                        None => keys.into_iter().collect(),
+                    };
+                    if surviving.len() < total {
+                        tracing::warn!(
+                            target: "rivers::daemon",
+                            asset_key = %tm.asset_key,
+                            dropped = total - surviving.len(),
+                            "condition selection named partition keys the asset does not have; dropping them"
+                        );
+                    }
+                    if !surviving.is_empty() {
+                        partitioned_mats.push((tm.asset_key, surviving));
+                    }
                 }
                 Some(PartitionSelection::All) | None => {
                     let resolved = self
@@ -501,6 +528,67 @@ mod tests {
             .and_utc()
             .timestamp_nanos_opt()
             .unwrap()
+    }
+
+    #[test]
+    fn classify_drops_mapped_keys_the_asset_does_not_have() {
+        // A mapped selection can name keys outside the asset's own range
+        // (e.g. a time_window shift when the upstream's range extends past
+        // this asset's) — those must not dispatch a materialization of a
+        // partition that doesn't exist.
+        let mut pass = ConditionPass::new(
+            AssetConditionCache::default(),
+            ConditionEvalState::default(),
+            vec![AssetConditionInfo {
+                asset_key: "down".to_string(),
+                condition: ConditionNode::InProgress,
+                partition_info: Some(PartitionInfo {
+                    all_keys: make_daily_keys(&["2024-01-01", "2024-01-02"]),
+                    mappings: HashMap::new(),
+                    time_window_fmt: None,
+                }),
+                backfill_strategy: None,
+            }],
+            HashMap::new(),
+        );
+        let plan = pass.classify_materializations(vec![ToMaterialize {
+            asset_key: "down".to_string(),
+            selection: Some(PartitionSelection::Keys(
+                [spk("2024-01-02"), spk("2024-08-16")].into_iter().collect(),
+            )),
+        }]);
+        assert_eq!(
+            plan.single_partition_groups,
+            HashMap::from([(spk("2024-01-02"), vec!["down".to_string()])])
+        );
+        assert!(plan.multi_partition_backfills.is_empty());
+        assert!(plan.unpartitioned.is_empty());
+    }
+
+    #[test]
+    fn classify_skips_asset_when_no_mapped_key_survives() {
+        let mut pass = ConditionPass::new(
+            AssetConditionCache::default(),
+            ConditionEvalState::default(),
+            vec![AssetConditionInfo {
+                asset_key: "down".to_string(),
+                condition: ConditionNode::InProgress,
+                partition_info: Some(PartitionInfo {
+                    all_keys: make_daily_keys(&["2024-01-01", "2024-01-02"]),
+                    mappings: HashMap::new(),
+                    time_window_fmt: None,
+                }),
+                backfill_strategy: None,
+            }],
+            HashMap::new(),
+        );
+        let plan = pass.classify_materializations(vec![ToMaterialize {
+            asset_key: "down".to_string(),
+            selection: Some(PartitionSelection::Keys(
+                [spk("2024-08-16")].into_iter().collect(),
+            )),
+        }]);
+        assert!(plan.is_empty());
     }
 
     #[test]

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -7,6 +7,7 @@
 use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
+use ordermap::OrderSet;
 
 use crate::condition::cache::AssetConditionCache;
 use crate::condition::eval::evaluate_with_tree;
@@ -77,7 +78,9 @@ pub enum PartitionUniverse {
 /// One dimension of a Multi universe: its current key list plus how it evolves.
 #[derive(Clone, Debug)]
 pub struct DimensionUniverse {
-    pub keys: Vec<String>,
+    /// Dim values in definition/seed order; a set so refresh re-yields
+    /// (explicit future end, seed/watermark races) cannot duplicate.
+    pub keys: OrderSet<String>,
     pub kind: DimensionKind,
 }
 
@@ -161,14 +164,9 @@ fn refresh_universe(
                             Ok(new_keys) => {
                                 // Seeding can enumerate past the watermark
                                 // (explicit future end; start/enumerate race),
-                                // so re-yielded starts must not duplicate.
-                                let fresh: Vec<String> = new_keys
-                                    .into_iter()
-                                    .filter(|k| !du.keys.contains(k))
-                                    .collect();
-                                if !fresh.is_empty() {
-                                    du.keys.extend(fresh);
-                                    changed = true;
+                                // so re-yielded starts insert as no-ops.
+                                for k in new_keys {
+                                    changed |= du.keys.insert(k);
                                 }
                                 *enumerated_to = bound;
                             }
@@ -185,7 +183,7 @@ fn refresh_universe(
                         {
                             let mut sorted: Vec<String> = keys.iter().cloned().collect();
                             sorted.sort();
-                            du.keys = sorted;
+                            du.keys = sorted.into_iter().collect();
                             changed = true;
                         }
                     }
@@ -951,7 +949,7 @@ mod tests {
             dims: vec![(
                 "date".to_string(),
                 DimensionUniverse {
-                    keys: vec![],
+                    keys: OrderSet::new(),
                     kind: DimensionKind::TimeWindow {
                         grid: broken,
                         enumerated_to: t0,
@@ -1014,7 +1012,7 @@ mod tests {
                 (
                     "date".to_string(),
                     DimensionUniverse {
-                        keys: vec!["2024-01-01T00:00:00".to_string()],
+                        keys: ["2024-01-01T00:00:00".to_string()].into_iter().collect(),
                         kind: DimensionKind::TimeWindow {
                             grid: hourly_grid(),
                             enumerated_to: naive("2024-01-01T00:30:00"),
@@ -1024,7 +1022,7 @@ mod tests {
                 (
                     "region".to_string(),
                     DimensionUniverse {
-                        keys: vec!["eu".to_string(), "us".to_string()],
+                        keys: ["eu".to_string(), "us".to_string()].into_iter().collect(),
                         kind: DimensionKind::Frozen,
                     },
                 ),
@@ -1067,7 +1065,7 @@ mod tests {
             dims: vec![(
                 "date".to_string(),
                 DimensionUniverse {
-                    keys: seeded.clone(),
+                    keys: seeded.iter().cloned().collect(),
                     kind: DimensionKind::TimeWindow {
                         grid,
                         enumerated_to: naive("2024-01-01T01:30:00"),
@@ -1089,7 +1087,10 @@ mod tests {
             !changed,
             "re-yielding already-seeded starts is not a change"
         );
-        assert_eq!(dims[0].1.keys, seeded, "no duplicate dim keys");
+        assert!(
+            dims[0].1.keys.iter().eq(seeded.iter()),
+            "no duplicate dim keys"
+        );
     }
 
     #[test]

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -295,7 +295,11 @@ pub fn compute_latest_time_window_keys(
                 _ => return None,
             };
             let dt = parse_key_datetime(key_str, fmt).ok()?;
-            if dt <= now_local { Some((pk, dt)) } else { None }
+            if dt <= now_local {
+                Some((pk, dt))
+            } else {
+                None
+            }
         })
         .collect();
 
@@ -309,9 +313,8 @@ pub fn compute_latest_time_window_keys(
         Some(delta_secs) => {
             let lookback_nanos = (delta_secs * 1_000_000_000.0) as i64;
             // A lookback too large to subtract means "no cutoff".
-            let cutoff = now_local.checked_sub_signed(chrono::Duration::nanoseconds(
-                lookback_nanos,
-            ));
+            let cutoff =
+                now_local.checked_sub_signed(chrono::Duration::nanoseconds(lookback_nanos));
             parsed
                 .into_iter()
                 .filter(|(_, dt)| cutoff.is_none_or(|c| *dt >= c))
@@ -411,19 +414,22 @@ impl ConditionPass {
         let mut changed = false;
         for info in &mut self.conditions {
             if let Some(pi) = info.partition_info.as_mut() {
-                changed |= refresh_universe(&mut pi.universe, &mut pi.all_keys, now, dynamic_keys);
+                let pi_changed =
+                    refresh_universe(&mut pi.universe, &mut pi.all_keys, now, dynamic_keys);
+                changed |= pi_changed;
+                // The conditioned asset's upstream entry mirrors its
+                // PartitionInfo; it was synced at extraction, so only a
+                // change needs a re-copy.
+                if pi_changed
+                    && let Some(entry) = self.upstream_partition_keys.get_mut(&info.asset_key)
+                {
+                    entry.clone_from(&pi.all_keys);
+                }
             }
         }
         for (asset, universe) in &mut self.upstream_universes {
             if let Some(keys) = self.upstream_partition_keys.get_mut(asset) {
                 changed |= refresh_universe(universe, keys, now, dynamic_keys);
-            }
-        }
-        for info in &self.conditions {
-            if let Some(pi) = &info.partition_info
-                && let Some(entry) = self.upstream_partition_keys.get_mut(&info.asset_key)
-            {
-                entry.clone_from(&pi.all_keys);
             }
         }
         changed
@@ -484,9 +490,7 @@ impl ConditionPass {
     fn evaluate(&self, now: i64, selective: bool) -> Vec<EvalResultRow> {
         // Partition keys are wall-clock labels; latest-window math compares
         // them against the local naive reading of the tick instant.
-        let now_local = chrono::Local
-            .timestamp_nanos(now)
-            .naive_local();
+        let now_local = chrono::Local.timestamp_nanos(now).naive_local();
         let in_progress_keys: HashSet<String> =
             self.cache.in_progress_assets.keys().cloned().collect();
 
@@ -529,8 +533,8 @@ impl ConditionPass {
                         failed: &status.failed,
                         timestamps: &status.timestamps,
                         resolver: PartitionResolver::new(
-                            pi.mappings.clone(),
-                            self.upstream_partition_keys.clone(),
+                            &pi.mappings,
+                            &self.upstream_partition_keys,
                         ),
                         latest_time_window_keys: latest_tw_keys.as_ref(),
                         all_partition_statuses: &self.cache.partition_status,
@@ -1123,7 +1127,11 @@ mod tests {
             selection: Some(PartitionSelection::All),
         }]);
         let mut backfills = plan.multi_partition_backfills;
-        assert_eq!(backfills.len(), 1, "All must dispatch the asset's partitions");
+        assert_eq!(
+            backfills.len(),
+            1,
+            "All must dispatch the asset's partitions"
+        );
         let (asset, mut keys) = backfills.pop().unwrap();
         assert_eq!(asset, "down");
         keys.sort_by_key(|k| format!("{k:?}"));
@@ -1145,14 +1153,10 @@ mod tests {
         // 10:00 wall-clock one, not 08:00. `evaluate` converts the tick
         // instant to local naive before calling this, so the helper itself
         // compares wall clock to wall clock.
-        let all_keys = make_daily_keys(&[
-            "2026-06-11T08:00",
-            "2026-06-11T09:00",
-            "2026-06-11T10:00",
-        ]);
+        let all_keys =
+            make_daily_keys(&["2026-06-11T08:00", "2026-06-11T09:00", "2026-06-11T10:00"]);
         let now_local = to_wall("2026-06-11 10:30");
-        let result =
-            compute_latest_time_window_keys(&all_keys, "%Y-%m-%dT%H:%M", now_local, None);
+        let result = compute_latest_time_window_keys(&all_keys, "%Y-%m-%dT%H:%M", now_local, None);
         assert_eq!(result.len(), 1);
         assert!(result.contains(&spk("2026-06-11T10:00")));
     }

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -159,8 +159,15 @@ fn refresh_universe(
                         }
                         match grid.window_starts_in(*enumerated_to, bound) {
                             Ok(new_keys) => {
-                                if !new_keys.is_empty() {
-                                    du.keys.extend(new_keys);
+                                // Seeding can enumerate past the watermark
+                                // (explicit future end; start/enumerate race),
+                                // so re-yielded starts must not duplicate.
+                                let fresh: Vec<String> = new_keys
+                                    .into_iter()
+                                    .filter(|k| !du.keys.contains(k))
+                                    .collect();
+                                if !fresh.is_empty() {
+                                    du.keys.extend(fresh);
                                     changed = true;
                                 }
                                 *enumerated_to = bound;
@@ -1035,6 +1042,51 @@ mod tests {
             ],
         };
         assert!(all_keys.contains(&expected));
+    }
+
+    #[test]
+    fn multi_dim_refresh_never_duplicates_seeded_window_starts() {
+        // Seeding enumerates a dim through its explicit (future) end while
+        // the watermark starts at daemon-start `now`; later refreshes re-yield
+        // already-seeded starts and must neither append duplicates nor report
+        // a spurious change.
+        let grid = TimeGrid {
+            cron_schedule: None,
+            interval_seconds: Some(3600.0),
+            start: naive("2024-01-01T00:00:00"),
+            end: Some(naive("2024-01-02T00:00:00")),
+            fmt: "%Y-%m-%dT%H:%M:%S".into(),
+        };
+        let seeded: Vec<String> = (0..24)
+            .map(|h| format!("2024-01-01T{h:02}:00:00"))
+            .collect();
+        let mut universe = PartitionUniverse::Multi {
+            dims: vec![(
+                "date".to_string(),
+                DimensionUniverse {
+                    keys: seeded.clone(),
+                    kind: DimensionKind::TimeWindow {
+                        grid,
+                        enumerated_to: naive("2024-01-01T01:30:00"),
+                    },
+                },
+            )],
+        };
+        let mut all_keys: HashSet<PartitionKey> = HashSet::new();
+        let changed = refresh_universe(
+            &mut universe,
+            &mut all_keys,
+            naive("2024-01-01T03:10:00"),
+            &HashMap::new(),
+        );
+        let PartitionUniverse::Multi { dims } = &universe else {
+            unreachable!()
+        };
+        assert!(
+            !changed,
+            "re-yielding already-seeded starts is not a change"
+        );
+        assert_eq!(dims[0].1.keys, seeded, "no duplicate dim keys");
     }
 
     #[test]

--- a/rust/rivers-core/src/condition/state.rs
+++ b/rust/rivers-core/src/condition/state.rs
@@ -245,9 +245,9 @@ pub fn update_condition_state(
             .get_or_insert_with(PartitionState::default);
         ps.previous_selections = sub_selections.clone();
         ps.timestamps = timestamps.clone();
-        if let Some(PartitionSelection::Keys(keys)) = &result.selection {
-            ps.handled.extend(keys.iter().cloned());
-        }
+        // `handled` is extended during classification with the keys that are
+        // actually dispatched — the raw selection may contain keys the asset
+        // doesn't have, and marking those would suppress them forever.
     }
 }
 

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -2338,7 +2338,7 @@ fn test_last_run_includes_target_partitioned() {
         in_progress: &HashSet::new(),
         failed: &HashSet::new(),
         timestamps: &timestamps,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &partition_status,
     };
@@ -2441,16 +2441,15 @@ fn test_last_run_includes_target_partitioned_joint_run_suppresses_newly_updated(
     ctx.tags.partition_last_run_asset_names = &partition_asset_names;
     ctx.all_asset_states = &all_states;
 
+    let empty_mappings = HashMap::new();
+    let upstream_b = HashMap::from([("b".to_string(), all_keys.clone())]);
     let pctx = PartitionEvalContext {
         all_keys: &all_keys,
         materialized: &all_keys,
         in_progress: &HashSet::new(),
         failed: &HashSet::new(),
         timestamps: &timestamps,
-        resolver: PartitionResolver::new(
-            HashMap::new(),
-            HashMap::from([("b".to_string(), all_keys.clone())]),
-        ),
+        resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
     };
@@ -2513,16 +2512,15 @@ fn test_last_run_includes_target_partitioned_solo_run_allows_newly_updated() {
     ctx.tags.partition_last_run_asset_names = &partition_asset_names;
     ctx.all_asset_states = &all_states;
 
+    let empty_mappings = HashMap::new();
+    let upstream_b = HashMap::from([("b".to_string(), all_keys.clone())]);
     let pctx = PartitionEvalContext {
         all_keys: &all_keys,
         materialized: &all_keys,
         in_progress: &HashSet::new(),
         failed: &HashSet::new(),
         timestamps: &timestamps,
-        resolver: PartitionResolver::new(
-            HashMap::new(),
-            HashMap::from([("b".to_string(), all_keys.clone())]),
-        ),
+        resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
     };
@@ -2590,16 +2588,15 @@ fn test_last_run_includes_target_partitioned_mixed_joint_and_solo() {
     ctx.tags.partition_last_run_asset_names = &partition_asset_names;
     ctx.all_asset_states = &all_states;
 
+    let empty_mappings = HashMap::new();
+    let upstream_b = HashMap::from([("b".to_string(), all_keys.clone())]);
     let pctx = PartitionEvalContext {
         all_keys: &all_keys,
         materialized: &all_keys,
         in_progress: &HashSet::new(),
         failed: &HashSet::new(),
         timestamps: &timestamps,
-        resolver: PartitionResolver::new(
-            HashMap::new(),
-            HashMap::from([("b".to_string(), all_keys.clone())]),
-        ),
+        resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
     };
@@ -5952,7 +5949,7 @@ impl OwnedPartitionData {
             in_progress: &self.in_progress,
             failed: &self.failed,
             timestamps: &self.timestamps,
-            resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+            resolver: PartitionResolver::empty(),
             latest_time_window_keys: None,
             all_partition_statuses: &self.all_partition_statuses,
         }
@@ -6178,7 +6175,7 @@ fn test_partitioned_in_latest_time_window_selects_recent_keys() {
         in_progress: &pdata.in_progress,
         failed: &pdata.failed,
         timestamps: &pdata.timestamps,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: Some(&latest),
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -6210,7 +6207,7 @@ fn test_partitioned_in_latest_time_window_empty_when_no_recent() {
         in_progress: &pdata.in_progress,
         failed: &pdata.failed,
         timestamps: &pdata.timestamps,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: Some(&latest),
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -6261,7 +6258,7 @@ fn test_partitioned_in_latest_time_window_combined_with_missing() {
         in_progress: &pdata.in_progress,
         failed: &pdata.failed,
         timestamps: &pdata.timestamps,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: Some(&latest),
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -6591,10 +6588,8 @@ fn test_partitioned_any_deps_missing_with_identity() {
 
     let upstream_keys: HashMap<String, HashSet<PartitionKey>> =
         HashMap::from([("a".into(), HashSet::from([spk("p1"), spk("p2"), spk("p3")]))]);
-    let resolver = PartitionResolver::new(
-        HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]),
-        upstream_keys,
-    );
+    let mappings = HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     let a_state = AssetConditionState {
         ..Default::default()
@@ -6677,10 +6672,8 @@ fn test_partitioned_all_deps_match_not_missing() {
 
     let upstream_keys: HashMap<String, HashSet<PartitionKey>> =
         HashMap::from([("a".into(), HashSet::from([spk("p1"), spk("p2")]))]);
-    let resolver = PartitionResolver::new(
-        HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]),
-        upstream_keys,
-    );
+    let mappings = HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     let asset_states = HashMap::from([("a".into(), AssetConditionState::default())]);
 
@@ -6789,10 +6782,10 @@ fn test_partition_mapping_specific() {
 
 #[test]
 fn test_partition_resolver_identity_passthrough() {
-    let resolver = PartitionResolver::new(
-        HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]),
-        HashMap::from([("a".into(), HashSet::from([spk("p1"), spk("p2"), spk("p3")]))]),
-    );
+    let mappings = HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]);
+    let upstream_keys =
+        HashMap::from([("a".into(), HashSet::from([spk("p1"), spk("p2"), spk("p3")]))]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
     let sel = PartitionSelection::Keys(HashSet::from([spk("p1"), spk("p2")]));
     assert_eq!(resolver.map_downstream("a", "b", &sel), sel);
 }
@@ -6800,7 +6793,7 @@ fn test_partition_resolver_identity_passthrough() {
 #[test]
 fn test_partition_resolver_no_mapping_is_identity() {
     // No mapping registered for edge (c, d) → identity passthrough
-    let resolver = PartitionResolver::new(HashMap::new(), HashMap::new());
+    let resolver = PartitionResolver::empty();
     let sel = PartitionSelection::Keys(HashSet::from([spk("p1")]));
     assert_eq!(resolver.map_downstream("d", "c", &sel), sel);
 }
@@ -6835,13 +6828,11 @@ fn test_partitioned_eager_selects_new_partition() {
         "raw".into(),
         HashSet::from([spk("p1"), spk("p2"), spk("p3")]),
     )]);
-    let resolver = PartitionResolver::new(
-        HashMap::from([(
-            ("cleaned".into(), "raw".into()),
-            PartitionMappingKind::Identity,
-        )]),
-        upstream_keys,
-    );
+    let mappings = HashMap::from([(
+        ("cleaned".into(), "raw".into()),
+        PartitionMappingKind::Identity,
+    )]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     let raw_state = AssetConditionState::default();
     let asset_states = HashMap::from([("raw".into(), raw_state)]);
@@ -7105,30 +7096,29 @@ fn test_partition_mapping_multi_to_single_empty_and_all() {
 
 #[test]
 fn test_resolver_multi_mapping() {
-    let resolver = PartitionResolver::new(
-        HashMap::from([(
-            ("down".into(), "up".into()),
-            PartitionMappingKind::Multi {
-                dimension_mappings: HashMap::from([
-                    (
-                        "date".into(),
-                        ("date".into(), Box::new(PartitionMappingKind::Identity)),
-                    ),
-                    (
-                        "region".into(),
-                        ("region".into(), Box::new(PartitionMappingKind::Identity)),
-                    ),
-                ]),
-            },
-        )]),
-        HashMap::from([(
-            "up".into(),
-            HashSet::from([
-                mpk(&[("date", "2024-01-01"), ("region", "us")]),
-                mpk(&[("date", "2024-01-01"), ("region", "eu")]),
+    let mappings = HashMap::from([(
+        ("down".into(), "up".into()),
+        PartitionMappingKind::Multi {
+            dimension_mappings: HashMap::from([
+                (
+                    "date".into(),
+                    ("date".into(), Box::new(PartitionMappingKind::Identity)),
+                ),
+                (
+                    "region".into(),
+                    ("region".into(), Box::new(PartitionMappingKind::Identity)),
+                ),
             ]),
-        )]),
-    );
+        },
+    )]);
+    let upstream_keys = HashMap::from([(
+        "up".to_string(),
+        HashSet::from([
+            mpk(&[("date", "2024-01-01"), ("region", "us")]),
+            mpk(&[("date", "2024-01-01"), ("region", "eu")]),
+        ]),
+    )]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     let sel = PartitionSelection::Keys(HashSet::from([mpk(&[
         ("date", "2024-01-01"),
@@ -7139,19 +7129,18 @@ fn test_resolver_multi_mapping() {
 
 #[test]
 fn test_resolver_multi_to_single_mapping() {
-    let resolver = PartitionResolver::new(
-        HashMap::from([(
-            ("single_down".into(), "multi_up".into()),
-            PartitionMappingKind::MultiToSingle {
-                dimension_name: "date".into(),
-                inner: Box::new(PartitionMappingKind::Identity),
-            },
-        )]),
-        HashMap::from([(
-            "multi_up".into(),
-            HashSet::from([mpk(&[("date", "2024-01-01"), ("region", "us")])]),
-        )]),
-    );
+    let mappings = HashMap::from([(
+        ("single_down".into(), "multi_up".into()),
+        PartitionMappingKind::MultiToSingle {
+            dimension_name: "date".into(),
+            inner: Box::new(PartitionMappingKind::Identity),
+        },
+    )]);
+    let upstream_keys = HashMap::from([(
+        "multi_up".to_string(),
+        HashSet::from([mpk(&[("date", "2024-01-01"), ("region", "us")])]),
+    )]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     let upstream = PartitionSelection::Keys(HashSet::from([mpk(&[
         ("date", "2024-01-01"),
@@ -7184,13 +7173,11 @@ fn test_partitioned_eager_partial_upstream_update() {
         "raw".into(),
         HashSet::from([spk("p1"), spk("p2"), spk("p3")]),
     )]);
-    let resolver = PartitionResolver::new(
-        HashMap::from([(
-            ("processed".into(), "raw".into()),
-            PartitionMappingKind::Identity,
-        )]),
-        upstream_keys,
-    );
+    let mappings = HashMap::from([(
+        ("processed".into(), "raw".into()),
+        PartitionMappingKind::Identity,
+    )]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     // raw_state has partition_state with p1, p2 already known at ts=200
     // so only p3 (newly materialized at ts=200) will be "NewlyUpdated"
@@ -7284,13 +7271,11 @@ fn test_partitioned_eager_only_fires_for_partitions_with_upstream_data() {
 
     let all_partitions = HashSet::from([spk("p1"), spk("p2"), spk("p3"), spk("p4"), spk("p5")]);
     let upstream_keys = HashMap::from([("raw".into(), all_partitions.clone())]);
-    let resolver = PartitionResolver::new(
-        HashMap::from([(
-            ("processed".into(), "raw".into()),
-            PartitionMappingKind::Identity,
-        )]),
-        upstream_keys,
-    );
+    let mappings = HashMap::from([(
+        ("processed".into(), "raw".into()),
+        PartitionMappingKind::Identity,
+    )]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     // Upstream "raw" only has p1, p2, p3 materialized (p4, p5 are missing)
     let partition_statuses = HashMap::from([(
@@ -7391,10 +7376,8 @@ fn test_partitioned_on_missing_only_missing_partitions() {
 
     let upstream_keys =
         HashMap::from([("a".into(), HashSet::from([spk("p1"), spk("p2"), spk("p3")]))]);
-    let resolver = PartitionResolver::new(
-        HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]),
-        upstream_keys,
-    );
+    let mappings = HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     let asset_states = HashMap::from([("a".into(), AssetConditionState::default())]);
 
@@ -7486,7 +7469,7 @@ fn test_partitioned_in_progress_excludes_from_and() {
         in_progress: &_ip,
         failed: &_fail,
         timestamps: &_ts,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -7551,7 +7534,7 @@ fn test_partitioned_code_version_changed_all_partitions() {
         in_progress: &_ip,
         failed: &_fail,
         timestamps: &_ts,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -7589,7 +7572,7 @@ fn test_partitioned_since_latch_per_partition() {
         in_progress: &_ip,
         failed: &_fail,
         timestamps: &_ts1,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -7639,7 +7622,7 @@ fn test_partitioned_since_latch_per_partition() {
         in_progress: &_ip,
         failed: &_fail,
         timestamps: &_ts2,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -7834,7 +7817,7 @@ fn test_partitioned_execution_failed_subset() {
         in_progress: &_ip,
         failed: &_fail,
         timestamps: &_ts,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -7868,7 +7851,7 @@ fn test_partitioned_complex_or_and_not() {
         in_progress: &_ip,
         failed: &_fail,
         timestamps: &_ts,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -9068,7 +9051,7 @@ fn test_partitioned_on_cron_no_deps_fires_all_partitions() {
         in_progress: &_ip,
         failed: &_fail,
         timestamps: &_ts,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -9134,7 +9117,7 @@ fn test_partitioned_on_cron_does_not_fire_without_tick() {
         in_progress: &_ip,
         failed: &_fail,
         timestamps: &_ts,
-        resolver: PartitionResolver::new(HashMap::new(), HashMap::new()),
+        resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
     };
@@ -9186,10 +9169,8 @@ fn test_partitioned_on_cron_waits_for_dep_update() {
 
     let upstream_keys: HashMap<String, HashSet<PartitionKey>> =
         HashMap::from([("a".into(), HashSet::from([spk("p1"), spk("p2")]))]);
-    let resolver = PartitionResolver::new(
-        HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]),
-        upstream_keys,
-    );
+    let mappings = HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     // a's partition timestamps haven't changed (dep not updated)
     let partition_statuses = HashMap::from([(
@@ -9275,10 +9256,8 @@ fn test_partitioned_on_cron_fires_after_dep_update() {
 
     let upstream_keys: HashMap<String, HashSet<PartitionKey>> =
         HashMap::from([("a".into(), HashSet::from([spk("p1"), spk("p2")]))]);
-    let resolver = PartitionResolver::new(
-        HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]),
-        upstream_keys,
-    );
+    let mappings = HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     // a's partitions have new timestamps (updated after cron tick)
     let partition_statuses = HashMap::from([(
@@ -9368,10 +9347,8 @@ fn test_partitioned_on_cron_partial_dep_update() {
 
     let upstream_keys: HashMap<String, HashSet<PartitionKey>> =
         HashMap::from([("a".into(), HashSet::from([spk("p1"), spk("p2")]))]);
-    let resolver = PartitionResolver::new(
-        HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]),
-        upstream_keys,
-    );
+    let mappings = HashMap::from([(("b".into(), "a".into()), PartitionMappingKind::Identity)]);
+    let resolver = PartitionResolver::new(&mappings, &upstream_keys);
 
     // Only p1 updated (ts=200), p2 not updated (ts=100, same as prev)
     let partition_statuses = HashMap::from([(
@@ -9541,11 +9518,9 @@ fn test_update_dep_baselines_prevents_newly_updated_false_positive() {
     let timestamps = HashMap::from([(pk1.clone(), 100_i64), (pk2.clone(), 100)]);
     let upstream_keys = HashMap::from([("b".into(), HashSet::from([pk1.clone(), pk2.clone()]))]);
 
+    let mappings = HashMap::from([(("a".into(), "b".into()), PartitionMappingKind::Identity)]);
     let build_ctx = |_states: &HashMap<String, AssetConditionState>| {
-        let resolver = PartitionResolver::new(
-            HashMap::from([(("a".into(), "b".into()), PartitionMappingKind::Identity)]),
-            upstream_keys.clone(),
-        );
+        let resolver = PartitionResolver::new(&mappings, &upstream_keys);
         let prev = AssetConditionState {
             last_tick_timestamp: Some(50),
             ..Default::default()

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -6041,21 +6041,36 @@ fn test_partition_selection_complement() {
 
 #[test]
 fn test_partition_selection_difference() {
+    let universe: HashSet<PartitionKey> = ["p1", "p2", "p3"].iter().map(|s| spk(s)).collect();
     let a = PartitionSelection::Keys(HashSet::from([spk("p1"), spk("p2"), spk("p3")]));
     let b = PartitionSelection::Keys(HashSet::from([spk("p2")]));
     assert_eq!(
-        a.difference(&b),
+        a.difference(&b, &universe),
         PartitionSelection::Keys(HashSet::from([spk("p1"), spk("p3")]))
     );
 
     assert_eq!(
-        a.difference(&PartitionSelection::All),
+        a.difference(&PartitionSelection::All, &universe),
         PartitionSelection::Empty
     );
-    assert_eq!(a.difference(&PartitionSelection::Empty), a);
+    assert_eq!(a.difference(&PartitionSelection::Empty, &universe), a);
     assert_eq!(
-        PartitionSelection::Empty.difference(&b),
+        PartitionSelection::Empty.difference(&b, &universe),
         PartitionSelection::Empty
+    );
+}
+
+/// `All - Keys` must resolve to the complement, not fall back to `All` —
+/// the fallback re-selects the very partitions the subtraction was meant to
+/// drop (e.g. `newly_requested().since_last_handled()` re-selecting handled
+/// keys).
+#[test]
+fn test_partition_selection_difference_all_minus_keys() {
+    let universe: HashSet<PartitionKey> = ["p1", "p2", "p3"].iter().map(|s| spk(s)).collect();
+    let handled = PartitionSelection::Keys(HashSet::from([spk("p2")]));
+    assert_eq!(
+        PartitionSelection::All.difference(&handled, &universe),
+        PartitionSelection::Keys(HashSet::from([spk("p1"), spk("p3")]))
     );
 }
 

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -6060,6 +6060,52 @@ fn test_partition_selection_difference() {
     );
 }
 
+/// `time_window(offset)` must shift in condition eval exactly as the
+/// runtime IO path does — a pass-through here fires conditions on the
+/// partition that does NOT read the updated upstream.
+#[test]
+fn test_time_window_mapping_shifts_selections_by_offset() {
+    use crate::timegrid::TimeGrid;
+    let grid = TimeGrid {
+        cron_schedule: Some("0 0 * * *".into()),
+        interval_seconds: None,
+        start: chrono::NaiveDate::from_ymd_opt(2024, 1, 1).unwrap().into(),
+        end: Some(chrono::NaiveDate::from_ymd_opt(2024, 2, 1).unwrap().into()),
+        fmt: "%Y-%m-%d".into(),
+    };
+    let m = PartitionMappingKind::TimeWindow {
+        offset: -1,
+        grid: Some(grid),
+    };
+
+    let d = PartitionSelection::Keys(HashSet::from([spk("2024-01-05")]));
+    // Downstream 2024-01-05 reads upstream 2024-01-04.
+    assert_eq!(
+        m.map_to_upstream(&d),
+        PartitionSelection::Keys(HashSet::from([spk("2024-01-04")]))
+    );
+    // Upstream 2024-01-05 updating affects downstream 2024-01-06.
+    assert_eq!(
+        m.map_to_downstream(&d),
+        PartitionSelection::Keys(HashSet::from([spk("2024-01-06")]))
+    );
+    // A shift outside [start, end) has no counterpart partition.
+    let first = PartitionSelection::Keys(HashSet::from([spk("2024-01-01")]));
+    assert_eq!(m.map_to_upstream(&first), PartitionSelection::Empty);
+}
+
+/// Mappings serialized before the grid existed degrade to pass-through.
+#[test]
+fn test_time_window_mapping_without_grid_passes_through() {
+    let m = PartitionMappingKind::TimeWindow {
+        offset: -1,
+        grid: None,
+    };
+    let sel = PartitionSelection::Keys(HashSet::from([spk("2024-01-05")]));
+    assert_eq!(m.map_to_upstream(&sel), sel);
+    assert_eq!(m.map_to_downstream(&sel), sel);
+}
+
 /// `All - Keys` must resolve to the complement, not fall back to `All` —
 /// the fallback re-selects the very partitions the subtraction was meant to
 /// drop (e.g. `newly_requested().since_last_handled()` re-selecting handled

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -6079,19 +6079,14 @@ fn test_time_window_mapping_shifts_selections_by_offset() {
     };
 
     let d = PartitionSelection::Keys(HashSet::from([spk("2024-01-05")]));
-    // Downstream 2024-01-05 reads upstream 2024-01-04.
-    assert_eq!(
-        m.map_to_upstream(&d),
-        PartitionSelection::Keys(HashSet::from([spk("2024-01-04")]))
-    );
     // Upstream 2024-01-05 updating affects downstream 2024-01-06.
     assert_eq!(
         m.map_to_downstream(&d),
         PartitionSelection::Keys(HashSet::from([spk("2024-01-06")]))
     );
     // A shift outside [start, end) has no counterpart partition.
-    let first = PartitionSelection::Keys(HashSet::from([spk("2024-01-01")]));
-    assert_eq!(m.map_to_upstream(&first), PartitionSelection::Empty);
+    let last = PartitionSelection::Keys(HashSet::from([spk("2024-01-31")]));
+    assert_eq!(m.map_to_downstream(&last), PartitionSelection::Empty);
 }
 
 /// Mappings serialized before the grid existed degrade to pass-through.
@@ -6102,7 +6097,6 @@ fn test_time_window_mapping_without_grid_passes_through() {
         grid: None,
     };
     let sel = PartitionSelection::Keys(HashSet::from([spk("2024-01-05")]));
-    assert_eq!(m.map_to_upstream(&sel), sel);
     assert_eq!(m.map_to_downstream(&sel), sel);
 }
 
@@ -6754,7 +6748,6 @@ fn test_partitioned_all_deps_match_not_missing() {
 fn test_partition_mapping_identity() {
     let m = PartitionMappingKind::Identity;
     let sel = PartitionSelection::Keys(HashSet::from([spk("p1"), spk("p2")]));
-    assert_eq!(m.map_to_upstream(&sel), sel);
     assert_eq!(m.map_to_downstream(&sel), sel);
 }
 
@@ -6762,8 +6755,6 @@ fn test_partition_mapping_identity() {
 fn test_partition_mapping_all_partitions() {
     let m = PartitionMappingKind::AllPartitions;
     let sel = PartitionSelection::Keys(HashSet::from([spk("p1")]));
-    // map_to_upstream returns All (resolved by PartitionResolver)
-    assert_eq!(m.map_to_upstream(&sel), PartitionSelection::All);
     // map_to_downstream: any upstream change affects all downstream
     assert_eq!(m.map_to_downstream(&sel), PartitionSelection::All);
     // Empty input → Empty
@@ -6778,13 +6769,7 @@ fn test_partition_mapping_static() {
     let m = PartitionMappingKind::Static {
         mapping: HashMap::from([("d1".into(), "u1".into()), ("d2".into(), "u2".into())]),
     };
-    // Downstream d1 maps to upstream u1
-    let sel = PartitionSelection::Keys(HashSet::from([spk("d1")]));
-    assert_eq!(
-        m.map_to_upstream(&sel),
-        PartitionSelection::Keys(HashSet::from([spk("u1")]))
-    );
-    // Upstream u2 maps back to downstream d2
+    // Upstream u2 maps to downstream d2
     let sel2 = PartitionSelection::Keys(HashSet::from([spk("u2")]));
     assert_eq!(
         m.map_to_downstream(&sel2),
@@ -6797,12 +6782,6 @@ fn test_partition_mapping_specific() {
     let m = PartitionMappingKind::SpecificPartitions {
         keys: vec!["latest".into()],
     };
-    // Any downstream partition maps to "latest" upstream
-    let sel = PartitionSelection::Keys(HashSet::from([spk("p1"), spk("p2")]));
-    assert_eq!(
-        m.map_to_upstream(&sel),
-        PartitionSelection::Keys(HashSet::from([spk("latest")]))
-    );
     // Any upstream change affects all downstream
     let up = PartitionSelection::Keys(HashSet::from([spk("latest")]));
     assert_eq!(m.map_to_downstream(&up), PartitionSelection::All);
@@ -6815,25 +6794,7 @@ fn test_partition_resolver_identity_passthrough() {
         HashMap::from([("a".into(), HashSet::from([spk("p1"), spk("p2"), spk("p3")]))]),
     );
     let sel = PartitionSelection::Keys(HashSet::from([spk("p1"), spk("p2")]));
-    assert_eq!(resolver.map_upstream("b", "a", &sel), sel);
     assert_eq!(resolver.map_downstream("a", "b", &sel), sel);
-}
-
-#[test]
-fn test_partition_resolver_all_partitions() {
-    let resolver = PartitionResolver::new(
-        HashMap::from([(
-            ("b".into(), "a".into()),
-            PartitionMappingKind::AllPartitions,
-        )]),
-        HashMap::from([("a".into(), HashSet::from([spk("u1"), spk("u2"), spk("u3")]))]),
-    );
-    // Any downstream partition → all upstream partitions
-    let sel = PartitionSelection::Keys(HashSet::from([spk("p1")]));
-    assert_eq!(
-        resolver.map_upstream("b", "a", &sel),
-        PartitionSelection::Keys(HashSet::from([spk("u1"), spk("u2"), spk("u3")]))
-    );
 }
 
 #[test]
@@ -6841,7 +6802,6 @@ fn test_partition_resolver_no_mapping_is_identity() {
     // No mapping registered for edge (c, d) → identity passthrough
     let resolver = PartitionResolver::new(HashMap::new(), HashMap::new());
     let sel = PartitionSelection::Keys(HashSet::from([spk("p1")]));
-    assert_eq!(resolver.map_upstream("c", "d", &sel), sel);
     assert_eq!(resolver.map_downstream("d", "c", &sel), sel);
 }
 
@@ -6973,7 +6933,6 @@ fn test_partition_mapping_multi_identity_dims() {
         ("date", "2024-01-01"),
         ("region", "us"),
     ])]));
-    assert_eq!(m.map_to_upstream(&sel), sel);
     assert_eq!(m.map_to_downstream(&sel), sel);
 }
 
@@ -6992,22 +6951,18 @@ fn test_partition_mapping_multi_dimension_rename() {
             ),
         ]),
     };
-    let downstream = PartitionSelection::Keys(HashSet::from([mpk(&[
-        ("date", "2024-01-01"),
-        ("region", "us"),
+    let upstream = PartitionSelection::Keys(HashSet::from([mpk(&[
+        ("src_date", "2024-01-01"),
+        ("src_region", "us"),
     ])]));
-    let upstream = m.map_to_upstream(&downstream);
+    let down = m.map_to_downstream(&upstream);
     assert_eq!(
-        upstream,
+        down,
         PartitionSelection::Keys(HashSet::from([mpk(&[
-            ("src_date", "2024-01-01"),
-            ("src_region", "us")
+            ("date", "2024-01-01"),
+            ("region", "us")
         ])]))
     );
-
-    // Reverse: upstream → downstream
-    let back = m.map_to_downstream(&upstream);
-    assert_eq!(back, downstream);
 }
 
 #[test]
@@ -7033,20 +6988,6 @@ fn test_partition_mapping_multi_with_static_sub() {
             ),
         ]),
     };
-    // Downstream "north" → upstream "us"
-    let downstream = PartitionSelection::Keys(HashSet::from([mpk(&[
-        ("date", "2024-01-01"),
-        ("region", "north"),
-    ])]));
-    let upstream = m.map_to_upstream(&downstream);
-    assert_eq!(
-        upstream,
-        PartitionSelection::Keys(HashSet::from([mpk(&[
-            ("date", "2024-01-01"),
-            ("region", "us")
-        ])]))
-    );
-
     // Upstream "eu" → downstream "europe"
     let up = PartitionSelection::Keys(HashSet::from([mpk(&[
         ("date", "2024-01-01"),
@@ -7070,14 +7011,6 @@ fn test_partition_mapping_multi_empty_and_all() {
             ("d".into(), Box::new(PartitionMappingKind::Identity)),
         )]),
     };
-    assert_eq!(
-        m.map_to_upstream(&PartitionSelection::Empty),
-        PartitionSelection::Empty
-    );
-    assert_eq!(
-        m.map_to_upstream(&PartitionSelection::All),
-        PartitionSelection::All
-    );
     assert_eq!(
         m.map_to_downstream(&PartitionSelection::Empty),
         PartitionSelection::Empty
@@ -7107,7 +7040,6 @@ fn test_partition_mapping_multi_multiple_keys() {
         mpk(&[("date", "2024-01-02"), ("region", "eu")]),
     ]));
     // Identity per-dim → same keys
-    assert_eq!(m.map_to_upstream(&sel), sel);
     assert_eq!(m.map_to_downstream(&sel), sel);
 }
 
@@ -7128,23 +7060,6 @@ fn test_partition_mapping_multi_to_single_extract_dimension() {
     assert_eq!(
         downstream,
         PartitionSelection::Keys(HashSet::from([spk("2024-01-01"), spk("2024-01-02")]))
-    );
-}
-
-#[test]
-fn test_partition_mapping_multi_to_single_upstream_direction() {
-    // Downstream is single, upstream is multi.
-    // Downstream "2024-01-01" maps upstream to "2024-01-01" (identity inner).
-    let m = PartitionMappingKind::MultiToSingle {
-        dimension_name: "date".into(),
-        inner: Box::new(PartitionMappingKind::Identity),
-    };
-    let downstream = PartitionSelection::Keys(HashSet::from([spk("2024-01-01")]));
-    let upstream = m.map_to_upstream(&downstream);
-    // Returns the single-dim value (the resolver handles reconstructing the full multi key)
-    assert_eq!(
-        upstream,
-        PartitionSelection::Keys(HashSet::from([spk("2024-01-01")]))
     );
 }
 
@@ -7176,14 +7091,6 @@ fn test_partition_mapping_multi_to_single_empty_and_all() {
         dimension_name: "date".into(),
         inner: Box::new(PartitionMappingKind::Identity),
     };
-    assert_eq!(
-        m.map_to_upstream(&PartitionSelection::Empty),
-        PartitionSelection::Empty
-    );
-    assert_eq!(
-        m.map_to_upstream(&PartitionSelection::All),
-        PartitionSelection::All
-    );
     assert_eq!(
         m.map_to_downstream(&PartitionSelection::Empty),
         PartitionSelection::Empty
@@ -7227,7 +7134,6 @@ fn test_resolver_multi_mapping() {
         ("date", "2024-01-01"),
         ("region", "us"),
     ])]));
-    assert_eq!(resolver.map_upstream("down", "up", &sel), sel);
     assert_eq!(resolver.map_downstream("up", "down", &sel), sel);
 }
 

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -2472,6 +2472,88 @@ fn test_last_run_includes_target_partitioned_joint_run_suppresses_newly_updated(
 }
 
 #[test]
+fn dep_updated_requires_dep_newer_than_target_key() {
+    // Observation baselines lag async event drains: a fire can baseline stale
+    // timestamps and the same events re-surface as "updated" a tick later
+    // (or, with no baseline at all, every key reads as newly appeared). A dep
+    // key counts as updated only while it is strictly newer than the root's
+    // own materialization of that key — the dispatched run then advances the
+    // root past the dep, making the trigger self-suppressing.
+    let a = make_materialized_record("a", 100);
+    let b = make_materialized_record("b", 100);
+    let records = HashMap::from([("a".to_string(), a.clone()), ("b".to_string(), b.clone())]);
+    let deps = HashMap::from([("a".to_string(), vec!["b".to_string()])]);
+
+    let pk1 = spk("2024-01-01");
+    let pk2 = spk("2024-01-02");
+    let all_keys = HashSet::from([pk1.clone(), pk2.clone()]);
+    // Root "a" materialized pk1 at 100 (same joint baseline run as the dep)
+    // and pk2 at 100.
+    let a_timestamps = HashMap::from([(pk1.clone(), 100i64), (pk2.clone(), 100)]);
+
+    // Dep "b": pk1 ts equals the root's (nothing new); pk2 genuinely newer.
+    // Its eval-state baseline is EMPTY — the drain-lag shape where every key
+    // would read as "newly appeared".
+    let all_states = HashMap::new();
+    let b_partition_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: HashSet::from([pk1.clone(), pk2.clone()]),
+        timestamps: HashMap::from([(pk1.clone(), 100i64), (pk2.clone(), 200)]),
+        ..Default::default()
+    };
+    let a_partition_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: HashSet::from([pk1.clone(), pk2.clone()]),
+        timestamps: a_timestamps.clone(),
+        ..Default::default()
+    };
+    let partition_statuses = HashMap::from([
+        ("a".to_string(), a_partition_status),
+        ("b".to_string(), b_partition_status),
+    ]);
+    // Solo runs: no joint-run suppression in play.
+    let partition_asset_names = HashMap::from([(
+        "b".to_string(),
+        HashMap::from([
+            (pk1.clone(), Arc::from(vec!["b".to_string()])),
+            (pk2.clone(), Arc::from(vec!["b".to_string()])),
+        ]),
+    )]);
+
+    let mut ctx = make_ctx("a", &a, &records, &deps);
+    ctx.tags.partition_last_run_asset_names = &partition_asset_names;
+    ctx.all_asset_states = &all_states;
+
+    let empty_mappings = HashMap::new();
+    let upstream_b = HashMap::from([("b".to_string(), all_keys.clone())]);
+    let pctx = PartitionEvalContext {
+        all_keys: &all_keys,
+        materialized: &all_keys,
+        in_progress: &HashSet::new(),
+        failed: &HashSet::new(),
+        timestamps: &a_timestamps,
+        resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
+        latest_time_window_keys: None,
+        all_partition_statuses: &partition_statuses,
+    };
+    ctx.partitions = Some(&pctx);
+
+    let cond = ConditionNode::any_deps_updated();
+    let result = evaluate(&cond, &ctx);
+
+    assert!(result.fired, "pk2 is genuinely newer than the root");
+    match result.selection {
+        Some(PartitionSelection::Keys(ref keys)) => {
+            assert!(keys.contains(&pk2));
+            assert!(
+                !keys.contains(&pk1),
+                "a dep key no newer than the root's must not count as updated"
+            );
+            assert_eq!(keys.len(), 1);
+        }
+        other => panic!("expected Keys selection, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_last_run_includes_target_partitioned_solo_run_allows_newly_updated() {
     // Scenario: partitioned dep "b" was materialized in a solo run (not with root "a").
     // On the next tick, b:pk1 shows NewlyUpdated and should NOT be suppressed.

--- a/rust/rivers-core/src/lib.rs
+++ b/rust/rivers-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod run_backend;
 pub mod staleness;
 pub mod storage;
 pub mod task;
+pub mod timegrid;
 pub mod util;
 
 pub const GRAPH_TOPOLOGY_KEY_PREFIX: &str = "graph_topology:";

--- a/rust/rivers-core/src/lib.rs
+++ b/rust/rivers-core/src/lib.rs
@@ -13,6 +13,10 @@ pub mod task;
 pub mod timegrid;
 pub mod util;
 
+// Storage record ids are `surrealdb::types::RecordId`; re-export the crate so
+// dependents can construct records without pinning the git dependency themselves.
+pub use surrealdb;
+
 pub const GRAPH_TOPOLOGY_KEY_PREFIX: &str = "graph_topology:";
 
 /// KV key for serialized graph topology — per-CL so the UI doesn't render

--- a/rust/rivers-core/src/storage/mod.rs
+++ b/rust/rivers-core/src/storage/mod.rs
@@ -438,7 +438,11 @@ impl SurrealValue for PartitionKey {
                 map.insert("variant".to_string(), "Single".to_string().into_value());
                 map.insert("keys".to_string(), keys.into_value());
             }
-            Self::Multi { dims } => {
+            Self::Multi { mut dims } => {
+                // Canonical order: the UNIQUE index and equality queries
+                // compare the serialized form, which must not depend on
+                // construction order (Python builds dims from a HashMap).
+                dims.sort_by(|a, b| a.0.cmp(&b.0));
                 map.insert("variant".to_string(), "Multi".to_string().into_value());
                 map.insert("dims".to_string(), dims.into_value());
             }

--- a/rust/rivers-core/src/storage/mod.rs
+++ b/rust/rivers-core/src/storage/mod.rs
@@ -349,10 +349,11 @@ impl PartitionKey {
     }
 
     /// Inverse of [`Self::to_display`] for point lookups: the candidate
-    /// structured keys a display string may denote. Always includes the
-    /// `Single` reading; adds a `Multi` reading when the string parses as
-    /// `dim=v,v|dim=v,v`. A Static key that happens to contain `=` is
-    /// ambiguous — querying with both candidates resolves it.
+    /// structured keys a display string may denote, ordered least-structured
+    /// first. Always includes the `Single` reading; appends a `Multi` reading
+    /// when the string parses as `dim=v,v|dim=v,v`. A Static key that happens
+    /// to contain `=` is ambiguous — lookups try the candidates
+    /// most-structured first, so the `Multi` reading wins when both match.
     pub fn display_candidates(display: &str) -> Vec<PartitionKey> {
         let mut out = vec![PartitionKey::Single {
             keys: vec![display.to_string()],

--- a/rust/rivers-core/src/storage/mod.rs
+++ b/rust/rivers-core/src/storage/mod.rs
@@ -274,6 +274,32 @@ impl PartitionKey {
         }
     }
 
+    /// Canonical key-as-string encoding for display and string matching:
+    /// `Single` → values comma-joined; `Multi` → dims sorted, `dim=v,v`
+    /// pipe-joined; `Set` → member displays joined with `", "`. Every layer
+    /// that renders or matches keys as strings (gRPC window keys, heatmap
+    /// members, run labels, picker rows) must use this — a divergent encoding
+    /// silently breaks cross-layer matching.
+    pub fn to_display(&self) -> String {
+        match self {
+            Self::Single { keys } => keys.join(","),
+            Self::Multi { dims } => {
+                let mut sorted = dims.clone();
+                sorted.sort_by(|a, b| a.0.cmp(&b.0));
+                sorted
+                    .iter()
+                    .map(|(dim, vals)| format!("{}={}", dim, vals.join(",")))
+                    .collect::<Vec<_>>()
+                    .join("|")
+            }
+            Self::Set { keys } => keys
+                .iter()
+                .map(|k| k.to_display())
+                .collect::<Vec<_>>()
+                .join(", "),
+        }
+    }
+
     /// Serialize to JSON for CLI args / K8s CRD fields.
     /// Single: `{"single":["2025-01-16"]}`, Multi: `{"multi":{"region":["us"],"date":["2025-03"]}}`.
     pub fn to_json(&self) -> String {
@@ -2178,4 +2204,56 @@ pub trait StorageBackend: PerCodeLocationStorage {
         &self,
         run_id: &str,
     ) -> impl Future<Output = Result<HashMap<String, String>>> + Send;
+}
+
+#[cfg(test)]
+mod partition_key_tests {
+    use super::PartitionKey;
+
+    // `to_display` is THE canonical key-as-string encoding: every layer that
+    // renders or matches keys as strings (gRPC window keys, heatmap members,
+    // run labels, picker rows) must agree on it. Format: dims sorted and
+    // pipe-joined, values comma-joined — `dim=v,v|dim=v`.
+
+    #[test]
+    fn single_displays_bare_value() {
+        let pk = PartitionKey::Single {
+            keys: vec!["2024-01-01".into()],
+        };
+        assert_eq!(pk.to_display(), "2024-01-01");
+    }
+
+    #[test]
+    fn batched_single_joins_values_with_comma() {
+        let pk = PartitionKey::Single {
+            keys: vec!["a".into(), "b".into()],
+        };
+        assert_eq!(pk.to_display(), "a,b");
+    }
+
+    #[test]
+    fn multi_sorts_dims_and_pipe_joins() {
+        let pk = PartitionKey::Multi {
+            dims: vec![
+                ("region".into(), vec!["us".into(), "eu".into()]),
+                ("date".into(), vec!["2024-01-01".into()]),
+            ],
+        };
+        assert_eq!(pk.to_display(), "date=2024-01-01|region=us,eu");
+    }
+
+    #[test]
+    fn set_joins_member_displays() {
+        let pk = PartitionKey::Set {
+            keys: vec![
+                PartitionKey::Single {
+                    keys: vec!["a".into()],
+                },
+                PartitionKey::Multi {
+                    dims: vec![("d".into(), vec!["x".into()])],
+                },
+            ],
+        };
+        assert_eq!(pk.to_display(), "a, d=x");
+    }
 }

--- a/rust/rivers-core/src/storage/mod.rs
+++ b/rust/rivers-core/src/storage/mod.rs
@@ -339,6 +339,39 @@ impl PartitionKey {
         }
     }
 
+    /// Inverse of [`Self::to_display`] for point lookups: the candidate
+    /// structured keys a display string may denote. Always includes the
+    /// `Single` reading; adds a `Multi` reading when the string parses as
+    /// `dim=v,v|dim=v,v`. A Static key that happens to contain `=` is
+    /// ambiguous — querying with both candidates resolves it.
+    pub fn display_candidates(display: &str) -> Vec<PartitionKey> {
+        let mut out = vec![PartitionKey::Single {
+            keys: vec![display.to_string()],
+        }];
+        if display.contains('=') {
+            let mut dims: Vec<(String, Vec<String>)> = Vec::new();
+            let mut ok = true;
+            for part in display.split('|') {
+                match part.split_once('=') {
+                    Some((name, vals)) if !name.is_empty() => {
+                        dims.push((
+                            name.to_string(),
+                            vals.split(',').map(str::to_string).collect(),
+                        ));
+                    }
+                    _ => {
+                        ok = false;
+                        break;
+                    }
+                }
+            }
+            if ok && !dims.is_empty() {
+                out.push(PartitionKey::Multi { dims });
+            }
+        }
+        out
+    }
+
     /// Serialize to JSON for CLI args / K8s CRD fields.
     /// Single: `{"single":["2025-01-16"]}`, Multi: `{"multi":{"region":["us"],"date":["2025-03"]}}`.
     pub fn to_json(&self) -> String {

--- a/rust/rivers-core/src/storage/mod.rs
+++ b/rust/rivers-core/src/storage/mod.rs
@@ -339,6 +339,15 @@ impl PartitionKey {
         }
     }
 
+    /// The first display-syntax separator found in `key`, if any. `|` joins
+    /// dimensions and `,` joins values in [`Self::to_display`]; a key value
+    /// containing either cannot round-trip through
+    /// [`Self::display_candidates`], so constructors and the dynamic-key
+    /// write path reject such values.
+    pub fn reserved_display_char(key: &str) -> Option<char> {
+        ['|', ','].into_iter().find(|&c| key.contains(c))
+    }
+
     /// Inverse of [`Self::to_display`] for point lookups: the candidate
     /// structured keys a display string may denote. Always includes the
     /// `Single` reading; adds a `Multi` reading when the string parses as

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -321,17 +321,17 @@ async fn stored_schema_version(db: &Surreal<Any>) -> anyhow::Result<u32> {
 }
 
 async fn set_schema_version(db: &Surreal<Any>, version: u32) -> anyhow::Result<()> {
-    db.query("DELETE FROM kv WHERE key = $key")
-        .bind(("key", SCHEMA_VERSION_KEY.to_string()))
-        .await?
-        .check()?;
-    let _: Option<DbKv> = db
-        .create("kv")
-        .content(DbKv {
-            key: SCHEMA_VERSION_KEY.to_string(),
-            value: Bytes::from(version.to_string().into_bytes()),
-        })
-        .await?;
+    // Single upsert on the unique key: concurrent first boots both converge
+    // instead of the loser aborting on idx_kv_key, and a crash can't leave
+    // the stamp deleted-but-unwritten.
+    db.query(
+        "INSERT INTO kv { key: $key, value: $value } \
+         ON DUPLICATE KEY UPDATE value = $value",
+    )
+    .bind(("key", SCHEMA_VERSION_KEY.to_string()))
+    .bind(("value", Bytes::from(version.to_string().into_bytes())))
+    .await?
+    .check()?;
     Ok(())
 }
 
@@ -4158,6 +4158,35 @@ mod tests {
             Some(1),
             "event key must be rewritten to canonical order"
         );
+    }
+
+    /// Two processes opening the same fresh/v1 remote database race the
+    /// stamp; a DELETE-then-CREATE pair aborts the loser on the kv unique
+    /// index, so the stamp must be a single upsert that both survive.
+    #[tokio::test]
+    async fn test_concurrent_schema_stamps_both_succeed() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        let db_a = storage.db.clone();
+        let db_b = storage.db.clone();
+        let a = tokio::spawn(async move {
+            for _ in 0..25 {
+                set_schema_version(&db_a, 2).await?;
+            }
+            anyhow::Ok(())
+        });
+        let b = tokio::spawn(async move {
+            for _ in 0..25 {
+                set_schema_version(&db_b, 3).await?;
+            }
+            anyhow::Ok(())
+        });
+        a.await.unwrap().expect("stamp task A failed");
+        b.await.unwrap().expect("stamp task B failed");
+        let v = stored_schema_version(&storage.db).await.unwrap();
+        assert!(v == 2 || v == 3, "one of the stamps must win, got {v}");
     }
 
     /// A fresh database is stamped with the current schema version at

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -2984,6 +2984,17 @@ impl PerCodeLocationStorage for SurrealStorage {
         partitions_def_name: &str,
         partition_keys: &[String],
     ) -> Result<()> {
+        for key in partition_keys {
+            if key.is_empty() {
+                anyhow::bail!("dynamic partition keys must not be empty");
+            }
+            if let Some(ch) = PartitionKey::reserved_display_char(key) {
+                anyhow::bail!(
+                    "partition key '{key}' contains reserved character '{ch}' \
+                     (used by the canonical display form)"
+                );
+            }
+        }
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -4640,6 +4651,30 @@ mod tests {
                 .unwrap()
                 .len(),
             3
+        );
+    }
+
+    /// Dynamic keys feed the canonical display form (`dim=v|dim=v`, values
+    /// joined with ','); the storage write path is the choke point for every
+    /// transport, so reserved separator characters and empty keys must be
+    /// rejected here.
+    #[tokio::test]
+    async fn test_add_dynamic_partitions_rejects_reserved_and_empty_keys() {
+        let storage = make_storage().await;
+        let cl = crate::storage::DEFAULT_CODE_LOCATION_ID;
+        for bad in ["us|eu", "a,b", ""] {
+            let result = storage
+                .add_dynamic_partitions(cl, "users", &[bad.to_string()])
+                .await;
+            assert!(result.is_err(), "key {bad:?} must be rejected");
+        }
+        assert!(
+            storage
+                .get_dynamic_partitions(cl, "users")
+                .await
+                .unwrap()
+                .is_empty(),
+            "rejected keys must not be persisted"
         );
     }
 

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -2782,14 +2782,13 @@ impl PerCodeLocationStorage for SurrealStorage {
     ) -> Result<Option<StoredEvent>> {
         let event_type_str = "Materialization".to_string();
         let mut result = if let Some(partition_key) = partition {
-            let spk = PartitionKey::Single {
-                keys: vec![partition_key.to_string()],
-            };
+            // The display string may denote a Single or a Multi key.
+            let candidates = PartitionKey::display_candidates(partition_key);
             self.db
-                .query("SELECT * FROM events WHERE code_location_id = $cl AND asset_key = $asset_key AND partition_key = $partition_key AND event_type = $event_type ORDER BY timestamp DESC LIMIT 1")
+                .query("SELECT * FROM events WHERE code_location_id = $cl AND asset_key = $asset_key AND partition_key IN $candidates AND event_type = $event_type ORDER BY timestamp DESC LIMIT 1")
                 .bind(("cl", code_location_id.to_string()))
                 .bind(("asset_key", asset_key.to_string()))
-                .bind(("partition_key", spk))
+                .bind(("candidates", candidates))
                 .bind(("event_type", event_type_str))
                 .await?
         } else {
@@ -3187,10 +3186,10 @@ impl PerCodeLocationStorage for SurrealStorage {
     ) -> Result<Vec<StoredEvent>> {
         let mut result = self
             .db
-            .query("SELECT * FROM events WHERE code_location_id = $cl AND asset_key = $asset_key AND partition_key = $partition_key ORDER BY timestamp DESC LIMIT $limit")
+            .query("SELECT * FROM events WHERE code_location_id = $cl AND asset_key = $asset_key AND partition_key IN $candidates ORDER BY timestamp DESC LIMIT $limit")
             .bind(("cl", code_location_id.to_string()))
             .bind(("asset_key", asset_key.to_string()))
-            .bind(("partition_key", PartitionKey::Single { keys: vec![partition_key.to_string()] }))
+            .bind(("candidates", PartitionKey::display_candidates(partition_key)))
             .bind(("limit", limit))
             .await?;
         let events: Vec<DbStoredEvent> = result.take(0)?;
@@ -4116,6 +4115,56 @@ mod tests {
             ts,
             vec![(pk.clone(), 2)],
             "must update the existing row in place"
+        );
+    }
+
+    /// Per-partition lookups receive the display string; for Multi-partitioned
+    /// assets the persisted key is a Multi object — the lookup must still match.
+    #[tokio::test]
+    async fn test_partition_string_lookup_matches_multi_keys() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        let cl = crate::storage::DEFAULT_CODE_LOCATION_ID;
+        let pk = PartitionKey::Multi {
+            dims: vec![
+                ("date".to_string(), vec!["2024-01-01".to_string()]),
+                ("region".to_string(), vec!["eu".to_string()]),
+            ],
+        };
+        let mut event = make_event("inv", "r1", 100);
+        event.partition_key = Some(pk.clone());
+        storage.store_event(&event).await.unwrap();
+
+        let display = pk.to_display();
+        assert_eq!(display, "date=2024-01-01|region=eu");
+        let latest = storage
+            .get_latest_materialization(cl, "inv", Some(&display))
+            .await
+            .unwrap();
+        assert!(
+            latest.is_some(),
+            "display-form lookup must match the Multi event"
+        );
+        let events = storage
+            .get_partition_events(cl, "inv", &display, 10)
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+
+        // Single-dim lookups keep working.
+        let mut single = make_event("inv", "r2", 200);
+        single.partition_key = Some(PartitionKey::Single {
+            keys: vec!["p1".to_string()],
+        });
+        storage.store_event(&single).await.unwrap();
+        assert!(
+            storage
+                .get_latest_materialization(cl, "inv", Some("p1"))
+                .await
+                .unwrap()
+                .is_some()
         );
     }
 

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -299,6 +299,114 @@ impl DbStoredEvent {
     }
 }
 
+/// In-place migration: rewrite persisted `Multi` partition keys whose dims
+/// aren't in canonical (sorted) order. Earlier builds serialized HashMap
+/// iteration order, which defeats the `asset_partitions` UNIQUE index (one
+/// logical partition could occupy several rows) and `partition_key =`
+/// lookups on `events`. Idempotent; sorted rows are left untouched.
+async fn migrate_multi_partition_key_order(db: &Surreal<Any>) -> anyhow::Result<()> {
+    fn is_sorted(dims: &[(String, Vec<String>)]) -> bool {
+        dims.windows(2).all(|w| w[0].0 <= w[1].0)
+    }
+
+    #[derive(Debug, SurrealValue)]
+    struct PartRow {
+        id: RecordId,
+        code_location_id: String,
+        asset_key: String,
+        partition_key: PartitionKey,
+        last_event_id: Option<String>,
+        last_run_id: Option<String>,
+        last_timestamp: Option<i64>,
+    }
+    let mut result = db
+        .query("SELECT id, code_location_id, asset_key, partition_key, last_event_id, last_run_id, last_timestamp FROM asset_partitions WHERE partition_key.variant = 'Multi'")
+        .await?;
+    let rows: Vec<PartRow> = result.take(0)?;
+    // Group by logical key (PartitionKey's Eq/Hash are order-insensitive):
+    // unsorted duplicates collapse onto the newest row.
+    let mut groups: HashMap<(String, String, PartitionKey), Vec<PartRow>> = HashMap::new();
+    for row in rows {
+        groups
+            .entry((
+                row.code_location_id.clone(),
+                row.asset_key.clone(),
+                row.partition_key.clone(),
+            ))
+            .or_default()
+            .push(row);
+    }
+    let mut rewritten = 0usize;
+    for ((_, _, key), group) in groups {
+        let needs_rewrite = group.len() > 1
+            || group.iter().any(
+                |r| matches!(&r.partition_key, PartitionKey::Multi { dims } if !is_sorted(dims)),
+            );
+        if !needs_rewrite {
+            continue;
+        }
+        let latest = group
+            .iter()
+            .max_by_key(|r| r.last_timestamp.unwrap_or(i64::MIN))
+            .expect("group is non-empty");
+        let write = DbAssetPartitionWrite {
+            code_location_id: latest.code_location_id.clone(),
+            asset_key: latest.asset_key.clone(),
+            partition_key: key,
+            last_event_id: latest.last_event_id.clone().unwrap_or_default(),
+            last_run_id: latest.last_run_id.clone().unwrap_or_default(),
+            last_timestamp: latest.last_timestamp.unwrap_or_default(),
+        };
+        for row in &group {
+            db.query("DELETE $rec")
+                .bind(("rec", row.id.clone()))
+                .await?
+                .check()?;
+        }
+        db.query(
+            "INSERT INTO asset_partitions $row ON DUPLICATE KEY UPDATE last_event_id = $input.last_event_id, last_run_id = $input.last_run_id, last_timestamp = $input.last_timestamp",
+        )
+        .bind(("row", write))
+        .await?
+        .check()?;
+        rewritten += 1;
+    }
+
+    #[derive(Debug, SurrealValue)]
+    struct EventRow {
+        id: RecordId,
+        partition_key: PartitionKey,
+    }
+    let mut result = db
+        .query("SELECT id, partition_key FROM events WHERE partition_key.variant = 'Multi'")
+        .await?;
+    let events: Vec<EventRow> = result.take(0)?;
+    let mut event_rewrites = 0usize;
+    for ev in events {
+        let PartitionKey::Multi { dims } = &ev.partition_key else {
+            continue;
+        };
+        if is_sorted(dims) {
+            continue;
+        }
+        // Re-binding the same key canonicalizes: into_value sorts dims.
+        db.query("UPDATE $rec SET partition_key = $pk")
+            .bind(("rec", ev.id))
+            .bind(("pk", ev.partition_key))
+            .await?
+            .check()?;
+        event_rewrites += 1;
+    }
+    if rewritten > 0 || event_rewrites > 0 {
+        tracing::info!(
+            partitions = rewritten,
+            events = event_rewrites,
+            "migrated Multi partition keys to canonical dim order"
+        );
+    }
+    Ok(())
+}
+
 const SCHEMA: &str = "
 DEFINE TABLE IF NOT EXISTS events SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS code_location_id ON events TYPE string DEFAULT 'default';
@@ -650,6 +758,7 @@ impl SurrealStorage {
                 .await?;
             tracing::debug!("applying schema");
             db.query(SCHEMA).await?;
+            migrate_multi_partition_key_order(&db).await?;
             Ok(db)
         })
         .await?;
@@ -700,6 +809,7 @@ impl SurrealStorage {
                 .await?;
             tracing::debug!("applying schema");
             db.query(SCHEMA).await?;
+            migrate_multi_partition_key_order(&db).await?;
             Ok(db)
         })
         .await?;
@@ -780,6 +890,7 @@ impl SurrealStorage {
             db.use_ns(&namespace).use_db(&database).await?;
             tracing::debug!("applying schema");
             db.query(SCHEMA).await?;
+            migrate_multi_partition_key_order(&db).await?;
             Ok(db)
         })
         .await?;
@@ -3811,6 +3922,146 @@ mod tests {
         assert!(
             !plan.contains("SortTopKByKey") && !plan.contains("\"operator\":\"Sort\""),
             "asset page should not sort: {plan}"
+        );
+    }
+
+    /// The UNIQUE index compares the SERIALIZED partition_key, so the same
+    /// logical Multi key written with dims in a different order must
+    /// canonicalize to one row — Python builds dims from a HashMap whose
+    /// iteration order varies per instance.
+    #[tokio::test]
+    async fn test_multi_partition_key_dims_order_canonicalized() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        let cl = crate::storage::DEFAULT_CODE_LOCATION_ID;
+        let mk = |dims: Vec<(&str, &str)>| PartitionKey::Multi {
+            dims: dims
+                .into_iter()
+                .map(|(d, v)| (d.to_string(), vec![v.to_string()]))
+                .collect(),
+        };
+        let row = |pk: PartitionKey, event_id: &str, ts: i64| super::DbAssetPartitionWrite {
+            code_location_id: cl.to_string(),
+            asset_key: "inventory".to_string(),
+            partition_key: pk,
+            last_event_id: event_id.to_string(),
+            last_run_id: "r".to_string(),
+            last_timestamp: ts,
+        };
+
+        let date_first = mk(vec![("date", "2024-01-01"), ("region", "eu")]);
+        let region_first = mk(vec![("region", "eu"), ("date", "2024-01-01")]);
+        storage
+            .upsert_asset_partitions(vec![row(date_first.clone(), "ev1", 1)])
+            .await
+            .unwrap();
+        storage
+            .upsert_asset_partitions(vec![row(region_first, "ev2", 2)])
+            .await
+            .unwrap();
+
+        let parts = storage
+            .get_materialized_partitions(cl, "inventory")
+            .await
+            .unwrap();
+        assert_eq!(
+            parts,
+            vec![date_first],
+            "dims order must canonicalize to one row"
+        );
+        assert_eq!(
+            storage
+                .count_materialized_partitions(cl, "inventory")
+                .await
+                .unwrap(),
+            1,
+            "the count must agree with the deduped key set"
+        );
+    }
+
+    /// Rows persisted by earlier builds carry HashMap-ordered dims; the
+    /// startup migration must collapse duplicates onto the canonical form
+    /// and rewrite unsorted event keys.
+    #[tokio::test]
+    async fn test_migration_canonicalizes_legacy_multi_rows() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        let cl = crate::storage::DEFAULT_CODE_LOCATION_ID;
+        // Legacy row with unsorted dims, written raw to bypass the
+        // canonicalizing serializer.
+        storage
+            .db
+            .query(
+                "CREATE asset_partitions CONTENT { code_location_id: 'default', \
+                 asset_key: 'inv', partition_key: { variant: 'Multi', dims: \
+                 [['region', ['eu']], ['date', ['2024-01-01']]] }, \
+                 last_event_id: 'e1', last_run_id: 'r1', last_timestamp: 1 }",
+            )
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+        // The same logical partition written by a current build (sorted).
+        let sorted = PartitionKey::Multi {
+            dims: vec![
+                ("date".to_string(), vec!["2024-01-01".to_string()]),
+                ("region".to_string(), vec!["eu".to_string()]),
+            ],
+        };
+        storage
+            .upsert_asset_partitions(vec![DbAssetPartitionWrite {
+                code_location_id: cl.to_string(),
+                asset_key: "inv".to_string(),
+                partition_key: sorted.clone(),
+                last_event_id: "e2".to_string(),
+                last_run_id: "r2".to_string(),
+                last_timestamp: 2,
+            }])
+            .await
+            .unwrap();
+        // Legacy event with unsorted dims.
+        storage
+            .db
+            .query(
+                "CREATE events CONTENT { code_location_id: 'default', \
+                 event_type: 'Materialization', asset_key: 'inv', run_id: 'r1', \
+                 partition_key: { variant: 'Multi', dims: \
+                 [['region', ['eu']], ['date', ['2024-01-01']]] }, \
+                 timestamp: 1, metadata: [] }",
+            )
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+
+        migrate_multi_partition_key_order(&storage.db)
+            .await
+            .unwrap();
+
+        let parts = storage
+            .get_materialized_partitions(cl, "inv")
+            .await
+            .unwrap();
+        assert_eq!(parts, vec![sorted.clone()], "one canonical row survives");
+        let ts = storage.get_partition_timestamps(cl, "inv").await.unwrap();
+        assert_eq!(ts, vec![(sorted.clone(), 2)], "newest row's values win");
+        // The event is reachable through an equality lookup with the
+        // canonical (sorted) bind.
+        let mut result = storage
+            .db
+            .query("SELECT count() AS total FROM events WHERE partition_key = $pk GROUP ALL")
+            .bind(("pk", sorted))
+            .await
+            .unwrap();
+        let total: Option<u64> = result.take((0, "total")).unwrap();
+        assert_eq!(
+            total,
+            Some(1),
+            "event key must be rewritten to canonical order"
         );
     }
 

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -301,7 +301,7 @@ impl DbStoredEvent {
 
 /// Current storage schema version. Bump when adding a migration step to
 /// [`run_migrations`].
-const SCHEMA_VERSION: u32 = 2;
+const SCHEMA_VERSION: u32 = 3;
 /// `kv` key holding the persisted schema version. Absent means v1 — a
 /// database from before versioning existed.
 const SCHEMA_VERSION_KEY: &str = "schema_version";
@@ -335,6 +335,55 @@ async fn set_schema_version(db: &Surreal<Any>, version: u32) -> anyhow::Result<(
     Ok(())
 }
 
+/// `kv` key listing dynamic partition keys that contain display-reserved
+/// characters (registered before the reserved-char guard existed). Operator
+/// remediation: delete each and re-register it under a clean name.
+const RESERVED_DYNAMIC_KEYS_KEY: &str = "reserved_dynamic_keys";
+
+/// v2 → v3 scan: stored reserved-char dynamic keys still classify (matching
+/// is structural) but cannot round-trip any display-string path (UI, gRPC).
+/// Renaming them silently would change user-visible keys, so warn and record
+/// them in `kv` instead.
+async fn scan_reserved_char_dynamic_keys(db: &Surreal<Any>) -> anyhow::Result<()> {
+    let mut result = db
+        .query(
+            "SELECT code_location_id, partitions_def_name, partition_key, create_timestamp \
+             FROM dynamic_partitions",
+        )
+        .await?;
+    let rows: Vec<DbDynamicPartition> = result.take(0)?;
+    let offenders: Vec<String> = rows
+        .iter()
+        .filter(|r| PartitionKey::reserved_display_char(&r.partition_key).is_some())
+        .map(|r| {
+            format!(
+                "{}/{}: '{}'",
+                r.code_location_id, r.partitions_def_name, r.partition_key
+            )
+        })
+        .collect();
+    if offenders.is_empty() {
+        return Ok(());
+    }
+    for o in offenders.iter().take(20) {
+        tracing::warn!(
+            key = %o,
+            "dynamic partition key contains display-reserved characters; \
+             delete it and re-register under a clean name"
+        );
+    }
+    let body = serde_json::to_vec(&offenders[..offenders.len().min(100)])?;
+    db.query(
+        "INSERT INTO kv { key: $key, value: $value } \
+         ON DUPLICATE KEY UPDATE value = $value",
+    )
+    .bind(("key", RESERVED_DYNAMIC_KEYS_KEY.to_string()))
+    .bind(("value", Bytes::from(body)))
+    .await?
+    .check()?;
+    Ok(())
+}
+
 /// Versioned in-place migrations, run once at every constructor. Steps
 /// between the persisted version and [`SCHEMA_VERSION`] run in order; the
 /// stamp is written only after they all succeed (each step is idempotent and
@@ -347,6 +396,15 @@ async fn run_migrations(db: &Surreal<Any>) -> anyhow::Result<()> {
     }
     if from < 2 {
         migrate_multi_partition_key_order(db).await?;
+    }
+    if from < 3 {
+        if from >= 2 {
+            // Released 0.1.x wheels predate canonical-on-write Multi dims;
+            // rows they wrote into a v2-stamped database were never healed
+            // once the every-boot scan became version-gated.
+            migrate_multi_partition_key_order(db).await?;
+        }
+        scan_reserved_char_dynamic_keys(db).await?;
     }
     set_schema_version(db, SCHEMA_VERSION).await?;
     tracing::info!(from, to = SCHEMA_VERSION, "storage schema migrated");
@@ -4177,6 +4235,85 @@ mod tests {
             Some(1),
             "event key must be rewritten to canonical order"
         );
+    }
+
+    /// Released 0.1.x wheels predate canonical-on-write Multi dims; rows they
+    /// write into a v2-stamped database were never healed once the every-boot
+    /// scan became version-gated. v3 re-runs the heal once.
+    #[tokio::test]
+    async fn test_v3_reheals_rows_written_into_v2_database() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        set_schema_version(&storage.db, 2).await.unwrap();
+        storage
+            .db
+            .query(
+                "CREATE asset_partitions CONTENT { code_location_id: 'default', \
+                 asset_key: 'inv', partition_key: { variant: 'Multi', dims: \
+                 [['region', ['eu']], ['date', ['2024-01-01']]] }, \
+                 last_event_id: 'e1', last_run_id: 'r1', last_timestamp: 1 }",
+            )
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+
+        run_migrations(&storage.db).await.unwrap();
+
+        assert_eq!(stored_schema_version(&storage.db).await.unwrap(), 3);
+        #[derive(Debug, SurrealValue)]
+        struct PkRow {
+            partition_key: PartitionKey,
+        }
+        let mut result = storage
+            .db
+            .query("SELECT partition_key FROM asset_partitions")
+            .await
+            .unwrap();
+        let rows: Vec<PkRow> = result.take(0).unwrap();
+        assert_eq!(rows.len(), 1);
+        let PartitionKey::Multi { dims } = &rows[0].partition_key else {
+            unreachable!()
+        };
+        assert_eq!(dims[0].0, "date", "v3 must re-heal post-v2 legacy writes");
+    }
+
+    /// Pre-guard databases can hold dynamic keys with display-reserved
+    /// characters. Renaming them silently would change user-visible keys, so
+    /// v3 records them for operator remediation instead.
+    #[tokio::test]
+    async fn test_v3_records_reserved_char_dynamic_keys() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        set_schema_version(&storage.db, 2).await.unwrap();
+        storage
+            .db
+            .query(
+                "CREATE dynamic_partitions CONTENT { code_location_id: 'default', \
+                 partitions_def_name: 'colors', partition_key: 'us|eu', \
+                 create_timestamp: 1 }",
+            )
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+
+        run_migrations(&storage.db).await.unwrap();
+
+        let mut res = storage
+            .db
+            .query("SELECT * FROM kv WHERE key = $key")
+            .bind(("key", RESERVED_DYNAMIC_KEYS_KEY.to_string()))
+            .await
+            .unwrap();
+        let rows: Vec<DbKv> = res.take(0).unwrap();
+        assert_eq!(rows.len(), 1, "offending keys must be recorded in kv");
+        let body = String::from_utf8(rows[0].value.to_vec()).unwrap();
+        assert!(body.contains("colors") && body.contains("us|eu"), "{body}");
     }
 
     /// The heal's values come from a snapshot taken before its write loop, so

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -357,18 +357,24 @@ async fn migrate_multi_partition_key_order(db: &Surreal<Any>) -> anyhow::Result<
             last_run_id: latest.last_run_id.clone().unwrap_or_default(),
             last_timestamp: latest.last_timestamp.unwrap_or_default(),
         };
-        for row in &group {
-            db.query("DELETE $rec")
-                .bind(("rec", row.id.clone()))
-                .await?
-                .check()?;
-        }
+        // Write the canonical row before touching the legacy ones: a crash
+        // between the two steps leaves a recoverable duplicate for the next
+        // start to clean up, never a lost partition. A pre-existing sorted
+        // row is updated in place via the UNIQUE index.
         db.query(
             "INSERT INTO asset_partitions $row ON DUPLICATE KEY UPDATE last_event_id = $input.last_event_id, last_run_id = $input.last_run_id, last_timestamp = $input.last_timestamp",
         )
         .bind(("row", write))
         .await?
         .check()?;
+        for row in &group {
+            if matches!(&row.partition_key, PartitionKey::Multi { dims } if !is_sorted(dims)) {
+                db.query("DELETE $rec")
+                    .bind(("rec", row.id.clone()))
+                    .await?
+                    .check()?;
+            }
+        }
         rewritten += 1;
     }
 
@@ -4062,6 +4068,82 @@ mod tests {
             Some(1),
             "event key must be rewritten to canonical order"
         );
+    }
+
+    /// A crash mid-migration must never lose a partition: the canonical row
+    /// is written before any legacy row is deleted, so a pre-existing sorted
+    /// row is updated in place — its record id survives — and the stale
+    /// duplicate is only removed afterwards.
+    #[tokio::test]
+    async fn test_migration_never_deletes_the_canonical_row() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        let cl = crate::storage::DEFAULT_CODE_LOCATION_ID;
+        let sorted = PartitionKey::Multi {
+            dims: vec![
+                ("date".to_string(), vec!["2024-01-01".to_string()]),
+                ("region".to_string(), vec!["eu".to_string()]),
+            ],
+        };
+        storage
+            .upsert_asset_partitions(vec![DbAssetPartitionWrite {
+                code_location_id: cl.to_string(),
+                asset_key: "inv".to_string(),
+                partition_key: sorted.clone(),
+                last_event_id: "e1".to_string(),
+                last_run_id: "r1".to_string(),
+                last_timestamp: 1,
+            }])
+            .await
+            .unwrap();
+        #[derive(Debug, SurrealValue)]
+        struct IdRow {
+            id: RecordId,
+            last_event_id: String,
+            last_timestamp: i64,
+        }
+        let mut result = storage
+            .db
+            .query("SELECT id, last_event_id, last_timestamp FROM asset_partitions")
+            .await
+            .unwrap();
+        let before: Vec<IdRow> = result.take(0).unwrap();
+        assert_eq!(before.len(), 1);
+        let canonical_id = before[0].id.clone();
+        // Legacy duplicate with unsorted dims and newer values (raw CREATE
+        // bypasses the canonicalizing serializer).
+        storage
+            .db
+            .query(
+                "CREATE asset_partitions CONTENT { code_location_id: 'default', \
+                 asset_key: 'inv', partition_key: { variant: 'Multi', dims: \
+                 [['region', ['eu']], ['date', ['2024-01-01']]] }, \
+                 last_event_id: 'e9', last_run_id: 'r9', last_timestamp: 5 }",
+            )
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+
+        migrate_multi_partition_key_order(&storage.db)
+            .await
+            .unwrap();
+
+        let mut result = storage
+            .db
+            .query("SELECT id, last_event_id, last_timestamp FROM asset_partitions")
+            .await
+            .unwrap();
+        let after: Vec<IdRow> = result.take(0).unwrap();
+        assert_eq!(after.len(), 1, "one canonical row survives");
+        assert_eq!(
+            after[0].id, canonical_id,
+            "the canonical row must be updated in place, never deleted"
+        );
+        assert_eq!(after[0].last_event_id, "e9", "newest row's values win");
+        assert_eq!(after[0].last_timestamp, 5);
     }
 
     /// `store_events`/`store_event` upsert `asset_partitions` via `INSERT ... ON

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -443,9 +443,7 @@ async fn migrate_multi_partition_key_order(db: &Surreal<Any>) -> anyhow::Result<
     let events: Vec<EventRow> = result.take(0)?;
     let to_rewrite: Vec<EventRow> = events
         .into_iter()
-        .filter(
-            |ev| matches!(&ev.partition_key, PartitionKey::Multi { dims } if !is_sorted(dims)),
-        )
+        .filter(|ev| matches!(&ev.partition_key, PartitionKey::Multi { dims } if !is_sorted(dims)))
         .collect();
     let event_rewrites = to_rewrite.len();
     // Chunked multi-statement updates: one round-trip per 200 rows instead

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -620,7 +620,9 @@ DEFINE TABLE IF NOT EXISTS backfills SCHEMALESS;
 DEFINE FIELD IF NOT EXISTS backfill_id ON backfills TYPE string;
 DEFINE FIELD IF NOT EXISTS code_location_id ON backfills TYPE string DEFAULT 'default';
 DEFINE FIELD IF NOT EXISTS status ON backfills TYPE string;
-DEFINE FIELD IF NOT EXISTS strategy ON backfills TYPE object FLEXIBLE;
+-- FLEXIBLE is SCHEMAFULL-only; on this SCHEMALESS table a plain object type
+-- validates the shape without stripping nested content.
+DEFINE FIELD IF NOT EXISTS strategy ON backfills TYPE object;
 DEFINE FIELD IF NOT EXISTS failure_policy ON backfills TYPE string;
 DEFINE FIELD IF NOT EXISTS asset_selection ON backfills TYPE array<string>;
 DEFINE FIELD IF NOT EXISTS partition_keys ON backfills TYPE array;
@@ -820,7 +822,7 @@ impl SurrealStorage {
                 .use_db(DEFAULT_DATABASE)
                 .await?;
             tracing::debug!("applying schema");
-            db.query(SCHEMA).await?;
+            db.query(SCHEMA).await?.check()?;
             run_migrations(&db).await?;
             Ok(db)
         })
@@ -871,7 +873,7 @@ impl SurrealStorage {
                 .use_db(DEFAULT_DATABASE)
                 .await?;
             tracing::debug!("applying schema");
-            db.query(SCHEMA).await?;
+            db.query(SCHEMA).await?.check()?;
             run_migrations(&db).await?;
             Ok(db)
         })
@@ -952,7 +954,7 @@ impl SurrealStorage {
             );
             db.use_ns(&namespace).use_db(&database).await?;
             tracing::debug!("applying schema");
-            db.query(SCHEMA).await?;
+            db.query(SCHEMA).await?.check()?;
             run_migrations(&db).await?;
             Ok(db)
         })

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -299,11 +299,65 @@ impl DbStoredEvent {
     }
 }
 
-/// In-place migration: rewrite persisted `Multi` partition keys whose dims
-/// aren't in canonical (sorted) order. Earlier builds serialized HashMap
-/// iteration order, which defeats the `asset_partitions` UNIQUE index (one
-/// logical partition could occupy several rows) and `partition_key =`
-/// lookups on `events`. Idempotent; sorted rows are left untouched.
+/// Current storage schema version. Bump when adding a migration step to
+/// [`run_migrations`].
+const SCHEMA_VERSION: u32 = 2;
+/// `kv` key holding the persisted schema version. Absent means v1 — a
+/// database from before versioning existed.
+const SCHEMA_VERSION_KEY: &str = "schema_version";
+
+async fn stored_schema_version(db: &Surreal<Any>) -> anyhow::Result<u32> {
+    let mut result = db
+        .query("SELECT * FROM kv WHERE key = $key LIMIT 1")
+        .bind(("key", SCHEMA_VERSION_KEY.to_string()))
+        .await?;
+    let rows: Vec<DbKv> = result.take(0)?;
+    Ok(rows
+        .into_iter()
+        .next()
+        .and_then(|kv| String::from_utf8(kv.value.to_vec()).ok())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1))
+}
+
+async fn set_schema_version(db: &Surreal<Any>, version: u32) -> anyhow::Result<()> {
+    db.query("DELETE FROM kv WHERE key = $key")
+        .bind(("key", SCHEMA_VERSION_KEY.to_string()))
+        .await?
+        .check()?;
+    let _: Option<DbKv> = db
+        .create("kv")
+        .content(DbKv {
+            key: SCHEMA_VERSION_KEY.to_string(),
+            value: Bytes::from(version.to_string().into_bytes()),
+        })
+        .await?;
+    Ok(())
+}
+
+/// Versioned in-place migrations, run once at every constructor. Steps
+/// between the persisted version and [`SCHEMA_VERSION`] run in order; the
+/// stamp is written only after they all succeed (each step is idempotent and
+/// crash-safe, so a partial run simply resumes on the next start). A
+/// database already at the current version skips the table scans entirely.
+async fn run_migrations(db: &Surreal<Any>) -> anyhow::Result<()> {
+    let from = stored_schema_version(db).await?;
+    if from >= SCHEMA_VERSION {
+        return Ok(());
+    }
+    if from < 2 {
+        migrate_multi_partition_key_order(db).await?;
+    }
+    set_schema_version(db, SCHEMA_VERSION).await?;
+    tracing::info!(from, to = SCHEMA_VERSION, "storage schema migrated");
+    Ok(())
+}
+
+/// v1 → v2: rewrite persisted `Multi` partition keys whose dims aren't in
+/// canonical (sorted) order. Earlier builds serialized HashMap iteration
+/// order, which defeats the `asset_partitions` UNIQUE index (one logical
+/// partition could occupy several rows) and `partition_key =` lookups on
+/// `events`. Idempotent; sorted rows are left untouched.
 async fn migrate_multi_partition_key_order(db: &Surreal<Any>) -> anyhow::Result<()> {
     fn is_sorted(dims: &[(String, Vec<String>)]) -> bool {
         dims.windows(2).all(|w| w[0].0 <= w[1].0)
@@ -387,21 +441,26 @@ async fn migrate_multi_partition_key_order(db: &Surreal<Any>) -> anyhow::Result<
         .query("SELECT id, partition_key FROM events WHERE partition_key.variant = 'Multi'")
         .await?;
     let events: Vec<EventRow> = result.take(0)?;
-    let mut event_rewrites = 0usize;
-    for ev in events {
-        let PartitionKey::Multi { dims } = &ev.partition_key else {
-            continue;
-        };
-        if is_sorted(dims) {
-            continue;
+    let to_rewrite: Vec<EventRow> = events
+        .into_iter()
+        .filter(
+            |ev| matches!(&ev.partition_key, PartitionKey::Multi { dims } if !is_sorted(dims)),
+        )
+        .collect();
+    let event_rewrites = to_rewrite.len();
+    // Chunked multi-statement updates: one round-trip per 200 rows instead
+    // of per row. Re-binding the same key canonicalizes (into_value sorts).
+    for chunk in to_rewrite.chunks(200) {
+        let stmts: String = (0..chunk.len())
+            .map(|i| format!("UPDATE $r{i} SET partition_key = $p{i};"))
+            .collect();
+        let mut query = db.query(stmts);
+        for (i, ev) in chunk.iter().enumerate() {
+            query = query
+                .bind((format!("r{i}"), ev.id.clone()))
+                .bind((format!("p{i}"), ev.partition_key.clone()));
         }
-        // Re-binding the same key canonicalizes: into_value sorts dims.
-        db.query("UPDATE $rec SET partition_key = $pk")
-            .bind(("rec", ev.id))
-            .bind(("pk", ev.partition_key))
-            .await?
-            .check()?;
-        event_rewrites += 1;
+        query.await?.check()?;
     }
     if rewritten > 0 || event_rewrites > 0 {
         tracing::info!(
@@ -764,7 +823,7 @@ impl SurrealStorage {
                 .await?;
             tracing::debug!("applying schema");
             db.query(SCHEMA).await?;
-            migrate_multi_partition_key_order(&db).await?;
+            run_migrations(&db).await?;
             Ok(db)
         })
         .await?;
@@ -815,7 +874,7 @@ impl SurrealStorage {
                 .await?;
             tracing::debug!("applying schema");
             db.query(SCHEMA).await?;
-            migrate_multi_partition_key_order(&db).await?;
+            run_migrations(&db).await?;
             Ok(db)
         })
         .await?;
@@ -896,7 +955,7 @@ impl SurrealStorage {
             db.use_ns(&namespace).use_db(&database).await?;
             tracing::debug!("applying schema");
             db.query(SCHEMA).await?;
-            migrate_multi_partition_key_order(&db).await?;
+            run_migrations(&db).await?;
             Ok(db)
         })
         .await?;
@@ -4101,6 +4160,114 @@ mod tests {
             Some(1),
             "event key must be rewritten to canonical order"
         );
+    }
+
+    /// A fresh database is stamped with the current schema version at
+    /// construction, so it never pays the legacy table scans again.
+    #[tokio::test]
+    async fn test_fresh_database_stamped_with_current_schema_version() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        assert_eq!(
+            stored_schema_version(&storage.db).await.unwrap(),
+            SCHEMA_VERSION
+        );
+    }
+
+    /// A database already at the current version must not re-run migrations:
+    /// a planted unsorted row stays untouched because the v1→v2 scan is
+    /// skipped entirely.
+    #[tokio::test]
+    async fn test_migrations_skip_when_version_is_current() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        storage
+            .db
+            .query(
+                "CREATE asset_partitions CONTENT { code_location_id: 'default', \
+                 asset_key: 'inv', partition_key: { variant: 'Multi', dims: \
+                 [['region', ['eu']], ['date', ['2024-01-01']]] }, \
+                 last_event_id: 'e1', last_run_id: 'r1', last_timestamp: 1 }",
+            )
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+
+        // Simulate the next startup's migration pass.
+        run_migrations(&storage.db).await.unwrap();
+
+        #[derive(Debug, SurrealValue)]
+        struct PkRow {
+            partition_key: PartitionKey,
+        }
+        let mut result = storage
+            .db
+            .query("SELECT partition_key FROM asset_partitions")
+            .await
+            .unwrap();
+        let rows: Vec<PkRow> = result.take(0).unwrap();
+        assert_eq!(rows.len(), 1);
+        let PartitionKey::Multi { dims } = &rows[0].partition_key else {
+            unreachable!()
+        };
+        assert_eq!(
+            dims[0].0, "region",
+            "a database at the current version must not be rescanned"
+        );
+    }
+
+    /// A pre-versioning database (no schema_version key) is treated as v1:
+    /// the Multi-key migration runs once, then the version is stamped.
+    #[tokio::test]
+    async fn test_legacy_database_migrates_and_stamps_version() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        // Erase the stamp to simulate a database from before versioning.
+        storage
+            .db
+            .query("DELETE FROM kv WHERE key = $key")
+            .bind(("key", SCHEMA_VERSION_KEY.to_string()))
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+        storage
+            .db
+            .query(
+                "CREATE asset_partitions CONTENT { code_location_id: 'default', \
+                 asset_key: 'inv', partition_key: { variant: 'Multi', dims: \
+                 [['region', ['eu']], ['date', ['2024-01-01']]] }, \
+                 last_event_id: 'e1', last_run_id: 'r1', last_timestamp: 1 }",
+            )
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+
+        run_migrations(&storage.db).await.unwrap();
+
+        assert_eq!(
+            stored_schema_version(&storage.db).await.unwrap(),
+            SCHEMA_VERSION
+        );
+        let sorted = PartitionKey::Multi {
+            dims: vec![
+                ("date".to_string(), vec!["2024-01-01".to_string()]),
+                ("region".to_string(), vec!["eu".to_string()]),
+            ],
+        };
+        let parts = storage
+            .get_materialized_partitions(crate::storage::DEFAULT_CODE_LOCATION_ID, "inv")
+            .await
+            .unwrap();
+        assert_eq!(parts, vec![sorted], "legacy row canonicalized exactly once");
     }
 
     /// A crash mid-migration must never lose a partition: the canonical row

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -2788,15 +2788,28 @@ impl PerCodeLocationStorage for SurrealStorage {
     ) -> Result<Option<StoredEvent>> {
         let event_type_str = "Materialization".to_string();
         let mut result = if let Some(partition_key) = partition {
-            // The display string may denote a Single or a Multi key.
-            let candidates = PartitionKey::display_candidates(partition_key);
-            self.db
-                .query("SELECT * FROM events WHERE code_location_id = $cl AND asset_key = $asset_key AND partition_key IN $candidates AND event_type = $event_type ORDER BY timestamp DESC LIMIT 1")
-                .bind(("cl", code_location_id.to_string()))
-                .bind(("asset_key", asset_key.to_string()))
-                .bind(("candidates", candidates))
-                .bind(("event_type", event_type_str))
-                .await?
+            // The display string may denote a Single or a Multi key. Both
+            // readings can have rows when the asset's def changed shape
+            // (legacy Single events vs current Multi ones) — the structured
+            // reading wins, so try candidates most-structured first instead
+            // of letting timestamps decide.
+            for cand in PartitionKey::display_candidates(partition_key)
+                .into_iter()
+                .rev()
+            {
+                let mut result = self.db
+                    .query("SELECT * FROM events WHERE code_location_id = $cl AND asset_key = $asset_key AND partition_key = $pk AND event_type = $event_type ORDER BY timestamp DESC LIMIT 1")
+                    .bind(("cl", code_location_id.to_string()))
+                    .bind(("asset_key", asset_key.to_string()))
+                    .bind(("pk", cand))
+                    .bind(("event_type", event_type_str.clone()))
+                    .await?;
+                let events: Vec<DbStoredEvent> = result.take(0)?;
+                if let Some(e) = events.into_iter().next() {
+                    return Ok(Some(e.into_stored_event()));
+                }
+            }
+            return Ok(None);
         } else {
             self.db
                 .query("SELECT * FROM events WHERE code_location_id = $cl AND asset_key = $asset_key AND event_type = $event_type ORDER BY timestamp DESC LIMIT 1")
@@ -3201,16 +3214,25 @@ impl PerCodeLocationStorage for SurrealStorage {
         partition_key: &str,
         limit: usize,
     ) -> Result<Vec<StoredEvent>> {
-        let mut result = self
-            .db
-            .query("SELECT * FROM events WHERE code_location_id = $cl AND asset_key = $asset_key AND partition_key IN $candidates ORDER BY timestamp DESC LIMIT $limit")
-            .bind(("cl", code_location_id.to_string()))
-            .bind(("asset_key", asset_key.to_string()))
-            .bind(("candidates", PartitionKey::display_candidates(partition_key)))
-            .bind(("limit", limit))
-            .await?;
-        let events: Vec<DbStoredEvent> = result.take(0)?;
-        Ok(events.into_iter().map(|e| e.into_stored_event()).collect())
+        // Most-structured reading first; see get_latest_materialization.
+        for cand in PartitionKey::display_candidates(partition_key)
+            .into_iter()
+            .rev()
+        {
+            let mut result = self
+                .db
+                .query("SELECT * FROM events WHERE code_location_id = $cl AND asset_key = $asset_key AND partition_key = $pk ORDER BY timestamp DESC LIMIT $limit")
+                .bind(("cl", code_location_id.to_string()))
+                .bind(("asset_key", asset_key.to_string()))
+                .bind(("pk", cand))
+                .bind(("limit", limit))
+                .await?;
+            let events: Vec<DbStoredEvent> = result.take(0)?;
+            if !events.is_empty() {
+                return Ok(events.into_iter().map(|e| e.into_stored_event()).collect());
+            }
+        }
+        Ok(Vec::new())
     }
 
     async fn get_materialized_partitions(
@@ -4258,6 +4280,68 @@ mod tests {
                 .await
                 .unwrap()
                 .is_some()
+        );
+    }
+
+    /// After a def-shape change, legacy Single events whose key strings look
+    /// like Multi displays can coexist with real Multi events for the same
+    /// asset. Display lookups must prefer the structured (Multi) reading —
+    /// not whichever row happens to be newest.
+    #[tokio::test]
+    async fn test_partition_string_lookup_prefers_structured_multi() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        let cl = crate::storage::DEFAULT_CODE_LOCATION_ID;
+        let multi = PartitionKey::Multi {
+            dims: vec![
+                ("date".to_string(), vec!["2024-01-01".to_string()]),
+                ("region".to_string(), vec!["eu".to_string()]),
+            ],
+        };
+        let display = multi.to_display();
+
+        // Legacy event from the asset's static-keyed era — NEWER timestamp.
+        let mut old_single = make_event("inv", "r1", 200);
+        old_single.partition_key = Some(PartitionKey::Single {
+            keys: vec![display.clone()],
+        });
+        storage.store_event(&old_single).await.unwrap();
+
+        let mut multi_event = make_event("inv", "r2", 100);
+        multi_event.partition_key = Some(multi.clone());
+        storage.store_event(&multi_event).await.unwrap();
+
+        let latest = storage
+            .get_latest_materialization(cl, "inv", Some(&display))
+            .await
+            .unwrap()
+            .expect("lookup must match");
+        assert_eq!(
+            latest.run_id, "r2",
+            "the structured Multi reading wins over a newer legacy Single row"
+        );
+        let events = storage
+            .get_partition_events(cl, "inv", &display, 10)
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1, "only the Multi partition's events return");
+        assert_eq!(events[0].run_id, "r2");
+
+        // The Single reading still works when no Multi rows exist.
+        let mut plain = make_event("inv2", "r3", 100);
+        plain.partition_key = Some(PartitionKey::Single {
+            keys: vec![display.clone()],
+        });
+        storage.store_event(&plain).await.unwrap();
+        assert!(
+            storage
+                .get_latest_materialization(cl, "inv2", Some(&display))
+                .await
+                .unwrap()
+                .is_some(),
+            "falls back to the Single reading"
         );
     }
 

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -353,6 +353,28 @@ async fn run_migrations(db: &Surreal<Any>) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Upsert the heal's canonical row. The migration computes its values from a
+/// snapshot taken before the write loop, so a live materialization can land a
+/// newer canonical row in between.
+async fn upsert_canonical_partition_row(
+    db: &Surreal<Any>,
+    write: DbAssetPartitionWrite,
+) -> anyhow::Result<()> {
+    // Pointer fields only move forward: a stale snapshot must never roll
+    // back a row a live materialization just advanced. last_timestamp is
+    // compared first and assigned last so the guards all see the old value.
+    db.query(
+        "INSERT INTO asset_partitions $row ON DUPLICATE KEY UPDATE \
+         last_event_id = IF $input.last_timestamp > last_timestamp THEN $input.last_event_id ELSE last_event_id END, \
+         last_run_id = IF $input.last_timestamp > last_timestamp THEN $input.last_run_id ELSE last_run_id END, \
+         last_timestamp = IF $input.last_timestamp > last_timestamp THEN $input.last_timestamp ELSE last_timestamp END",
+    )
+    .bind(("row", write))
+    .await?
+    .check()?;
+    Ok(())
+}
+
 /// v1 → v2: rewrite persisted `Multi` partition keys whose dims aren't in
 /// canonical (sorted) order. Earlier builds serialized HashMap iteration
 /// order, which defeats the `asset_partitions` UNIQUE index (one logical
@@ -415,12 +437,7 @@ async fn migrate_multi_partition_key_order(db: &Surreal<Any>) -> anyhow::Result<
         // between the two steps leaves a recoverable duplicate for the next
         // start to clean up, never a lost partition. A pre-existing sorted
         // row is updated in place via the UNIQUE index.
-        db.query(
-            "INSERT INTO asset_partitions $row ON DUPLICATE KEY UPDATE last_event_id = $input.last_event_id, last_run_id = $input.last_run_id, last_timestamp = $input.last_timestamp",
-        )
-        .bind(("row", write))
-        .await?
-        .check()?;
+        upsert_canonical_partition_row(db, write).await?;
         for row in &group {
             if matches!(&row.partition_key, PartitionKey::Multi { dims } if !is_sorted(dims)) {
                 db.query("DELETE $rec")
@@ -4160,6 +4177,55 @@ mod tests {
             Some(1),
             "event key must be rewritten to canonical order"
         );
+    }
+
+    /// The heal's values come from a snapshot taken before its write loop, so
+    /// a live materialization can land newer pointers on the canonical row in
+    /// between — the upsert must not roll them back to snapshot values.
+    #[tokio::test]
+    async fn test_migration_upsert_never_rolls_back_newer_pointers() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        let key = PartitionKey::Multi {
+            dims: vec![
+                ("date".to_string(), vec!["2024-01-01".to_string()]),
+                ("region".to_string(), vec!["eu".to_string()]),
+            ],
+        };
+        let row = |event: &str, ts: i64| DbAssetPartitionWrite {
+            code_location_id: "default".to_string(),
+            asset_key: "a".to_string(),
+            partition_key: key.clone(),
+            last_event_id: event.to_string(),
+            last_run_id: format!("run-{event}"),
+            last_timestamp: ts,
+        };
+        // The live writer's row lands first with newer pointers...
+        upsert_canonical_partition_row(&storage.db, row("ev-new", 200))
+            .await
+            .unwrap();
+        // ...then the migration applies its stale snapshot values.
+        upsert_canonical_partition_row(&storage.db, row("ev-old", 100))
+            .await
+            .unwrap();
+        #[derive(Debug, SurrealValue)]
+        struct Ptr {
+            last_event_id: String,
+            last_timestamp: i64,
+        }
+        let mut res = storage
+            .db
+            .query(
+                "SELECT last_event_id, last_timestamp FROM asset_partitions WHERE asset_key = 'a'",
+            )
+            .await
+            .unwrap();
+        let rows: Vec<Ptr> = res.take(0).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].last_timestamp, 200, "newer pointers must survive");
+        assert_eq!(rows[0].last_event_id, "ev-new");
     }
 
     /// Two processes opening the same fresh/v1 remote database race the

--- a/rust/rivers-core/src/timegrid.rs
+++ b/rust/rivers-core/src/timegrid.rs
@@ -82,6 +82,53 @@ impl TimeGrid {
         Ok(shifted.format(&self.fmt).to_string())
     }
 
+    /// Enumerate the grid keys in `[from, to]` (inclusive) without touching
+    /// the rest of the universe — O(range), not O(universe). Callers pass
+    /// endpoints already validated as on-grid keys, so every tick between
+    /// them is inside `[start, end)` by construction.
+    pub fn keys_in_range(&self, from: NaiveDateTime, to: NaiveDateTime) -> Result<Vec<String>> {
+        let mut out = Vec::new();
+        if to < from {
+            return Ok(out);
+        }
+        if let Some(secs) = self.interval_seconds {
+            let interval_ns = (secs * 1_000_000_000.0) as i64;
+            if interval_ns <= 0 {
+                bail!("TimeWindow interval must be positive");
+            }
+            let step = chrono::Duration::nanoseconds(interval_ns);
+            let mut t = from;
+            while t <= to {
+                out.push(t.format(&self.fmt).to_string());
+                match t.checked_add_signed(step) {
+                    Some(next) => t = next,
+                    None => break,
+                }
+            }
+        } else if let Some(expr) = &self.cron_schedule {
+            let cron = parse_cron(expr)?;
+            // Anchor one second below `from` (cron's resolution) so an
+            // on-tick `from` is included — a sub-second anchor makes croner
+            // carry the fraction into every yielded tick.
+            let anchor = from
+                .checked_sub_signed(chrono::Duration::seconds(1))
+                .unwrap_or(from);
+            for tick in cron.iter_from(Utc.from_utc_datetime(&anchor), croner::Direction::Forward) {
+                let t = cron_tick_naive(tick);
+                if t < from {
+                    continue;
+                }
+                if t > to {
+                    break;
+                }
+                out.push(t.format(&self.fmt).to_string());
+            }
+        } else {
+            bail!("TimeWindow requires either cron_schedule or interval_seconds");
+        }
+        Ok(out)
+    }
+
     /// Nearest valid keys around `dt` — the latest grid tick `<= dt` and the
     /// earliest tick `> dt`, both clamped to `[start, end)`. Best-effort for
     /// diagnostics: a side with no representable tick is `None`.
@@ -125,14 +172,14 @@ impl TimeGrid {
             let prev = {
                 let anchor = Utc.from_utc_datetime(&std::cmp::min(dt, end_dt));
                 cron.iter_from(anchor, croner::Direction::Backward)
-                    .map(|t| t.naive_utc())
+                    .map(cron_tick_naive)
                     .find(|t| *t <= dt && *t < end_dt)
                     .filter(|t| *t >= self.start)
             };
             let next = {
                 let anchor = Utc.from_utc_datetime(&std::cmp::max(dt, self.start));
                 cron.iter_from(anchor, croner::Direction::Forward)
-                    .map(|t| t.naive_utc())
+                    .map(cron_tick_naive)
                     .find(|t| *t > dt)
                     .filter(|t| *t < end_dt)
             };
@@ -141,6 +188,14 @@ impl TimeGrid {
             (None, None)
         }
     }
+}
+
+/// croner carries a sub-second anchor fraction into every yielded tick;
+/// cron schedules are second-granular, so normalize to whole seconds.
+fn cron_tick_naive(tick: chrono::DateTime<Utc>) -> NaiveDateTime {
+    use chrono::Timelike;
+    let naive = tick.naive_utc();
+    naive.with_nanosecond(0).unwrap_or(naive)
 }
 
 fn parse_cron(expr: &str) -> Result<croner::Cron> {
@@ -231,6 +286,39 @@ mod tests {
 
     fn dt(s: &str) -> chrono::NaiveDateTime {
         chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").unwrap()
+    }
+
+    #[test]
+    fn interval_keys_in_range_walks_only_the_window() {
+        let keys = hourly_jan1()
+            .keys_in_range(dt("2024-01-01T07:00:00"), dt("2024-01-01T09:00:00"))
+            .unwrap();
+        assert_eq!(
+            keys,
+            vec![
+                "2024-01-01T07:00:00",
+                "2024-01-01T08:00:00",
+                "2024-01-01T09:00:00",
+            ]
+        );
+    }
+
+    #[test]
+    fn cron_keys_in_range_includes_on_tick_endpoints() {
+        let g = daily_jan();
+        let keys = g
+            .keys_in_range(dt("2024-01-05T00:00:00"), dt("2024-01-07T00:00:00"))
+            .unwrap();
+        assert_eq!(keys, vec!["2024-01-05", "2024-01-06", "2024-01-07"]);
+    }
+
+    #[test]
+    fn keys_in_range_inverted_is_empty() {
+        let g = hourly_jan1();
+        let keys = g
+            .keys_in_range(dt("2024-01-01T09:00:00"), dt("2024-01-01T07:00:00"))
+            .unwrap();
+        assert!(keys.is_empty());
     }
 
     #[test]

--- a/rust/rivers-core/src/timegrid.rs
+++ b/rust/rivers-core/src/timegrid.rs
@@ -35,12 +35,21 @@ impl TimeGrid {
         if offset == 0 {
             return Ok(key.to_string());
         }
+        let end_dt = self.end_bound();
+        let out_of_range = || {
+            anyhow::anyhow!(
+                "time_window(offset={offset}) maps '{key}' outside the partition range \
+                 [{}, {end_dt})",
+                self.start
+            )
+        };
         let shifted = if let Some(secs) = self.interval_seconds {
             let interval_ns = (secs * 1_000_000_000.0) as i64;
             let total = interval_ns.checked_mul(offset).ok_or_else(|| {
                 anyhow::anyhow!("time_window offset {offset} overflows for interval {secs}s")
             })?;
-            dt + chrono::Duration::nanoseconds(total)
+            dt.checked_add_signed(chrono::Duration::nanoseconds(total))
+                .ok_or_else(out_of_range)?
         } else if let Some(expr) = &self.cron_schedule {
             let cron = parse_cron(expr)?;
             let anchor = Utc.from_utc_datetime(&dt);
@@ -61,19 +70,14 @@ impl TimeGrid {
                     break;
                 }
             }
-            shifted.ok_or_else(|| {
-                anyhow::anyhow!("Cannot shift time window key '{key}' by {offset} windows")
-            })?
+            // The iterator ends at croner's internal year limits — that far
+            // out is by definition outside the partition range.
+            shifted.ok_or_else(out_of_range)?
         } else {
             bail!("TimeWindow requires either cron_schedule or interval_seconds");
         };
-        let end_dt = self.end_bound();
         if shifted < self.start || shifted >= end_dt {
-            bail!(
-                "time_window(offset={offset}) maps '{key}' outside the partition range \
-                 [{}, {end_dt})",
-                self.start
-            );
+            return Err(out_of_range());
         }
         Ok(shifted.format(&self.fmt).to_string())
     }
@@ -115,6 +119,29 @@ mod tests {
         let g = daily_jan();
         assert!(g.shift_key("2024-01-01", -1).is_err());
         assert!(g.shift_key("2024-01-31", 1).is_err());
+    }
+
+    #[test]
+    fn interval_shift_near_datetime_bounds_errors_instead_of_panicking() {
+        let g = TimeGrid {
+            cron_schedule: None,
+            interval_seconds: Some(3600.0),
+            start: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap().into(),
+            end: None,
+            fmt: "%Y-%m-%dT%H:%M:%S".into(),
+        };
+        // Parses to chrono's minimum date; one window earlier is unrepresentable.
+        assert!(g.shift_key("-262143-01-01T00:00:00", -1).is_err());
+    }
+
+    #[test]
+    fn cron_walk_exhaustion_reports_the_partition_range() {
+        let g = daily_jan();
+        let err = g.shift_key("2024-01-05", -10_000_000).unwrap_err();
+        assert!(
+            err.to_string().contains("outside the partition range"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/rust/rivers-core/src/timegrid.rs
+++ b/rust/rivers-core/src/timegrid.rs
@@ -1,0 +1,134 @@
+//! Wall-clock time-window grid — the shared timeline convention for
+//! time-partition keys: a cron or fixed-interval grid over the naive
+//! timeline interpreted as UTC. No DST gaps or duplicates, identical on
+//! every host timezone, and croner cannot stall on it (its `Local`
+//! iteration spins re-resolving the DST fall-back hour).
+
+use anyhow::{Result, bail};
+use chrono::{Local, NaiveDateTime, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+
+/// The time parameters of a TimeWindow partition definition, detached from
+/// any language binding so both the PyO3 layer and core condition eval can
+/// shift keys identically.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TimeGrid {
+    pub cron_schedule: Option<String>,
+    pub interval_seconds: Option<f64>,
+    pub start: NaiveDateTime,
+    pub end: Option<NaiveDateTime>,
+    pub fmt: String,
+}
+
+impl TimeGrid {
+    /// Effective end bound: the explicit `end`, else now.
+    fn end_bound(&self) -> NaiveDateTime {
+        self.end.unwrap_or_else(|| Local::now().naive_local())
+    }
+
+    /// Shift `key` by `offset` windows (negative = earlier). Interval grids
+    /// shift by exact nanosecond arithmetic; cron grids walk the tick grid.
+    /// Errors when the shifted window falls outside `[start, end)`.
+    pub fn shift_key(&self, key: &str, offset: i64) -> Result<String> {
+        let dt = crate::util::parse_key_datetime(key, &self.fmt)
+            .map_err(|e| anyhow::anyhow!("Invalid time window key '{key}': {e}"))?;
+        if offset == 0 {
+            return Ok(key.to_string());
+        }
+        let shifted = if let Some(secs) = self.interval_seconds {
+            let interval_ns = (secs * 1_000_000_000.0) as i64;
+            let total = interval_ns.checked_mul(offset).ok_or_else(|| {
+                anyhow::anyhow!("time_window offset {offset} overflows for interval {secs}s")
+            })?;
+            dt + chrono::Duration::nanoseconds(total)
+        } else if let Some(expr) = &self.cron_schedule {
+            let cron = parse_cron(expr)?;
+            let anchor = Utc.from_utc_datetime(&dt);
+            let direction = if offset > 0 {
+                croner::Direction::Forward
+            } else {
+                croner::Direction::Backward
+            };
+            let mut remaining = offset.unsigned_abs();
+            let mut shifted = None;
+            for tick in cron.iter_from(anchor, direction) {
+                if tick == anchor {
+                    continue;
+                }
+                remaining -= 1;
+                if remaining == 0 {
+                    shifted = Some(tick.naive_utc());
+                    break;
+                }
+            }
+            shifted.ok_or_else(|| {
+                anyhow::anyhow!("Cannot shift time window key '{key}' by {offset} windows")
+            })?
+        } else {
+            bail!("TimeWindow requires either cron_schedule or interval_seconds");
+        };
+        let end_dt = self.end_bound();
+        if shifted < self.start || shifted >= end_dt {
+            bail!(
+                "time_window(offset={offset}) maps '{key}' outside the partition range \
+                 [{}, {end_dt})",
+                self.start
+            );
+        }
+        Ok(shifted.format(&self.fmt).to_string())
+    }
+}
+
+fn parse_cron(expr: &str) -> Result<croner::Cron> {
+    croner::parser::CronParser::builder()
+        .seconds(croner::parser::Seconds::Optional)
+        .build()
+        .parse(expr)
+        .map_err(|e| anyhow::anyhow!("Invalid cron expression '{expr}': {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TimeGrid;
+    use chrono::NaiveDate;
+
+    fn daily_jan() -> TimeGrid {
+        TimeGrid {
+            cron_schedule: Some("0 0 * * *".into()),
+            interval_seconds: None,
+            start: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap().into(),
+            end: Some(NaiveDate::from_ymd_opt(2024, 2, 1).unwrap().into()),
+            fmt: "%Y-%m-%d".into(),
+        }
+    }
+
+    #[test]
+    fn cron_shift_backward_and_forward() {
+        let g = daily_jan();
+        assert_eq!(g.shift_key("2024-01-05", -1).unwrap(), "2024-01-04");
+        assert_eq!(g.shift_key("2024-01-05", 1).unwrap(), "2024-01-06");
+        assert_eq!(g.shift_key("2024-01-05", 0).unwrap(), "2024-01-05");
+    }
+
+    #[test]
+    fn cron_shift_outside_range_errors() {
+        let g = daily_jan();
+        assert!(g.shift_key("2024-01-01", -1).is_err());
+        assert!(g.shift_key("2024-01-31", 1).is_err());
+    }
+
+    #[test]
+    fn interval_shift() {
+        let g = TimeGrid {
+            cron_schedule: None,
+            interval_seconds: Some(21600.0),
+            start: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap().into(),
+            end: Some(NaiveDate::from_ymd_opt(2024, 1, 3).unwrap().into()),
+            fmt: "%Y-%m-%dT%H:%M:%S".into(),
+        };
+        assert_eq!(
+            g.shift_key("2024-01-01T12:00:00", -1).unwrap(),
+            "2024-01-01T06:00:00"
+        );
+    }
+}

--- a/rust/rivers-core/src/timegrid.rs
+++ b/rust/rivers-core/src/timegrid.rs
@@ -81,6 +81,66 @@ impl TimeGrid {
         }
         Ok(shifted.format(&self.fmt).to_string())
     }
+
+    /// Nearest valid keys around `dt` — the latest grid tick `<= dt` and the
+    /// earliest tick `> dt`, both clamped to `[start, end)`. Best-effort for
+    /// diagnostics: a side with no representable tick is `None`.
+    pub fn nearest_keys(&self, dt: NaiveDateTime) -> (Option<String>, Option<String>) {
+        let end_dt = self.end_bound();
+        let key = |t: NaiveDateTime| t.format(&self.fmt).to_string();
+        if let Some(secs) = self.interval_seconds {
+            let interval_ns = (secs * 1_000_000_000.0) as i64;
+            if interval_ns <= 0 {
+                return (None, None);
+            }
+            let tick = |idx: i64| {
+                idx.checked_mul(interval_ns).and_then(|ns| {
+                    self.start
+                        .checked_add_signed(chrono::Duration::nanoseconds(ns))
+                })
+            };
+            let prev = end_dt
+                .checked_sub_signed(chrono::Duration::nanoseconds(1))
+                .map(|last| std::cmp::min(dt, last))
+                .filter(|cap| *cap >= self.start)
+                .and_then(|cap| (cap - self.start).num_nanoseconds())
+                .map(|ns| ns.div_euclid(interval_ns))
+                .and_then(tick);
+            let next = if dt < self.start {
+                Some(self.start)
+            } else {
+                (dt - self.start)
+                    .num_nanoseconds()
+                    .and_then(|ns| ns.div_euclid(interval_ns).checked_add(1))
+                    .and_then(tick)
+            }
+            .filter(|t| *t < end_dt);
+            (prev.map(key), next.map(key))
+        } else if let Some(expr) = &self.cron_schedule {
+            let Ok(cron) = parse_cron(expr) else {
+                return (None, None);
+            };
+            // Anchors are clamped to the range so the walk finds its tick
+            // within a step or two instead of crossing dt→range tick by tick.
+            let prev = {
+                let anchor = Utc.from_utc_datetime(&std::cmp::min(dt, end_dt));
+                cron.iter_from(anchor, croner::Direction::Backward)
+                    .map(|t| t.naive_utc())
+                    .find(|t| *t <= dt && *t < end_dt)
+                    .filter(|t| *t >= self.start)
+            };
+            let next = {
+                let anchor = Utc.from_utc_datetime(&std::cmp::max(dt, self.start));
+                cron.iter_from(anchor, croner::Direction::Forward)
+                    .map(|t| t.naive_utc())
+                    .find(|t| *t > dt)
+                    .filter(|t| *t < end_dt)
+            };
+            (prev.map(key), next.map(key))
+        } else {
+            (None, None)
+        }
+    }
 }
 
 fn parse_cron(expr: &str) -> Result<croner::Cron> {
@@ -157,5 +217,58 @@ mod tests {
             g.shift_key("2024-01-01T12:00:00", -1).unwrap(),
             "2024-01-01T06:00:00"
         );
+    }
+
+    fn hourly_jan1() -> TimeGrid {
+        TimeGrid {
+            cron_schedule: None,
+            interval_seconds: Some(3600.0),
+            start: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap().into(),
+            end: Some(NaiveDate::from_ymd_opt(2024, 1, 2).unwrap().into()),
+            fmt: "%Y-%m-%dT%H:%M:%S".into(),
+        }
+    }
+
+    fn dt(s: &str) -> chrono::NaiveDateTime {
+        chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").unwrap()
+    }
+
+    #[test]
+    fn interval_nearest_keys_brackets_off_grid_datetime() {
+        let (prev, next) = hourly_jan1().nearest_keys(dt("2024-01-01T07:30:00"));
+        assert_eq!(prev.as_deref(), Some("2024-01-01T07:00:00"));
+        assert_eq!(next.as_deref(), Some("2024-01-01T08:00:00"));
+    }
+
+    #[test]
+    fn interval_nearest_keys_clamps_to_range() {
+        let g = hourly_jan1();
+        // Before start: nothing earlier; the first key is the suggestion.
+        let (prev, next) = g.nearest_keys(dt("2023-12-30T05:00:00"));
+        assert_eq!(prev, None);
+        assert_eq!(next.as_deref(), Some("2024-01-01T00:00:00"));
+        // At/after the exclusive end: only the last key survives.
+        let (prev, next) = g.nearest_keys(dt("2024-01-02T05:00:00"));
+        assert_eq!(prev.as_deref(), Some("2024-01-01T23:00:00"));
+        assert_eq!(next, None);
+    }
+
+    #[test]
+    fn cron_nearest_keys_brackets_off_grid_datetime() {
+        let g = daily_jan();
+        let (prev, next) = g.nearest_keys(dt("2024-01-05T13:30:00"));
+        assert_eq!(prev.as_deref(), Some("2024-01-05"));
+        assert_eq!(next.as_deref(), Some("2024-01-06"));
+    }
+
+    #[test]
+    fn cron_nearest_keys_clamps_to_range() {
+        let g = daily_jan();
+        let (prev, next) = g.nearest_keys(dt("2023-11-20T00:00:00"));
+        assert_eq!(prev, None);
+        assert_eq!(next.as_deref(), Some("2024-01-01"));
+        let (prev, next) = g.nearest_keys(dt("2024-03-15T00:00:00"));
+        assert_eq!(prev.as_deref(), Some("2024-01-31"));
+        assert_eq!(next, None);
     }
 }

--- a/rust/rivers-core/src/timegrid.rs
+++ b/rust/rivers-core/src/timegrid.rs
@@ -129,6 +129,66 @@ impl TimeGrid {
         Ok(out)
     }
 
+    /// Window starts in the half-open `[from, to)`, for arbitrary (possibly
+    /// off-grid) endpoints — an off-grid `from` snaps forward to the next
+    /// tick. Both bounds are clamped to `[start, end)`. O(result).
+    pub fn window_starts_in(&self, from: NaiveDateTime, to: NaiveDateTime) -> Result<Vec<String>> {
+        let from = from.max(self.start);
+        let to = to.min(self.end_bound());
+        let mut out = Vec::new();
+        if to <= from {
+            return Ok(out);
+        }
+        if let Some(secs) = self.interval_seconds {
+            let interval_ns = (secs * 1_000_000_000.0) as i64;
+            if interval_ns <= 0 {
+                bail!("TimeWindow interval must be positive");
+            }
+            let Some(offset_ns) = (from - self.start).num_nanoseconds() else {
+                return Ok(out);
+            };
+            let first_idx = offset_ns.div_euclid(interval_ns)
+                + if offset_ns.rem_euclid(interval_ns) == 0 {
+                    0
+                } else {
+                    1
+                };
+            let step = chrono::Duration::nanoseconds(interval_ns);
+            let mut t = match first_idx.checked_mul(interval_ns).and_then(|ns| {
+                self.start
+                    .checked_add_signed(chrono::Duration::nanoseconds(ns))
+            }) {
+                Some(t) => t,
+                None => return Ok(out),
+            };
+            while t < to {
+                out.push(t.format(&self.fmt).to_string());
+                match t.checked_add_signed(step) {
+                    Some(next) => t = next,
+                    None => break,
+                }
+            }
+        } else if let Some(expr) = &self.cron_schedule {
+            let cron = parse_cron(expr)?;
+            let anchor = from
+                .checked_sub_signed(chrono::Duration::seconds(1))
+                .unwrap_or(from);
+            for tick in cron.iter_from(Utc.from_utc_datetime(&anchor), croner::Direction::Forward) {
+                let t = cron_tick_naive(tick);
+                if t < from {
+                    continue;
+                }
+                if t >= to {
+                    break;
+                }
+                out.push(t.format(&self.fmt).to_string());
+            }
+        } else {
+            bail!("TimeWindow requires either cron_schedule or interval_seconds");
+        }
+        Ok(out)
+    }
+
     /// Nearest valid keys around `dt` — the latest grid tick `<= dt` and the
     /// earliest tick `> dt`, both clamped to `[start, end)`. Best-effort for
     /// diagnostics: a side with no representable tick is `None`.
@@ -310,6 +370,35 @@ mod tests {
             .keys_in_range(dt("2024-01-05T00:00:00"), dt("2024-01-07T00:00:00"))
             .unwrap();
         assert_eq!(keys, vec!["2024-01-05", "2024-01-06", "2024-01-07"]);
+    }
+
+    #[test]
+    fn interval_window_starts_snap_off_grid_from_forward() {
+        let g = hourly_jan1();
+        // Off-grid from snaps to the next tick; to is exclusive.
+        let keys = g
+            .window_starts_in(dt("2024-01-01T06:30:00"), dt("2024-01-01T09:00:00"))
+            .unwrap();
+        assert_eq!(keys, vec!["2024-01-01T07:00:00", "2024-01-01T08:00:00"]);
+        // On-grid from is included.
+        let keys = g
+            .window_starts_in(dt("2024-01-01T07:00:00"), dt("2024-01-01T08:00:00"))
+            .unwrap();
+        assert_eq!(keys, vec!["2024-01-01T07:00:00"]);
+    }
+
+    #[test]
+    fn cron_window_starts_half_open_and_clamped() {
+        let g = daily_jan();
+        let keys = g
+            .window_starts_in(dt("2024-01-05T12:00:00"), dt("2024-01-08T00:00:00"))
+            .unwrap();
+        assert_eq!(keys, vec!["2024-01-06", "2024-01-07"]);
+        // Clamped to [start, end): asking past the end yields nothing new.
+        let keys = g
+            .window_starts_in(dt("2024-01-31T00:00:01"), dt("2024-03-01T00:00:00"))
+            .unwrap();
+        assert!(keys.is_empty());
     }
 
     #[test]

--- a/rust/rivers-core/src/util.rs
+++ b/rust/rivers-core/src/util.rs
@@ -10,12 +10,22 @@ pub fn now_ts() -> i64 {
         .as_nanos() as i64
 }
 
-/// Parse a partition key, falling back to date-only at midnight if `fmt` includes a time component.
+/// Parse a partition key against `fmt`, defaulting the time fields the
+/// format omits to zero. A plain `NaiveDateTime::parse_from_str` errors when
+/// the format lacks any time field (date-only fmts) — and a date-only
+/// fallback silently DROPS the hour for formats like hourly's
+/// `%Y-%m-%dT%H:00`, which carry an hour but no minute.
 pub fn parse_key_datetime(key: &str, fmt: &str) -> Result<NaiveDateTime, chrono::ParseError> {
-    NaiveDateTime::parse_from_str(key, fmt).or_else(|_| {
-        chrono::NaiveDate::parse_from_str(key, fmt).map(|d| {
-            d.and_hms_opt(0, 0, 0)
-                .expect("00:00:00 is a valid NaiveTime")
-        })
-    })
+    use chrono::format::{Parsed, StrftimeItems, parse};
+    let mut parsed = Parsed::new();
+    parse(&mut parsed, key, StrftimeItems::new(fmt))?;
+    if parsed.hour_div_12().is_none() && parsed.hour_mod_12().is_none() {
+        parsed.set_hour(0)?;
+    }
+    if parsed.minute().is_none() {
+        parsed.set_minute(0)?;
+    }
+    let date = parsed.to_naive_date()?;
+    let time = parsed.to_naive_time()?;
+    Ok(date.and_time(time))
 }

--- a/rust/rivers-core/src/util.rs
+++ b/rust/rivers-core/src/util.rs
@@ -10,22 +10,86 @@ pub fn now_ts() -> i64 {
         .as_nanos() as i64
 }
 
-/// Parse a partition key against `fmt`, defaulting the time fields the
-/// format omits to zero. A plain `NaiveDateTime::parse_from_str` errors when
-/// the format lacks any time field (date-only fmts) — and a date-only
-/// fallback silently DROPS the hour for formats like hourly's
-/// `%Y-%m-%dT%H:00`, which carry an hour but no minute.
+/// Parse a partition key against `fmt`. Fully-specified formats (including
+/// timestamp-derived ones like `%s`) go through `parse_from_str`; formats
+/// that omit time fields — date-only, or hourly's `%Y-%m-%dT%H:00` which
+/// carries an hour but no minute — fall back to a `Parsed` pass that
+/// defaults the missing fields to zero instead of dropping them.
 pub fn parse_key_datetime(key: &str, fmt: &str) -> Result<NaiveDateTime, chrono::ParseError> {
     use chrono::format::{Parsed, StrftimeItems, parse};
-    let mut parsed = Parsed::new();
-    parse(&mut parsed, key, StrftimeItems::new(fmt))?;
-    if parsed.hour_div_12().is_none() && parsed.hour_mod_12().is_none() {
-        parsed.set_hour(0)?;
+    NaiveDateTime::parse_from_str(key, fmt).or_else(|e| {
+        let mut parsed = Parsed::new();
+        parse(&mut parsed, key, StrftimeItems::new(fmt))?;
+        if parsed.timestamp().is_some() {
+            // The instant came from the timestamp; zero-defaults would
+            // conflict with it — surface the original error instead.
+            return Err(e);
+        }
+        if parsed.hour_div_12().is_none() && parsed.hour_mod_12().is_none() {
+            parsed.set_hour(0)?;
+        }
+        if parsed.minute().is_none() {
+            parsed.set_minute(0)?;
+        }
+        let date = parsed.to_naive_date()?;
+        let time = parsed.to_naive_time()?;
+        Ok(date.and_time(time))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_key_datetime;
+    use chrono::NaiveDate;
+
+    fn dt(y: i32, mo: u32, d: u32, h: u32, mi: u32, s: u32) -> chrono::NaiveDateTime {
+        NaiveDate::from_ymd_opt(y, mo, d)
+            .unwrap()
+            .and_hms_opt(h, mi, s)
+            .unwrap()
     }
-    if parsed.minute().is_none() {
-        parsed.set_minute(0)?;
+
+    #[test]
+    fn date_only_fmt_defaults_to_midnight() {
+        assert_eq!(
+            parse_key_datetime("2024-01-05", "%Y-%m-%d").unwrap(),
+            dt(2024, 1, 5, 0, 0, 0)
+        );
     }
-    let date = parsed.to_naive_date()?;
-    let time = parsed.to_naive_time()?;
-    Ok(date.and_time(time))
+
+    #[test]
+    fn hourly_fmt_preserves_the_hour() {
+        // `%H:00` carries an hour but no minute — the hour must survive.
+        assert_eq!(
+            parse_key_datetime("2024-11-03T05:00", "%Y-%m-%dT%H:00").unwrap(),
+            dt(2024, 11, 3, 5, 0, 0)
+        );
+    }
+
+    #[test]
+    fn full_datetime_fmt_round_trips() {
+        assert_eq!(
+            parse_key_datetime("2024-01-05T06:07:08", "%Y-%m-%dT%H:%M:%S").unwrap(),
+            dt(2024, 1, 5, 6, 7, 8)
+        );
+    }
+
+    #[test]
+    fn epoch_fmt_derives_time_from_the_timestamp() {
+        // `%s` carries the whole instant; the zero-defaults for omitted
+        // hour/minute fields must not clobber it.
+        assert_eq!(
+            parse_key_datetime("1704067200", "%s").unwrap(),
+            dt(2024, 1, 1, 0, 0, 0)
+        );
+        assert_eq!(
+            parse_key_datetime("1704110645", "%s").unwrap(),
+            dt(2024, 1, 1, 12, 4, 5)
+        );
+    }
+
+    #[test]
+    fn trailing_garbage_rejected() {
+        assert!(parse_key_datetime("2024-01-05XYZ", "%Y-%m-%d").is_err());
+    }
 }

--- a/rust/rivers-core/src/util.rs
+++ b/rust/rivers-core/src/util.rs
@@ -44,6 +44,9 @@ pub fn parse_key_datetime(key: &str, fmt: &str) -> Result<NaiveDateTime, chrono:
         if parsed.minute().is_none() {
             parsed.set_minute(0)?;
         }
+        if parsed.second().is_none() {
+            parsed.set_second(0)?;
+        }
         let date = parsed.to_naive_date()?;
         let time = parsed.to_naive_time()?;
         Ok(date.and_time(time))

--- a/rust/rivers-core/src/util.rs
+++ b/rust/rivers-core/src/util.rs
@@ -25,6 +25,19 @@ pub fn parse_key_datetime(key: &str, fmt: &str) -> Result<NaiveDateTime, chrono:
             // conflict with it — surface the original error instead.
             return Err(e);
         }
+        // Coarse fmts (monthly `%Y-%m`, yearly `%Y`) omit calendar fields;
+        // default them to the window start unless week/ordinal info already
+        // pins the date.
+        let has_week_info = parsed.isoweek().is_some()
+            || parsed.week_from_sun().is_some()
+            || parsed.week_from_mon().is_some()
+            || parsed.ordinal().is_some();
+        if parsed.month().is_none() && !has_week_info {
+            parsed.set_month(1)?;
+        }
+        if parsed.day().is_none() && !has_week_info && parsed.weekday().is_none() {
+            parsed.set_day(1)?;
+        }
         if parsed.hour_div_12().is_none() && parsed.hour_mod_12().is_none() {
             parsed.set_hour(0)?;
         }
@@ -63,6 +76,22 @@ mod tests {
         assert_eq!(
             parse_key_datetime("2024-11-03T05:00", "%Y-%m-%dT%H:00").unwrap(),
             dt(2024, 11, 3, 5, 0, 0)
+        );
+    }
+
+    #[test]
+    fn month_only_fmt_defaults_to_first_day() {
+        assert_eq!(
+            parse_key_datetime("2024-03", "%Y-%m").unwrap(),
+            dt(2024, 3, 1, 0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn year_only_fmt_defaults_to_january_first() {
+        assert_eq!(
+            parse_key_datetime("2024", "%Y").unwrap(),
+            dt(2024, 1, 1, 0, 0, 0)
         );
     }
 

--- a/rust/rivers-ui/src/components/partition_picker.rs
+++ b/rust/rivers-ui/src/components/partition_picker.rs
@@ -64,7 +64,7 @@ pub fn PartitionPicker(
 
     let toggle_single = move |idx: usize, shift: bool| {
         let keys = match picker.get_untracked() {
-            JobPartitionPicker::SingleDim { keys } => keys,
+            JobPartitionPicker::SingleDim { keys, .. } => keys,
             _ => return,
         };
         let next = apply_toggle(
@@ -108,7 +108,7 @@ pub fn PartitionPicker(
     view! {
         {move || match picker.get() {
             JobPartitionPicker::None => ().into_any(),
-            JobPartitionPicker::SingleDim { keys } => {
+            JobPartitionPicker::SingleDim { keys, truncated } => {
                 let keys_for_select_all = keys.clone();
                 view! {
                     <div class="form-group">
@@ -122,6 +122,14 @@ pub fn PartitionPicker(
                                 single_selected.set(keys_for_select_all.clone())
                             })
                         />
+                        {truncated
+                            .then(|| {
+                                view! {
+                                    <p class="exec-dialog-partition-hint">
+                                        "Key lists were truncated — only shared keys from the first window are shown."
+                                    </p>
+                                }
+                            })}
                     </div>
                 }
                 .into_any()
@@ -1061,6 +1069,7 @@ mod tests {
     fn submit_keys_single_dim_wraps_each_selected_in_single() {
         let picker = JobPartitionPicker::SingleDim {
             keys: vec!["a".into(), "b".into(), "c".into()],
+            truncated: false,
         };
         let selected = vec!["a".to_string(), "c".to_string()];
         let multi = HashMap::new();

--- a/rust/rivers-ui/src/components/partition_picker.rs
+++ b/rust/rivers-ui/src/components/partition_picker.rs
@@ -168,12 +168,20 @@ pub fn PartitionPicker(
                 </div>
             }
             .into_any(),
-            JobPartitionPicker::Multi { dimensions, asset_key } => view! {
+            JobPartitionPicker::Multi { dimensions, asset_key, truncated } => view! {
                 <div class="form-group">
                     <label>"Partitions"</label>
                     <div class="exec-dialog-partition-hint">
                         "Pick at least one value per dimension. The cartesian product fires one run each."
                     </div>
+                    {truncated
+                        .then(|| {
+                            view! {
+                                <p class="exec-dialog-partition-hint">
+                                    "Dimension key lists were truncated — only shared keys from the first window are shown."
+                                </p>
+                            }
+                        })}
                     {dimensions.into_iter().map(|dim| {
                         let dim_name = dim.name.clone();
                         // Page a dimension only for a single Multi asset whose
@@ -1087,6 +1095,7 @@ mod tests {
         let picker = JobPartitionPicker::Multi {
             dimensions: vec![dim("color", &["r", "g"]), dim("size", &["s", "m"])],
             asset_key: None,
+            truncated: false,
         };
         let selected = Vec::new();
         let mut multi = HashMap::new();
@@ -1107,6 +1116,7 @@ mod tests {
         let picker = JobPartitionPicker::Multi {
             dimensions: vec![dim("color", &["r"]), dim("size", &["s", "m"])],
             asset_key: None,
+            truncated: false,
         };
         let selected = Vec::new();
         let mut multi = HashMap::new();

--- a/rust/rivers-ui/src/helpers.rs
+++ b/rust/rivers-ui/src/helpers.rs
@@ -455,8 +455,7 @@ pub fn partition_picker_for_assets(
         // bounded window) exposes every key on demand and doesn't count.
         let truncated = defs.iter().any(|d| {
             d.dimensions.iter().any(|dim| {
-                let bounded =
-                    dim.keys_truncated || dim.total_count as usize > dim.keys.len();
+                let bounded = dim.keys_truncated || dim.total_count as usize > dim.keys.len();
                 let paged = asset_key.is_some() && dim.keys_truncated;
                 bounded && !paged
             })
@@ -1028,7 +1027,12 @@ mod tests {
         let b = make_multi("b", &[("color", &["r", "g"]), ("size", &["s", "m"])]);
         let infos = make_map(vec![a, b]);
         let picker = picker(&["a", "b"], &infos);
-        let JobPartitionPicker::Multi { truncated, asset_key, .. } = picker else {
+        let JobPartitionPicker::Multi {
+            truncated,
+            asset_key,
+            ..
+        } = picker
+        else {
             panic!("expected Multi, got {picker:?}");
         };
         assert_eq!(asset_key, None);
@@ -1046,7 +1050,12 @@ mod tests {
         }
         let infos = make_map(vec![m]);
         let picker = picker(&["m"], &infos);
-        let JobPartitionPicker::Multi { truncated, asset_key, .. } = picker else {
+        let JobPartitionPicker::Multi {
+            truncated,
+            asset_key,
+            ..
+        } = picker
+        else {
             panic!("expected Multi, got {picker:?}");
         };
         assert_eq!(asset_key.as_deref(), Some("m"));

--- a/rust/rivers-ui/src/helpers.rs
+++ b/rust/rivers-ui/src/helpers.rs
@@ -356,7 +356,9 @@ pub enum JobPartitionPicker {
     None,
     /// Static / TimeWindow / etc. — flat list of keys, intersection
     /// across the job's partitioned assets in first-encounter order.
-    SingleDim { keys: Vec<String> },
+    /// `truncated` is set when any contributing key list was a bounded
+    /// window, i.e. shared keys beyond the window exist but can't be shown.
+    SingleDim { keys: Vec<String>, truncated: bool },
     /// Single-dim with more partitions than fit in the inline key window —
     /// paged on demand by `asset_key` as the user scrolls (`total` sizes the
     /// scrollbar). Avoids ever shipping the full key list to the browser.
@@ -407,6 +409,17 @@ pub fn partition_picker_for_assets(
         let first = defs[0];
         let mut dims: Vec<crate::types::PartitionDimensionInfo> = first.dimensions.clone();
         for other in defs.iter().skip(1) {
+            // Dimension-name sets must match exactly — a key carrying a dim
+            // the other asset lacks (or missing one it has) can never
+            // validate for both, so there is nothing to offer. Jobs are
+            // guarded at resolve time; ad-hoc selections reach here.
+            let dims_match = other.dimensions.len() == dims.len()
+                && dims
+                    .iter()
+                    .all(|d| other.dimensions.iter().any(|od| od.name == d.name));
+            if !dims_match {
+                return JobPartitionPicker::None;
+            }
             for dim in dims.iter_mut() {
                 let Some(other_dim) = other.dimensions.iter().find(|d| d.name == dim.name) else {
                     continue;
@@ -486,23 +499,28 @@ pub fn partition_picker_for_assets(
             total: first_def.total_count,
         };
     }
-    let key_lists: Vec<&Vec<String>> = defs
-        .iter()
-        .filter(|d| !d.keys.is_empty())
-        .map(|d| &d.keys)
-        .collect();
-    let Some((first, rest)) = key_lists.split_first() else {
+    let contributing: Vec<&&crate::types::PartitionDefinitionInfo> =
+        defs.iter().filter(|d| !d.keys.is_empty()).collect();
+    let Some((first, rest)) = contributing.split_first() else {
         return JobPartitionPicker::None;
     };
-    let mut intersection: Vec<String> = first.to_vec();
-    for keys in rest {
-        let next: std::collections::HashSet<&str> = keys.iter().map(String::as_str).collect();
+    let mut intersection: Vec<String> = first.keys.to_vec();
+    for d in rest {
+        let next: std::collections::HashSet<&str> = d.keys.iter().map(String::as_str).collect();
         intersection.retain(|k| next.contains(k.as_str()));
     }
+    // Intersecting bounded windows can only see the shared keys inside them
+    // — surface that so the dialog doesn't present the list as exhaustive.
+    let truncated = contributing
+        .iter()
+        .any(|d| d.keys_truncated || d.total_count as usize > d.keys.len());
     if intersection.is_empty() {
         JobPartitionPicker::None
     } else {
-        JobPartitionPicker::SingleDim { keys: intersection }
+        JobPartitionPicker::SingleDim {
+            keys: intersection,
+            truncated,
+        }
     }
 }
 
@@ -796,6 +814,7 @@ mod tests {
             picker(&["a", "b"], &infos),
             JobPartitionPicker::SingleDim {
                 keys: vec!["y".into()],
+                truncated: false,
             }
         );
     }
@@ -822,6 +841,7 @@ mod tests {
             picker(&["first", "second"], &infos),
             JobPartitionPicker::SingleDim {
                 keys: vec!["b".into(), "a".into()],
+                truncated: false,
             }
         );
     }
@@ -836,6 +856,7 @@ mod tests {
             picker(&["known", "missing"], &infos),
             JobPartitionPicker::SingleDim {
                 keys: vec!["x".into(), "y".into()],
+                truncated: false,
             }
         );
     }
@@ -852,6 +873,7 @@ mod tests {
             picker(&["part", "plain"], &infos),
             JobPartitionPicker::SingleDim {
                 keys: vec!["x".into(), "y".into()],
+                truncated: false,
             }
         );
     }
@@ -922,6 +944,7 @@ mod tests {
             picker(&["dyn", "stat"], &infos),
             JobPartitionPicker::SingleDim {
                 keys: vec!["x".into(), "y".into()],
+                truncated: false,
             }
         );
     }
@@ -1028,7 +1051,8 @@ mod tests {
     #[test]
     fn picker_divergent_large_assets_do_not_page() {
         // Different key spaces must NOT page one asset's keys (could offer a key
-        // invalid for the other). Fall back to intersecting the visible windows.
+        // invalid for the other). Fall back to intersecting the visible windows
+        // — and say so: shared keys beyond the windows exist but can't be shown.
         let infos = make_map(vec![
             make_paged("a", &["k0", "k1", "k2"], 10_000),
             make_paged("b", &["k1", "k2", "k3"], 12_000),
@@ -1037,8 +1061,22 @@ mod tests {
             picker(&["a", "b"], &infos),
             JobPartitionPicker::SingleDim {
                 keys: vec!["k1".into(), "k2".into()],
+                truncated: true,
             }
         );
+    }
+
+    #[test]
+    fn picker_mismatched_multi_dims_returns_none() {
+        // a has {region,date}, b has {region} only: a key with `date` is
+        // invalid for b, a key without it is invalid for a — no shared key
+        // exists, so the picker must offer nothing instead of a's full
+        // `date` keyset.
+        let infos = make_map(vec![
+            make_multi("a", &[("region", &["us", "eu"]), ("date", &["d1", "d2"])]),
+            make_multi("b", &[("region", &["us", "eu"])]),
+        ]);
+        assert_eq!(picker(&["a", "b"], &infos), JobPartitionPicker::None);
     }
 
     use crate::types::SubmitPartitionKey;

--- a/rust/rivers-ui/src/helpers.rs
+++ b/rust/rivers-ui/src/helpers.rs
@@ -371,9 +371,13 @@ pub enum JobPartitionPicker {
     /// `asset_key` is `Some` only for a single-Multi-asset job, enabling
     /// per-dimension paging; `None` (several Multi assets) keeps the intersected
     /// windows inline — same cross-asset guard as `SingleDimPaged`.
+    /// `truncated` is set when an inline dimension window was bounded, i.e.
+    /// shared keys beyond the windows exist but can't be shown (paged
+    /// dimensions are exempt — paging exposes every key on demand).
     Multi {
         dimensions: Vec<crate::types::PartitionDimensionInfo>,
         asset_key: Option<String>,
+        truncated: bool,
     },
 }
 
@@ -445,9 +449,22 @@ pub fn partition_picker_for_assets(
             })
             .flatten()
             .cloned();
+        // Intersecting bounded dimension windows can only see the shared keys
+        // inside them — surface that so the dialog doesn't present the lists
+        // as exhaustive. A dimension that pages (single Multi asset with a
+        // bounded window) exposes every key on demand and doesn't count.
+        let truncated = defs.iter().any(|d| {
+            d.dimensions.iter().any(|dim| {
+                let bounded =
+                    dim.keys_truncated || dim.total_count as usize > dim.keys.len();
+                let paged = asset_key.is_some() && dim.keys_truncated;
+                bounded && !paged
+            })
+        });
         return JobPartitionPicker::Multi {
             dimensions: dims,
             asset_key,
+            truncated,
         };
     }
     // Only when every partitioned asset shares one Dynamic namespace — a mixed
@@ -996,6 +1013,57 @@ mod tests {
         };
         assert_eq!(dimensions[0].keys, vec!["g", "b"]);
         assert_eq!(dimensions[1].keys, vec!["m"]);
+    }
+
+    #[test]
+    fn picker_multi_inline_windows_surface_truncation() {
+        // Several Multi assets — windows stay inline (no paging), so a
+        // bounded dimension window on either asset must flag the picker:
+        // shared keys beyond the windows exist but can't be shown.
+        let mut a = make_multi("a", &[("color", &["r", "g"]), ("size", &["s", "m"])]);
+        if let Some(pd) = a.partition_def.as_mut() {
+            pd.dimensions[1].keys_truncated = true;
+            pd.dimensions[1].total_count = 5000;
+        }
+        let b = make_multi("b", &[("color", &["r", "g"]), ("size", &["s", "m"])]);
+        let infos = make_map(vec![a, b]);
+        let picker = picker(&["a", "b"], &infos);
+        let JobPartitionPicker::Multi { truncated, asset_key, .. } = picker else {
+            panic!("expected Multi, got {picker:?}");
+        };
+        assert_eq!(asset_key, None);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn picker_multi_paged_dimension_is_not_flagged_truncated() {
+        // Single Multi asset — a bounded dimension pages on demand instead,
+        // so the picker must not warn about hidden keys.
+        let mut m = make_multi("m", &[("color", &["r", "g"]), ("size", &["s", "m"])]);
+        if let Some(pd) = m.partition_def.as_mut() {
+            pd.dimensions[1].keys_truncated = true;
+            pd.dimensions[1].total_count = 5000;
+        }
+        let infos = make_map(vec![m]);
+        let picker = picker(&["m"], &infos);
+        let JobPartitionPicker::Multi { truncated, asset_key, .. } = picker else {
+            panic!("expected Multi, got {picker:?}");
+        };
+        assert_eq!(asset_key.as_deref(), Some("m"));
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn picker_multi_unbounded_windows_not_truncated() {
+        let infos = make_map(vec![
+            make_multi("a", &[("color", &["r", "g"]), ("size", &["s", "m"])]),
+            make_multi("b", &[("color", &["r", "g"]), ("size", &["s", "m"])]),
+        ]);
+        let picker = picker(&["a", "b"], &infos);
+        let JobPartitionPicker::Multi { truncated, .. } = picker else {
+            panic!("expected Multi, got {picker:?}");
+        };
+        assert!(!truncated);
     }
 
     #[test]

--- a/rust/rivers-ui/src/server_fns/overview.rs
+++ b/rust/rivers-ui/src/server_fns/overview.rs
@@ -153,17 +153,7 @@ pub async fn get_assets_info(
 /// materializes several at once — each one counts independently.
 #[cfg(feature = "ssr")]
 fn partition_key_members(pk: &rivers_core::storage::PartitionKey) -> Vec<String> {
-    use rivers_core::storage::PartitionKey;
-    match pk {
-        PartitionKey::Single { keys } => keys.clone(),
-        PartitionKey::Multi { dims } => vec![
-            dims.iter()
-                .map(|(d, ks)| format!("{d}={}", ks.join("|")))
-                .collect::<Vec<_>>()
-                .join(", "),
-        ],
-        PartitionKey::Set { keys } => keys.iter().flat_map(partition_key_members).collect(),
-    }
+    pk.members().iter().map(|m| m.to_display()).collect()
 }
 
 /// Tri-state per-partition status (Materialized / Failed / Missing) for the
@@ -529,4 +519,52 @@ pub async fn get_deployment_info(
         daemon_schedules,
         daemon_sensors,
     })
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod tests {
+    use super::partition_key_members;
+    use rivers_core::storage::PartitionKey;
+
+    /// Heatmap classification compares these member strings against the gRPC
+    /// window keys (`dim=v|dim=v`, dims sorted). Any other encoding makes
+    /// every multi-dim cell render Missing.
+    #[test]
+    fn multi_dim_member_matches_grpc_window_key_format() {
+        let pk = PartitionKey::Multi {
+            dims: vec![
+                ("region".into(), vec!["us".into()]),
+                ("date".into(), vec!["2024-01-01".into()]),
+            ],
+        };
+        assert_eq!(
+            partition_key_members(&pk),
+            vec!["date=2024-01-01|region=us"]
+        );
+    }
+
+    /// A batched Multi key counts each cartesian member independently.
+    #[test]
+    fn batched_multi_expands_to_one_member_per_combo() {
+        let pk = PartitionKey::Multi {
+            dims: vec![
+                ("date".into(), vec!["d1".into()]),
+                ("region".into(), vec!["us".into(), "eu".into()]),
+            ],
+        };
+        assert_eq!(
+            partition_key_members(&pk),
+            vec!["date=d1|region=us", "date=d1|region=eu"]
+        );
+    }
+
+    /// Single members stay bare values — they must equal the gRPC window
+    /// keys for single-dim assets, which are bare strings.
+    #[test]
+    fn single_members_stay_bare() {
+        let pk = PartitionKey::Single {
+            keys: vec!["a".into(), "b".into()],
+        };
+        assert_eq!(partition_key_members(&pk), vec!["a", "b"]);
+    }
 }

--- a/rust/rivers-ui/src/types.rs
+++ b/rust/rivers-ui/src/types.rs
@@ -1250,9 +1250,7 @@ mod conversions {
         fn stored_event_partition_key_uses_canonical_display() {
             let core = rivers_core::storage::StoredEvent {
                 id: rivers_core::surrealdb::types::RecordId::new("events", "e1"),
-                event_type: rivers_core::storage::EventType::Materialization {
-                    data_version: None,
-                },
+                event_type: rivers_core::storage::EventType::Materialization { data_version: None },
                 asset_key: Some("orders".into()),
                 run_id: "r1".into(),
                 partition_key: Some(rivers_core::storage::PartitionKey::Multi {

--- a/rust/rivers-ui/src/types.rs
+++ b/rust/rivers-ui/src/types.rs
@@ -1290,7 +1290,9 @@ mod conversions {
                 launched_by: rivers_core::storage::LaunchedBy::Manual,
             };
             let ui: RunRecord = core.into();
-            let preview = ui.partition_key.expect("partitioned run keeps its partition preview");
+            let preview = ui
+                .partition_key
+                .expect("partitioned run keeps its partition preview");
             assert_eq!(preview.preview, vec!["date=2024-01-01|region=us"]);
             assert_eq!(preview.total, 1);
             assert_eq!(preview.label(), "date=2024-01-01|region=us");

--- a/rust/rivers-ui/src/types.rs
+++ b/rust/rivers-ui/src/types.rs
@@ -963,7 +963,7 @@ mod conversions {
                 event_type: e.event_type.into(),
                 asset_key: e.asset_key,
                 run_id: e.run_id,
-                partition_key: e.partition_key.map(|pk| format!("{:?}", pk)),
+                partition_key: e.partition_key.map(partition_key_to_display),
                 timestamp: e.timestamp,
                 metadata: e
                     .metadata
@@ -1237,6 +1237,36 @@ mod conversions {
                 launched_by: rivers_core::storage::LaunchedBy::Manual,
             };
             let ui: RunRecord = core.into();
+            assert_eq!(
+                ui.partition_key.as_deref(),
+                Some("date=2024-01-01|region=us")
+            );
+        }
+
+        /// Event partition labels must use the same canonical `dim=v|dim=v`
+        /// encoding as everywhere else — `{:?}` leaks the Rust enum shape
+        /// (`Multi { dims: [...] }`) into the UI.
+        #[test]
+        fn stored_event_partition_key_uses_canonical_display() {
+            let core = rivers_core::storage::StoredEvent {
+                id: rivers_core::surrealdb::types::RecordId::new("events", "e1"),
+                event_type: rivers_core::storage::EventType::Materialization {
+                    data_version: None,
+                },
+                asset_key: Some("orders".into()),
+                run_id: "r1".into(),
+                partition_key: Some(rivers_core::storage::PartitionKey::Multi {
+                    dims: vec![
+                        ("region".into(), vec!["us".into()]),
+                        ("date".into(), vec!["2024-01-01".into()]),
+                    ],
+                }),
+                timestamp: 0,
+                metadata: vec![],
+                code_version: None,
+                input_data_versions: vec![],
+            };
+            let ui: StoredEvent = core.into();
             assert_eq!(
                 ui.partition_key.as_deref(),
                 Some("date=2024-01-01|region=us")

--- a/rust/rivers-ui/src/types.rs
+++ b/rust/rivers-ui/src/types.rs
@@ -1290,10 +1290,10 @@ mod conversions {
                 launched_by: rivers_core::storage::LaunchedBy::Manual,
             };
             let ui: RunRecord = core.into();
-            assert_eq!(
-                ui.partition_key.as_deref(),
-                Some("date=2024-01-01|region=us")
-            );
+            let preview = ui.partition_key.expect("partitioned run keeps its partition preview");
+            assert_eq!(preview.preview, vec!["date=2024-01-01|region=us"]);
+            assert_eq!(preview.total, 1);
+            assert_eq!(preview.label(), "date=2024-01-01|region=us");
         }
 
         /// Event partition labels must use the same canonical `dim=v|dim=v`

--- a/rust/rivers-ui/src/types.rs
+++ b/rust/rivers-ui/src/types.rs
@@ -5,25 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "ssr")]
 fn partition_key_to_display(pk: rivers_core::storage::PartitionKey) -> String {
-    match pk {
-        rivers_core::storage::PartitionKey::Single { keys } => {
-            keys.first().cloned().unwrap_or_default()
-        }
-        rivers_core::storage::PartitionKey::Multi { dims } => {
-            let mut sorted = dims;
-            sorted.sort_by(|a, b| a.0.cmp(&b.0));
-            sorted
-                .iter()
-                .map(|(dim, vals)| format!("{}={}", dim, vals.join(",")))
-                .collect::<Vec<_>>()
-                .join("|")
-        }
-        rivers_core::storage::PartitionKey::Set { keys } => keys
-            .into_iter()
-            .map(partition_key_to_display)
-            .collect::<Vec<_>>()
-            .join(", "),
-    }
+    pk.to_display()
 }
 
 /// Mirrors `rivers_core::storage::StaleStatus`. Computed on demand via
@@ -889,21 +871,7 @@ mod conversions {
 
     impl From<rivers_core::storage::RunRecord> for RunRecord {
         fn from(r: rivers_core::storage::RunRecord) -> Self {
-            let partition_key = r.partition_key.as_ref().map(|pk| {
-                pk.members()
-                    .iter()
-                    .map(|m| match m {
-                        rivers_core::storage::PartitionKey::Multi { dims } => dims
-                            .iter()
-                            .map(|(d, ks)| format!("{d}={}", ks.join("|")))
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                        rivers_core::storage::PartitionKey::Single { keys } => keys.join("|"),
-                        _ => String::new(),
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            });
+            let partition_key = r.partition_key.as_ref().map(|pk| pk.to_display());
             Self {
                 run_id: r.run_id,
                 job_name: r.job_name,
@@ -1242,6 +1210,37 @@ mod conversions {
             assert!(core.job_substring.is_none());
             assert!(core.asset_substring.is_none());
             assert!(core.partition_substring.is_none());
+        }
+
+        /// Run-list partition labels must use the same canonical `dim=v|dim=v`
+        /// encoding as the picker/heatmap — a second hand-rolled format here
+        /// renders the same partition differently across pages.
+        #[test]
+        fn run_record_partition_key_uses_canonical_display() {
+            let core = rivers_core::storage::RunRecord {
+                run_id: "r1".into(),
+                code_location_id: rivers_core::storage::default_code_location_id(),
+                job_name: None,
+                status: rivers_core::storage::RunStatus::Success,
+                start_time: 0,
+                end_time: None,
+                tags: vec![],
+                node_names: vec![],
+                priority: 0,
+                partition_key: Some(rivers_core::storage::PartitionKey::Multi {
+                    dims: vec![
+                        ("region".into(), vec!["us".into()]),
+                        ("date".into(), vec!["2024-01-01".into()]),
+                    ],
+                }),
+                block_reason: None,
+                launched_by: rivers_core::storage::LaunchedBy::Manual,
+            };
+            let ui: RunRecord = core.into();
+            assert_eq!(
+                ui.partition_key.as_deref(),
+                Some("date=2024-01-01|region=us")
+            );
         }
 
         /// Non-empty filter values round-trip unchanged.

--- a/rust/rivers-ui/tests/dialog_success_browser.rs
+++ b/rust/rivers-ui/tests/dialog_success_browser.rs
@@ -250,6 +250,7 @@ async fn execute_job_with_multi_picker_fires_one_request_per_combination() {
             },
         ],
         asset_key: None,
+        truncated: false,
     };
     mount_to(target.clone(), move || {
         view! {

--- a/rust/rivers-ui/tests/execute_job_dialog_browser.rs
+++ b/rust/rivers-ui/tests/execute_job_dialog_browser.rs
@@ -142,6 +142,7 @@ async fn submit_with_empty_multi_selection_shows_multi_dim_error() {
                 },
             ],
             asset_key: None,
+            truncated: false,
         },
     );
     flush_effects().await;
@@ -204,6 +205,7 @@ async fn run_count_label_reflects_cartesian_product_size() {
                 },
             ],
             asset_key: None,
+            truncated: false,
         },
     );
     flush_effects().await;

--- a/rust/rivers-ui/tests/execute_job_dialog_browser.rs
+++ b/rust/rivers-ui/tests/execute_job_dialog_browser.rs
@@ -90,6 +90,7 @@ async fn single_dim_picker_renders_one_row_per_key() {
                 "2025-01-02".into(),
                 "2025-01-03".into(),
             ],
+            truncated: false,
         },
     );
     flush_effects().await;
@@ -105,6 +106,7 @@ async fn submit_with_empty_single_dim_selection_shows_error() {
         "daily_job",
         JobPartitionPicker::SingleDim {
             keys: vec!["2025-01-01".into(), "2025-01-02".into()],
+            truncated: false,
         },
     );
     flush_effects().await;
@@ -229,6 +231,7 @@ async fn reopen_clears_previous_error() {
         "daily_job",
         JobPartitionPicker::SingleDim {
             keys: vec!["2025-01-01".into()],
+            truncated: false,
         },
     );
     flush_effects().await;

--- a/rust/rivers-ui/tests/materialize_dialog_browser.rs
+++ b/rust/rivers-ui/tests/materialize_dialog_browser.rs
@@ -224,6 +224,7 @@ async fn submit_button_label_reflects_partition_count_under_multi_picker() {
                 },
             ],
             asset_key: None,
+            truncated: false,
         },
     );
     flush_effects().await;

--- a/rust/rivers-ui/tests/partition_picker_browser.rs
+++ b/rust/rivers-ui/tests/partition_picker_browser.rs
@@ -49,6 +49,7 @@ fn multi_picker(dims: &[(&str, &[&str])]) -> JobPartitionPicker {
             })
             .collect(),
         asset_key: None,
+        truncated: false,
     }
 }
 

--- a/rust/rivers-ui/tests/partition_picker_browser.rs
+++ b/rust/rivers-ui/tests/partition_picker_browser.rs
@@ -33,6 +33,7 @@ fn rows(host: &HtmlElement) -> Vec<Element> {
 fn single_picker(keys: &[&str]) -> JobPartitionPicker {
     JobPartitionPicker::SingleDim {
         keys: keys.iter().map(|s| s.to_string()).collect(),
+        truncated: false,
     }
 }
 


### PR DESCRIPTION
# Description

Partition definitions & keys
- Stricter validation: empty-string static keys rejected; display-reserved characters (`=`, `|`) rejected in key values and dimension names; definitions re-validated at resolve time with one shared validator across all factories
- Time grids: cron grids explicitly reject sub-second starts; `fmt` must round-trip across the whole grid (not just two ticks); fixed `parse_key_datetime` regression for timestamp-derived fmts; checked arithmetic with precise range errors in `TimeGrid::shift_key`
- Error quality: invalid-key errors show the display form; range-endpoint errors name the nearest valid keys; deterministic `PartitionKeyRange.__repr__`

## Partition mappings
- `Identity` enforces grid compatibility, validates Multi/Multi pairs per dimension, and requires matching dynamic namespaces
- `time_window` mapping requires a compatible upstream grid; off-grid `time_window(offset)` results are rejected; condition eval shifts offsets the same way the runtime does
- Subgrid compatibility is proven on actual ticks rather than cron-string comparison, and rejections name the upstream grid
- `MultiToSingle` validates its inner mapping per orientation; unmapped partitioned deps carry their default Identity mapping into condition eval; mapped selections are constrained to the asset's real partitions

## Partition ranges
- Single-dim ranges rejected against Multi definitions; unknown dimension selectors rejected; `ForKeys` selectors and dim names validated at resolve time
- Time-window range endpoints must be real partition keys; bounded walk for time-window range resolve (perf)

## Automation conditions
- `dep_updated` compares dep staleness against the root asset's own per-partition timestamps instead of observation baselines — no spurious fires under async event-drain lag
- `in_latest_time_window`: compares on the wall-clock timeline, anchors the lookback cutoff at the latest window start (not now), rejects non-finite/non-positive lookback
- Partition universes refresh every tick; the enumeration watermark only advances on success; multi-dim refresh dedups re-yielded window starts; multi-dim keys held in an insertion-ordered set
- Dispatch classification: only keys actually dispatched are marked handled (including `All` selections); dispatched key lists emitted in canonical display order
- Perf: odometer-style cartesian product for multi-dim enumeration; `PartitionResolver` borrows per tick instead of cloning

## Storage & migrations
- Versioned migration runner with a persisted schema version (single-upsert stamp)
- Multi-key migrations: canonical Multi row written before legacy rows are deleted; heal upsert never rolls back newer pointer fields; v3 re-heals post-v2 legacy writes and records reserved-char dynamic keys
- Canonical dimension order for persisted Multi keys; partition-string lookups match Multi-keyed events; display lookups prefer the structured Multi reading; SurrealDB SCHEMA statement errors surfaced via `.check()`

## Backfills
- `PerDimension` invariants enforced at the submit boundary; range keys validated against every partitioned asset in the selection; keys/ranges require a partitioned selection
- Rerun replays surviving partitions across definition changes and drops only genuinely retired dynamic keys

## Daemon / dispatch
- Dropped dispatch requests fail the tick instead of silently vanishing
- Unified dispatch-outcome logger for runs and backfills

## UI
- Multi-dim partition picker surfaces dimension window truncation; event partition labels use the canonical display form

## Related Issue(s)
- related https://github.com/ion-elgreco/rivers/issues/15

