### PR TITLE
feat: add httproute to helm chart

### DIFF
--- a/deploy/helm/rivers/templates/ui-httproute.yaml
+++ b/deploy/helm/rivers/templates/ui-httproute.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.ui.enabled .Values.ui.httpRoute.enabled }}
+{{- $svcPort := .Values.ui.port }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rivers-ui
+  namespace: {{ include "rivers.namespace" . }}
+  labels:
+    app.kubernetes.io/name: rivers-ui
+    {{- include "rivers.labels" . | nindent 4 }}
+  {{- with .Values.ui.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.ui.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ui.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ui.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: rivers-ui
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/deploy/helm/rivers/tests/ui_httproute_test.yaml
+++ b/deploy/helm/rivers/tests/ui_httproute_test.yaml
@@ -1,0 +1,118 @@
+suite: UI HTTPRoute
+templates:
+  - templates/ui-httproute.yaml
+release:
+  name: rivers
+  namespace: rivers
+tests:
+  - it: omits the HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: omits the HTTPRoute when ui.enabled is false even if httpRoute.enabled is true
+    set:
+      ui.enabled: false
+      ui.httpRoute.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: emits a minimal HTTPRoute with default rules when enabled
+    set:
+      ui.httpRoute.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: rivers-ui
+      - equal:
+          path: metadata.namespace
+          value: rivers
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: rivers-ui
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: rivers-ui
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 3000
+      - equal:
+          path: spec.rules[0].backendRefs[0].weight
+          value: 1
+
+  - it: renders annotations, hostnames, and parentRefs when provided
+    set:
+      ui.httpRoute.enabled: true
+      ui.httpRoute.annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+      ui.httpRoute.parentRefs:
+        - name: public
+          namespace: gateway-system
+      ui.httpRoute.hostnames:
+        - rivers.example.com
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.hostnames[0]
+          value: rivers.example.com
+
+  - it: renders multiple rules with matches and filters
+    set:
+      ui.httpRoute.enabled: true
+      ui.httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /api/rivers
+          filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  type: ReplacePrefix
+                  replacePrefix: /api/v1
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /api/rivers
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: URLRewrite
+      - equal:
+          path: spec.rules[1].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[1].backendRefs[0].name
+          value: rivers-ui
+      - equal:
+          path: spec.rules[1].backendRefs[0].port
+          value: 3000

--- a/deploy/helm/rivers/values.yaml
+++ b/deploy/helm/rivers/values.yaml
@@ -143,8 +143,8 @@ operator:
       # `helm upgrade` to regenerate.
       certDays: 3650
     certManager:
-      duration: 8760h    # 1y
-      renewBefore: 720h  # re-issue 30d before expiry
+      duration: 8760h # 1y
+      renewBefore: 720h # re-issue 30d before expiry
       issuerRef:
         # Name of an existing Issuer / ClusterIssuer. Required when
         # certProvider=certManager — `helm install` fails until set.
@@ -186,6 +186,16 @@ ui:
       enabled: false
       # Required when tls.enabled=true.
       secretName: ""
+  httpRoute:
+    enabled: false
+    annotations: {}
+    parentRefs: []
+    hostnames: []
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
 
 executor:
   serviceAccountName: rivers-executor


### PR DESCRIPTION
# Description

Add HTTPRoute resource to the helm chart as an alternative to Ingress. This is also included in the default scaffold from `helm create`, which I copied the values structure from.

## Related Issue(s)
<!---
For example:

- closes #106
--->

## Documentation

<!---
Share links to useful documentation
--->

https://gateway-api.sigs.k8s.io/reference/api-types/httproute/
