### PR TITLE
fix: more partititioning correctness (condition evals)

### DIFF
--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -70,7 +70,7 @@ All query methods block the calling thread until the result is ready.
 | `has_dynamic_partition(name, key)` | `bool` |
 | `get_materialized_partitions(asset_key)` | `list[PartitionKey]` |
 
-Dynamic keys registered before the reserved-character guard existed (`|`/`,`) still classify, but cannot round-trip display-string paths (UI, gRPC). The storage migration records any such keys under the `reserved_dynamic_keys` entry in the `kv` table and logs a warning at startup — delete each offending key and re-register it under a clean name.
+Dynamic keys registered before the reserved-character guard existed (`|`/`,`) still classify, but cannot round-trip display-string paths (UI, gRPC). The storage migration records all such keys under the `reserved_dynamic_keys` entry in the `kv` table; every subsequent open re-checks that record and logs a warning while any remain. Delete each offending key and re-register it under a clean name — remediated keys drop out of the record automatically, and the warning clears once it is empty.
 
 ### `compute_staleness()`
 

--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -40,6 +40,10 @@ Each parameter resolves via: explicit kwarg → `RIVERS_SURREAL_*` env var → d
 
 When `username` and `password` both resolve to non-empty values, they authenticate as a database-scoped user against `namespace` / `database` — matching a `DEFINE USER ... ON DATABASE` definition.
 
+### Schema migrations
+
+Every open runs versioned in-place migrations and stamps the schema version in the `kv` table; databases already at the current version skip the scans. Migrations are one-shot: **all processes sharing a database must run the same rivers version**. A pre-0.2 writer pointed at a migrated database re-introduces the data shapes the migration healed (unsorted multi-dimension partition keys, unguarded dynamic keys) and nothing heals them again until the next schema bump — upgrade every code location and UI/daemon process together.
+
 ### `storage.type`
 
 Returns a `StorageType` enum (`StorageType.Memory`, `StorageType.Embedded`, or `StorageType.Remote`).

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -1053,42 +1053,67 @@ fn validate_time_window_fmt(
     };
     // Walk the grid with the same helpers `enumerate` uses — validation must
     // judge exactly the keys the definition will mint.
-    let mut checked = 0usize;
-    let mut failure: Option<PyErr> = None;
-    let mut check = |t: NaiveDateTime| -> bool {
-        checked += 1;
+    fn round_trip_tick(t: NaiveDateTime, fmt: &str, failure: &mut Option<PyErr>) -> bool {
         let key = t.format(fmt).to_string();
         if let Some(ch) = rivers_core::storage::PartitionKey::reserved_display_char(&key) {
-            failure = Some(PartitionDefinitionError::new_err(format!(
+            *failure = Some(PartitionDefinitionError::new_err(format!(
                 "fmt '{fmt}' produces keys containing reserved character '{ch}' \
                  (used by the canonical display form): '{key}'"
             )));
             return false;
         }
         match parse_key_datetime(&key, fmt) {
-            Ok(parsed) if parsed == t => {}
+            Ok(parsed) if parsed == t => true,
             Ok(parsed) => {
-                failure = Some(PartitionDefinitionError::new_err(format!(
+                *failure = Some(PartitionDefinitionError::new_err(format!(
                     "fmt '{fmt}' cannot represent the partition grid: window start {t} \
                      formats to '{key}', which parses back to {parsed}; \
                      use a format at least as fine as the grid"
                 )));
-                return false;
+                false
             }
             Err(e) => {
-                failure = Some(PartitionDefinitionError::new_err(format!(
+                *failure = Some(PartitionDefinitionError::new_err(format!(
                     "fmt '{fmt}' cannot represent the partition grid: window start {t} \
                      formats to '{key}', which does not parse back: {e}"
                 )));
-                return false;
+                false
             }
         }
-        checked < MAX_TICKS
-    };
+    }
+    let mut checked = 0usize;
+    let mut failure: Option<PyErr> = None;
     if let Some(secs) = interval_seconds {
-        for_each_interval_tick(*secs, start, bound, &mut check);
+        for_each_interval_tick(*secs, start, bound, &mut |t| {
+            checked += 1;
+            round_trip_tick(t, fmt, &mut failure) && checked < MAX_TICKS
+        });
     } else if let Some(expr) = cron_schedule {
-        for_each_cron_tick(expr, start, bound, &mut check)?;
+        for_each_cron_tick(expr, start, bound, &mut |t| {
+            checked += 1;
+            round_trip_tick(t, fmt, &mut failure) && checked < MAX_TICKS
+        })?;
+    }
+    // A grid sparser than the horizon still mints its first ticks — they
+    // must round-trip no matter how far out they lie (the pre-horizon code
+    // always checked the first two).
+    if failure.is_none() && checked < 2 {
+        let true_end = match end {
+            Some(e) => *e,
+            None => NaiveDateTime::MAX,
+        };
+        let mut taken = 0usize;
+        if let Some(secs) = interval_seconds {
+            for_each_interval_tick(*secs, start, true_end, &mut |t| {
+                taken += 1;
+                round_trip_tick(t, fmt, &mut failure) && taken < 2
+            });
+        } else if let Some(expr) = cron_schedule {
+            for_each_cron_tick(expr, start, true_end, &mut |t| {
+                taken += 1;
+                round_trip_tick(t, fmt, &mut failure) && taken < 2
+            })?;
+        }
     }
     match failure {
         Some(err) => Err(err),

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -772,6 +772,17 @@ impl PartitionsDefinition {
                         "Multi partitions must have at least one dimension",
                     ));
                 }
+                // The multi() factory's dict input can't duplicate names, but
+                // the raw variant constructor takes a list — a duplicate
+                // silently collapses the cartesian universe.
+                let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+                for (name, _) in dimensions {
+                    if !seen.insert(name.as_str()) {
+                        return Err(PartitionDefinitionError::new_err(format!(
+                            "Multi partitions: duplicate dimension name '{name}'"
+                        )));
+                    }
+                }
                 for (name, def) in dimensions {
                     if matches!(def, Self::Multi { .. }) {
                         return Err(PartitionDefinitionError::new_err(

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -901,12 +901,9 @@ impl PartitionsDefinition {
 
     #[staticmethod]
     fn dynamic(name: String) -> PyResult<Self> {
-        if name.is_empty() {
-            return Err(PartitionDefinitionError::new_err(
-                "Dynamic partition definition name cannot be empty",
-            ));
-        }
-        Ok(Self::Dynamic { name })
+        let def = Self::Dynamic { name };
+        def.validate_definition()?;
+        Ok(def)
     }
 
     #[pyo3(name = "get_partition_keys")]

--- a/python/src/partitions/definition.rs
+++ b/python/src/partitions/definition.rs
@@ -1310,6 +1310,13 @@ pub(crate) fn for_each_cron_tick(
 
 /// Whether `t` falls exactly on the cron grid (cron is second-granular).
 pub(crate) fn cron_grid_contains(cron_expr: &str, t: NaiveDateTime) -> PyResult<bool> {
+    use chrono::Timelike;
+    // croner never inspects nanoseconds and echoes a fractional `t` back
+    // verbatim from the inclusive iterator, so it would report sub-second
+    // times as on-grid.
+    if t.nanosecond() != 0 {
+        return Ok(false);
+    }
     let probe_end = t
         .checked_add_signed(chrono::Duration::seconds(1))
         .unwrap_or(NaiveDateTime::MAX);

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -801,39 +801,76 @@ fn validate_time_window_grid_compat(
                 Some(e) => (*e).min(horizon),
                 None => horizon,
             };
-            let mut count = 0usize;
-            let mut offgrid: Option<chrono::NaiveDateTime> = None;
-            let mut walk_err: Option<String> = None;
-            let mut visit = |t: chrono::NaiveDateTime| -> bool {
-                count += 1;
-                let on_upstream = match (up_cron, up_interval) {
-                    (Some(expr), _) => match cron_grid_contains(expr, t) {
-                        Ok(hit) => hit,
-                        Err(e) => {
-                            walk_err = Some(e.to_string());
-                            return false;
-                        }
-                    },
+            // Is `t` a tick of the upstream grid? `Err` carries a cron-parse
+            // failure to surface after the walk.
+            let on_upstream = |t: chrono::NaiveDateTime| -> Result<bool, String> {
+                match (up_cron, up_interval) {
+                    (Some(expr), _) => cron_grid_contains(expr, t).map_err(|e| e.to_string()),
                     (None, Some(ui)) => {
                         let up_ns = (ui * 1_000_000_000.0) as i64;
-                        up_ns > 0
+                        Ok(up_ns > 0
                             && (t - *up_start)
                                 .num_nanoseconds()
-                                .is_some_and(|ns| ns.rem_euclid(up_ns) == 0)
+                                .is_some_and(|ns| ns.rem_euclid(up_ns) == 0))
                     }
-                    (None, None) => false,
-                };
-                if !on_upstream {
-                    offgrid = Some(t);
-                    return false;
+                    (None, None) => Ok(false),
                 }
-                count < PROBE_TICKS
             };
-            if let Some(dc) = down_cron {
-                for_each_cron_tick(dc, down_start, horizon, &mut visit)
-                    .map_err(|e| MappingValidationError::DefinitionError(e.to_string()))?;
-            } else if let Some(di) = down_interval {
-                for_each_interval_tick(*di, down_start, horizon, &mut visit);
+            let mut offgrid: Option<chrono::NaiveDateTime> = None;
+            let mut walk_err: Option<String> = None;
+            let mut count = 0usize;
+            {
+                let mut visit = |t: chrono::NaiveDateTime| -> bool {
+                    count += 1;
+                    match on_upstream(t) {
+                        Ok(true) => count < PROBE_TICKS,
+                        Ok(false) => {
+                            offgrid = Some(t);
+                            false
+                        }
+                        Err(e) => {
+                            walk_err = Some(e);
+                            false
+                        }
+                    }
+                };
+                if let Some(dc) = down_cron {
+                    for_each_cron_tick(dc, down_start, horizon, &mut visit)
+                        .map_err(|e| MappingValidationError::DefinitionError(e.to_string()))?;
+                } else if let Some(di) = down_interval {
+                    for_each_interval_tick(*di, down_start, horizon, &mut visit);
+                }
+            }
+            // A grid whose 2nd tick lies past the 1461-day horizon would be
+            // judged on tick 0 alone; always probe the first two ticks against
+            // the true end so a tick-1 divergence is caught (the same
+            // min-two-ticks guard validate_time_window_fmt applies).
+            if walk_err.is_none() && offgrid.is_none() && count < 2 {
+                let true_end = match down_end {
+                    Some(e) => *e,
+                    None => chrono::NaiveDateTime::MAX,
+                };
+                let mut taken = 0usize;
+                let mut visit2 = |t: chrono::NaiveDateTime| -> bool {
+                    taken += 1;
+                    match on_upstream(t) {
+                        Ok(true) => taken < 2,
+                        Ok(false) => {
+                            offgrid = Some(t);
+                            false
+                        }
+                        Err(e) => {
+                            walk_err = Some(e);
+                            false
+                        }
+                    }
+                };
+                if let Some(dc) = down_cron {
+                    for_each_cron_tick(dc, down_start, true_end, &mut visit2)
+                        .map_err(|e| MappingValidationError::DefinitionError(e.to_string()))?;
+                } else if let Some(di) = down_interval {
+                    for_each_interval_tick(*di, down_start, true_end, &mut visit2);
+                }
             }
             if let Some(msg) = walk_err {
                 return Err(MappingValidationError::DefinitionError(msg));

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -787,7 +787,10 @@ fn validate_time_window_grid_compat(
             // can coincide with an interval grid, so prove the subgrid
             // relation on the ticks themselves: every downstream window
             // start over a bounded probe must fall on the upstream grid.
-            const PROBE_TICKS: usize = 32;
+            // The budget matches validate_time_window_fmt's walk — calendar
+            // gates (day-of-week, month ranges) diverge far past the first
+            // ticks: an hourly grid meets its first Saturday at tick 121.
+            const PROBE_TICKS: usize = 1024;
             let horizon = down_start
                 .checked_add_signed(chrono::Duration::days(1461))
                 .unwrap_or(chrono::NaiveDateTime::MAX);

--- a/python/src/partitions/mapping.rs
+++ b/python/src/partitions/mapping.rs
@@ -738,8 +738,8 @@ fn validate_time_window_grid_compat(
             cron_schedule: down_cron,
             interval_seconds: down_interval,
             start: down_start,
+            end: down_end,
             fmt: down_fmt,
-            ..
         },
         PartitionsDefinition::TimeWindow {
             cron_schedule: up_cron,
@@ -791,9 +791,16 @@ fn validate_time_window_grid_compat(
             // gates (day-of-week, month ranges) diverge far past the first
             // ticks: an hourly grid meets its first Saturday at tick 121.
             const PROBE_TICKS: usize = 1024;
+            // Judge exactly the keys the definition will mint: window starts
+            // at/after the downstream's explicit end never exist downstream,
+            // so they must not fail the edge.
             let horizon = down_start
                 .checked_add_signed(chrono::Duration::days(1461))
                 .unwrap_or(chrono::NaiveDateTime::MAX);
+            let horizon = match down_end {
+                Some(e) => (*e).min(horizon),
+                None => horizon,
+            };
             let mut count = 0usize;
             let mut offgrid: Option<chrono::NaiveDateTime> = None;
             let mut walk_err: Option<String> = None;

--- a/python/tests/backfill/test_backfill_priority.py
+++ b/python/tests/backfill/test_backfill_priority.py
@@ -8,8 +8,6 @@ Tests verify:
 - Daemon-triggered backfills carry priority -10
 """
 
-import time
-
 import rivers as rs
 from _polling import wait_for_backfill_runs as _wait_for_backfill_runs
 from rivers._core import AutomationDaemon

--- a/python/tests/backfill/test_backfill_priority.py
+++ b/python/tests/backfill/test_backfill_priority.py
@@ -253,28 +253,24 @@ class TestDaemonBackfillPriority:
             partition_key=rs.PartitionKey.single("b"),
         )
 
-        # Per-partition dep matching: the upstream re-materializations must
-        # land within one tick window to dispatch as a single backfill.
+        # Burst before the daemon starts: per-partition dep matching sees
+        # both stale keys on the first tick — one backfill, no tick race.
+        repo.materialize(
+            selection=["d_up"],
+            partition_key=rs.PartitionKey.single("a"),
+        )
+        repo.materialize(
+            selection=["d_up"],
+            partition_key=rs.PartitionKey.single("b"),
+        )
+
         daemon = AutomationDaemon(
             repo=repo,
             storage=storage,
-            condition_eval_interval="3s",
+            condition_eval_interval="1s",
         )
         daemon.start()
         try:
-            # Let daemon establish baseline
-            time.sleep(2)
-
-            # Re-materialize upstream to trigger downstream backfill
-            repo.materialize(
-                selection=["d_up"],
-                partition_key=rs.PartitionKey.single("a"),
-            )
-            repo.materialize(
-                selection=["d_up"],
-                partition_key=rs.PartitionKey.single("b"),
-            )
-
             # Wait for backfill runs
             tagged_runs = _wait_for_backfill_runs(storage, timeout=20)
             assert len(tagged_runs) >= 1, (

--- a/python/tests/backfill/test_daemon_backfill.py
+++ b/python/tests/backfill/test_daemon_backfill.py
@@ -40,7 +40,7 @@ class TestDaemonConditionBackfill:
         1. Pre-materialize both upstream partitions AND both downstream partitions
            (so the daemon cache sees them as "existed" before the upstream re-materialization)
         2. Re-materialize upstream for both partitions (makes downstream stale)
-        3. Start daemon with condition eval (1s interval)
+        3. Start daemon (1s interval) — its first tick sees both stale keys
         4. Condition detects upstream updates → fires for [a, b]
         5. Since 2 partitions fire, daemon should create a backfill
         6. Backfill runs execute (via pickup loop)
@@ -81,27 +81,25 @@ class TestDaemonConditionBackfill:
             partition_key=rs.PartitionKey.single("b"),
         )
 
-        # Start daemon FIRST so it captures the baseline state
+        # Re-materialize upstream BEFORE the daemon starts: dep matching is
+        # staleness-based, so the first tick deterministically sees both
+        # stale keys — no racing the tick boundary with a burst.
+        repo.materialize(
+            selection=["upstream"],
+            partition_key=rs.PartitionKey.single("a"),
+        )
+        repo.materialize(
+            selection=["upstream"],
+            partition_key=rs.PartitionKey.single("b"),
+        )
+
         daemon = AutomationDaemon(
             repo=repo,
             storage=storage,
-            condition_eval_interval="3s",
+            condition_eval_interval="1s",
         )
         daemon.start()
         try:
-            # Let the daemon run a baseline tick (sees everything UpToDate)
-            time.sleep(2)
-
-            # Now re-materialize upstream to make downstream stale
-            repo.materialize(
-                selection=["upstream"],
-                partition_key=rs.PartitionKey.single("a"),
-            )
-            repo.materialize(
-                selection=["upstream"],
-                partition_key=rs.PartitionKey.single("b"),
-            )
-
             # Wait for backfill-launched runs
             tagged_runs = _wait_for_backfill_runs(storage, timeout=20)
             assert len(tagged_runs) >= 1, (
@@ -246,25 +244,25 @@ class TestDaemonConditionBackfill:
             partition_key=rs.PartitionKey.single("b"),
         )
 
+        # Burst before the daemon starts: the first tick sees both stale
+        # keys at once, so the strict one-backfill asserts below are
+        # deterministic instead of racing the tick boundary.
+        repo.materialize(
+            selection=["strat_up"],
+            partition_key=rs.PartitionKey.single("a"),
+        )
+        repo.materialize(
+            selection=["strat_up"],
+            partition_key=rs.PartitionKey.single("b"),
+        )
+
         daemon = AutomationDaemon(
             repo=repo,
             storage=storage,
-            condition_eval_interval="3s",
+            condition_eval_interval="1s",
         )
         daemon.start()
         try:
-            time.sleep(2)
-
-            # Re-materialize upstream
-            repo.materialize(
-                selection=["strat_up"],
-                partition_key=rs.PartitionKey.single("a"),
-            )
-            repo.materialize(
-                selection=["strat_up"],
-                partition_key=rs.PartitionKey.single("b"),
-            )
-
             # Wait for backfill to complete
             bf = _wait_for_backfill(repo, timeout=20)
             assert bf is not None, "Backfill should have been created and completed"
@@ -346,27 +344,24 @@ class TestDaemonConditionBackfill:
                     partition_key=pk,
                 )
 
-        # Dep matching is per-partition: the four upstream re-materializations
-        # below must land within one tick window or the condition legitimately
-        # fires as two separate backfills.
+        # Dep matching is per-partition: burst all four upstream updates
+        # BEFORE the daemon starts so its first tick sees them together and
+        # dispatches a single backfill — no racing the tick boundary.
+        for region in ["us", "eu"]:
+            for date in ["d1", "d2"]:
+                pk = rs.PartitionKey.multi({"region": region, "date": date})
+                repo.materialize(
+                    selection=["pd_up"],
+                    partition_key=pk,
+                )
+
         daemon = AutomationDaemon(
             repo=repo,
             storage=storage,
-            condition_eval_interval="3s",
+            condition_eval_interval="1s",
         )
         daemon.start()
         try:
-            time.sleep(2)
-
-            # Re-materialize all upstream partitions to trigger downstream
-            for region in ["us", "eu"]:
-                for date in ["d1", "d2"]:
-                    pk = rs.PartitionKey.multi({"region": region, "date": date})
-                    repo.materialize(
-                        selection=["pd_up"],
-                        partition_key=pk,
-                    )
-
             # Wait for backfill to complete
             bf = _wait_for_backfill(repo, timeout=20)
             assert bf is not None, "Backfill should have been created and completed"

--- a/python/tests/daemon/test_last_run_includes_target.py
+++ b/python/tests/daemon/test_last_run_includes_target.py
@@ -126,10 +126,14 @@ class TestLastRunIncludesTarget:
         finally:
             daemon.stop()
 
-    def test_naive_condition_fires_redundantly_after_joint_run(self, storage):
-        """Without ~last_run_includes_target, a joint run causes a redundant fire.
+    def test_naive_condition_self_suppresses_after_joint_run(self, storage):
+        """Even without ~last_run_includes_target, a joint run must not re-fire.
 
-        Uses any_deps_match(newly_updated) without the filter to show the contrast.
+        Dep-updated compares staleness against the root's own record: after a
+        joint run the dep is no newer than the root, so the naive
+        any_deps_match(newly_updated) form is self-suppressing too (the
+        filter remains for explicitness). This used to fire a redundant
+        third run under fire-time baselines.
         """
 
         @rs.Asset(name="a", io_handler=rs.InMemoryIOHandler())
@@ -178,10 +182,10 @@ class TestLastRunIncludesTarget:
             repo.materialize(selection=["a", "b"])
             assert _count_successful_runs_for(storage, "b") == 2
 
-            got_extra = _wait_for_n_runs(storage, "b", 3, timeout=10)
-            assert got_extra, (
-                f"naive eager (AnyDepsUpdated, no filter) should fire "
-                f"a redundant 3rd run, but B has "
+            got_extra = _wait_for_n_runs(storage, "b", 3, timeout=5)
+            assert not got_extra, (
+                f"a joint run must not re-trigger B (dep is not newer than "
+                f"the root), but B has "
                 f"{_count_successful_runs_for(storage, 'b')} runs"
             )
         finally:

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -285,6 +285,23 @@ def test_fractional_interval_downstream_on_cron_upstream_rejected():
         make_repo(_identity_edge(down, up))
 
 
+def test_subgrid_divergence_past_first_window_rejected():
+    """An hourly grid against a weekday-only hourly upstream diverges at the
+    first Saturday — downstream tick 121. A 32-tick probe sails past
+    construction and mints 24 phantom Saturday keys a week; the probe must
+    look far enough to see one full week."""
+    fmt = "%Y-%m-%dT%H:00"
+    # 2024-01-01 is a Monday.
+    up = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, cron_schedule="0 * * * 1-5", fmt=fmt
+    )
+    down = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, cron_schedule="0 * * * *", fmt=fmt
+    )
+    with pytest.raises(PartitionValidationError, match="is not on the upstream grid"):
+        make_repo(_identity_edge(down, up))
+
+
 def test_equivalent_cron_spellings_allowed():
     """'0 0 * * *' and its 6-field spelling '0 0 0 * * *' are one schedule;
     textual comparison must not reject them."""

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -302,6 +302,27 @@ def test_subgrid_divergence_past_first_window_rejected():
         make_repo(_identity_edge(down, up))
 
 
+def test_subgrid_second_tick_past_probe_horizon_rejected():
+    """A sparse downstream grid whose SECOND tick lies beyond the 1461-day
+    probe horizon is otherwise validated on tick 0 alone; the probe must always
+    check the first two ticks so a tick-1 divergence is still caught."""
+    fmt = "%Y-%m-%d"
+    # Upstream fires only on Jan 1 each year.
+    up = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, cron_schedule="0 0 1 1 *", fmt=fmt
+    )
+    # Downstream steps every 1500 days (>1461): tick 0 = 2024-01-01 (on the
+    # yearly grid), tick 1 = 2028-02-09 (off it) and past the probe horizon.
+    down = rs.PartitionsDefinition.time_window(
+        start=DAILY_START,
+        end=datetime(2050, 1, 1),
+        interval_seconds=1500 * 86400,
+        fmt=fmt,
+    )
+    with pytest.raises(PartitionValidationError, match="is not on the upstream grid"):
+        make_repo(_identity_edge(down, up))
+
+
 def test_subgrid_probe_respects_downstream_end():
     """Range edges are a per-key concern: a downstream def whose explicit end
     precedes the first off-grid tick mints only on-grid keys, so the probe

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -302,6 +302,24 @@ def test_subgrid_divergence_past_first_window_rejected():
         make_repo(_identity_edge(down, up))
 
 
+def test_subgrid_probe_respects_downstream_end():
+    """Range edges are a per-key concern: a downstream def whose explicit end
+    precedes the first off-grid tick mints only on-grid keys, so the probe
+    must not reject it for a window start it will never mint."""
+    fmt = "%Y-%m-%d"
+    # Mon 2024-01-01 .. Fri 2024-01-05 (end exclusive at Sat 2024-01-06).
+    up = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, cron_schedule="0 0 * * 1-5", fmt=fmt
+    )
+    down = rs.PartitionsDefinition.time_window(
+        start=DAILY_START,
+        end=datetime(2024, 1, 6),
+        interval_seconds=86400,
+        fmt=fmt,
+    )
+    assert make_repo(_identity_edge(down, up)) is not None
+
+
 def test_equivalent_cron_spellings_allowed():
     """'0 0 * * *' and its 6-field spelling '0 0 0 * * *' are one schedule;
     textual comparison must not reject them."""

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -269,6 +269,22 @@ def test_time_window_mapping_misaligned_mixed_grid_kinds_rejected():
         make_repo(_tw_edge(down, up))
 
 
+def test_fractional_interval_downstream_on_cron_upstream_rejected():
+    """Cron grids are second-granular, so an interval grid whose ticks carry
+    sub-second fractions mints keys that can never exist upstream. croner
+    matches fractional probe times verbatim (it never inspects nanoseconds),
+    so the subgrid probe must reject them explicitly."""
+    fmt = "%Y-%m-%dT%H:%M:%S%.f"
+    up = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, cron_schedule="* * * * * *", fmt=fmt
+    )
+    down = rs.PartitionsDefinition.time_window(
+        start=DAILY_START, interval_seconds=1.5, fmt=fmt
+    )
+    with pytest.raises(PartitionValidationError, match="is not on the upstream grid"):
+        make_repo(_identity_edge(down, up))
+
+
 def test_equivalent_cron_spellings_allowed():
     """'0 0 * * *' and its 6-field spelling '0 0 0 * * *' are one schedule;
     textual comparison must not reject them."""

--- a/python/tests/partitions/test_partition_mapping_validation.py
+++ b/python/tests/partitions/test_partition_mapping_validation.py
@@ -1321,6 +1321,27 @@ def test_resolve_rejects_variant_constructed_multi_with_bad_dim_name():
         make_repo([standalone])
 
 
+def test_resolve_rejects_variant_constructed_multi_with_duplicate_dim_names():
+    """The multi() factory's dict input makes duplicate names impossible, but
+    the raw variant constructor takes a list of tuples: a duplicated name
+    silently collapses the universe (the enumeration paths even disagree on
+    which dimension survives) and the minted keys fail the definition's own
+    validation."""
+    bad = rs.PartitionsDefinition.Multi(
+        dimensions=[
+            ("d", rs.PartitionsDefinition.static_(["x1", "x2"])),
+            ("d", rs.PartitionsDefinition.static_(["y1", "y2"])),
+        ]
+    )
+
+    @rs.Asset(partitions_def=bad)
+    def standalone() -> Any:
+        return 1
+
+    with pytest.raises(PartitionValidationError, match="duplicate dimension name"):
+        make_repo([standalone])
+
+
 def test_factory_constructed_defs_resolve_fine():
     """The re-validation must not reject anything the factories produce."""
     pd = rs.PartitionsDefinition.multi(

--- a/python/tests/partitions/test_partitions_def.py
+++ b/python/tests/partitions/test_partitions_def.py
@@ -344,6 +344,22 @@ def test_time_window_interval_coarser_than_horizon_accepted():
     assert pd is not None
 
 
+def test_time_window_fmt_checked_on_ticks_beyond_validation_horizon():
+    """A grid sparser than the validation horizon still mints its later
+    ticks: a 5-year interval's tick 1 (2028-12-30) renders '2028-12', which
+    parses back to 2028-12-01 and fails the definition's own key validation.
+    The first two ticks must round-trip no matter how far out they lie."""
+    with pytest.raises(
+        PartitionDefinitionError, match="cannot represent the partition grid"
+    ):
+        rs.PartitionsDefinition.time_window(
+            start=datetime.datetime(2024, 1, 1),
+            interval_seconds=5.0 * 365.0 * 86400.0,
+            end=datetime.datetime(2035, 1, 1),
+            fmt="%Y-%m",
+        )
+
+
 def test_static_rejects_empty_string_key():
     """Empty key strings render as nothing in the display form and are
     unreachable via string lookups — same guard as the dynamic write path."""

--- a/rust/rivers-core/src/condition/cache.rs
+++ b/rust/rivers-core/src/condition/cache.rs
@@ -47,6 +47,8 @@ pub struct PartitionStatusEntry {
     pub in_progress: HashSet<PartitionKey>,
     /// Which partitions failed in latest execution.
     pub failed: HashSet<PartitionKey>,
+    /// Latest failure timestamp for each currently-failed partition.
+    pub failed_timestamps: HashMap<PartitionKey, i64>,
     /// Per-partition last materialization timestamp.
     pub timestamps: HashMap<PartitionKey, i64>,
 }
@@ -297,9 +299,8 @@ impl AssetConditionCache {
             let failed = scoped
                 .get_failed_partitions(asset_key, &entry.timestamps)
                 .await?;
-            for pk in &failed {
-                entry.failed.insert(pk.clone());
-            }
+            entry.failed = failed.keys().cloned().collect();
+            entry.failed_timestamps = failed;
 
             self.partition_status.insert(asset_key.clone(), entry);
         }
@@ -648,11 +649,11 @@ impl AssetConditionCache {
                 .await?
                 .into_iter()
                 .collect();
-            entry.failed = scoped
+            let failed = scoped
                 .get_failed_partitions(asset_key, &entry.timestamps)
-                .await?
-                .into_iter()
-                .collect();
+                .await?;
+            entry.failed = failed.keys().cloned().collect();
+            entry.failed_timestamps = failed;
             out.insert(asset_key.clone(), entry);
         }
         Ok(out)

--- a/rust/rivers-core/src/condition/cache.rs
+++ b/rust/rivers-core/src/condition/cache.rs
@@ -117,8 +117,10 @@ struct RefreshDelta {
     /// Asset keys to add to `failed_assets`, with the failing run's
     /// end (or start) timestamp.
     failed_adds: HashMap<String, i64>,
-    /// Asset keys to remove from `failed_assets`.
-    failed_removes: HashSet<String>,
+    /// Asset keys whose success clears `failed_assets`, with the success run's
+    /// timestamp — a remove only clears a failure floor older than it, so a
+    /// co-batched older success can't clobber a newer failure.
+    failed_removes: HashMap<String, i64>,
     /// Tag updates: `(asset, partition_key, tags)`.
     run_tag_updates: Vec<RunTagUpdate>,
     /// Tick tag updates: `(asset, partition_key, tags)`.
@@ -586,7 +588,11 @@ impl AssetConditionCache {
                     .and_modify(|t| *t = (*t).max(run_ts))
                     .or_insert(run_ts);
             } else {
-                delta.failed_removes.insert(asset.clone());
+                delta
+                    .failed_removes
+                    .entry(asset.clone())
+                    .and_modify(|t| *t = (*t).max(run_ts))
+                    .or_insert(run_ts);
             }
             for partition_key in &run_partitions {
                 if !run_tags.is_empty() {
@@ -784,9 +790,18 @@ impl AssetConditionCache {
                 .and_modify(|t| *t = (*t).max(ts))
                 .or_insert(ts);
         }
-        for asset in failed_removes {
-            self.failed_assets.remove(asset.as_str());
-            self.failed_asset_timestamps.remove(asset.as_str());
+        // A success clears the floor only if it is at least as new as the
+        // recorded failure — an older co-batched success must not clobber a
+        // newer failure.
+        for (asset, success_ts) in failed_removes {
+            let outranked_by_failure = self
+                .failed_asset_timestamps
+                .get(asset.as_str())
+                .is_some_and(|&fail_ts| success_ts < fail_ts);
+            if !outranked_by_failure {
+                self.failed_assets.remove(asset.as_str());
+                self.failed_asset_timestamps.remove(asset.as_str());
+            }
         }
 
         for (asset, pk, tags) in run_tag_updates {
@@ -1098,5 +1113,67 @@ impl AssetConditionCache {
             }
         }
         result.into_iter().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_run(run_id: &str, status: RunStatus, asset: &str, ts: i64) -> RunRecord {
+        RunRecord {
+            run_id: run_id.to_string(),
+            code_location_id: crate::storage::default_code_location_id(),
+            job_name: None,
+            status,
+            start_time: ts,
+            end_time: Some(ts),
+            tags: Vec::new(),
+            node_names: vec![asset.to_string()],
+            priority: 0,
+            partition_key: None,
+            block_reason: None,
+            launched_by: crate::storage::LaunchedBy::default(),
+        }
+    }
+
+    #[test]
+    fn failure_floor_survives_co_batched_older_success() {
+        // A refresh batch carrying a Success@100 and a chronologically newer
+        // Failure@200 for the same unpartitioned asset must NOT let the
+        // success clear the newer failure's floor — apply applied all
+        // failed_adds then all failed_removes with no chronology check.
+        let mut cache = AssetConditionCache::new("default".to_string());
+        let mut delta = RefreshDelta::default();
+        cache.apply_run_effects_to_delta(&mk_run("s", RunStatus::Success, "R", 100), &mut delta);
+        cache.apply_run_effects_to_delta(&mk_run("f", RunStatus::Failure, "R", 200), &mut delta);
+        cache.apply_refresh_delta(delta);
+
+        assert_eq!(
+            cache.failed_asset_timestamps.get("R"),
+            Some(&200),
+            "newer failure floor must survive an older co-batched success"
+        );
+        assert!(
+            cache.failed_assets.contains("R"),
+            "asset must remain in failed_assets"
+        );
+    }
+
+    #[test]
+    fn newer_success_clears_failure_floor() {
+        // The boundary: a Success NEWER than the failure must still clear it.
+        let mut cache = AssetConditionCache::new("default".to_string());
+        let mut delta = RefreshDelta::default();
+        cache.apply_run_effects_to_delta(&mk_run("f", RunStatus::Failure, "R", 100), &mut delta);
+        cache.apply_run_effects_to_delta(&mk_run("s", RunStatus::Success, "R", 200), &mut delta);
+        cache.apply_refresh_delta(delta);
+
+        assert_eq!(
+            cache.failed_asset_timestamps.get("R"),
+            None,
+            "a success newer than the failure must clear the floor"
+        );
+        assert!(!cache.failed_assets.contains("R"));
     }
 }

--- a/rust/rivers-core/src/condition/cache.rs
+++ b/rust/rivers-core/src/condition/cache.rs
@@ -114,9 +114,10 @@ struct RefreshDelta {
     record_updates: Vec<AssetRecord>,
     /// In-progress changes, in apply order.
     in_progress_changes: Vec<InProgressChange>,
-    /// Asset keys to add to `failed_assets`, with the failing run's
-    /// end (or start) timestamp.
-    failed_adds: HashMap<String, i64>,
+    /// Asset keys to add to `failed_assets`, each with the failing run's
+    /// end (or start) timestamp and run id. The run id lets `apply` skip an
+    /// asset that actually materialized in the failed (joint) run.
+    failed_adds: HashMap<String, (i64, String)>,
     /// Asset keys whose success clears `failed_assets`, with the success run's
     /// timestamp — a remove only clears a failure floor older than it, so a
     /// co-batched older success can't clobber a newer failure.
@@ -585,8 +586,12 @@ impl AssetConditionCache {
                 delta
                     .failed_adds
                     .entry(asset.clone())
-                    .and_modify(|t| *t = (*t).max(run_ts))
-                    .or_insert(run_ts);
+                    .and_modify(|e| {
+                        if run_ts > e.0 {
+                            *e = (run_ts, run.run_id.clone());
+                        }
+                    })
+                    .or_insert_with(|| (run_ts, run.run_id.clone()));
             } else {
                 delta
                     .failed_removes
@@ -783,7 +788,27 @@ impl AssetConditionCache {
             }
         }
 
-        for (asset, ts) in failed_adds {
+        // record_updates are applied above, so `last_run_id` is current. A
+        // joint run can fail one step while others materialized: an asset whose
+        // latest materialization IS this run produced output, so it clears like
+        // a success instead of carrying a failure floor.
+        for (asset, (ts, run_id)) in failed_adds {
+            let materialized_here = self
+                .records
+                .get(asset.as_str())
+                .and_then(|r| r.last_run_id.as_deref())
+                == Some(run_id.as_str());
+            if materialized_here {
+                if self
+                    .failed_asset_timestamps
+                    .get(asset.as_str())
+                    .is_none_or(|&f| ts >= f)
+                {
+                    self.failed_assets.remove(asset.as_str());
+                    self.failed_asset_timestamps.remove(asset.as_str());
+                }
+                continue;
+            }
             self.failed_assets.insert(asset.clone());
             self.failed_asset_timestamps
                 .entry(asset)
@@ -1120,7 +1145,7 @@ impl AssetConditionCache {
 mod tests {
     use super::*;
 
-    fn mk_run(run_id: &str, status: RunStatus, asset: &str, ts: i64) -> RunRecord {
+    fn mk_run(run_id: &str, status: RunStatus, assets: &[&str], ts: i64) -> RunRecord {
         RunRecord {
             run_id: run_id.to_string(),
             code_location_id: crate::storage::default_code_location_id(),
@@ -1129,11 +1154,29 @@ mod tests {
             start_time: ts,
             end_time: Some(ts),
             tags: Vec::new(),
-            node_names: vec![asset.to_string()],
+            node_names: assets.iter().map(|s| s.to_string()).collect(),
             priority: 0,
             partition_key: None,
             block_reason: None,
             launched_by: crate::storage::LaunchedBy::default(),
+        }
+    }
+
+    fn rec_with_run(asset: &str, last_run_id: Option<&str>, ts: i64) -> AssetRecord {
+        AssetRecord {
+            code_location_id: crate::storage::default_code_location_id(),
+            asset_key: asset.to_string(),
+            tags: vec![],
+            kinds: vec![],
+            asset_group: None,
+            code_version: None,
+            last_event_id: None,
+            last_run_id: last_run_id.map(String::from),
+            last_timestamp: Some(ts),
+            last_data_version: None,
+            last_materialization_code_version: None,
+            last_input_data_versions: vec![],
+            pool: vec![],
         }
     }
 
@@ -1145,8 +1188,8 @@ mod tests {
         // failed_adds then all failed_removes with no chronology check.
         let mut cache = AssetConditionCache::new("default".to_string());
         let mut delta = RefreshDelta::default();
-        cache.apply_run_effects_to_delta(&mk_run("s", RunStatus::Success, "R", 100), &mut delta);
-        cache.apply_run_effects_to_delta(&mk_run("f", RunStatus::Failure, "R", 200), &mut delta);
+        cache.apply_run_effects_to_delta(&mk_run("s", RunStatus::Success, &["R"], 100), &mut delta);
+        cache.apply_run_effects_to_delta(&mk_run("f", RunStatus::Failure, &["R"], 200), &mut delta);
         cache.apply_refresh_delta(delta);
 
         assert_eq!(
@@ -1165,8 +1208,8 @@ mod tests {
         // The boundary: a Success NEWER than the failure must still clear it.
         let mut cache = AssetConditionCache::new("default".to_string());
         let mut delta = RefreshDelta::default();
-        cache.apply_run_effects_to_delta(&mk_run("f", RunStatus::Failure, "R", 100), &mut delta);
-        cache.apply_run_effects_to_delta(&mk_run("s", RunStatus::Success, "R", 200), &mut delta);
+        cache.apply_run_effects_to_delta(&mk_run("f", RunStatus::Failure, &["R"], 100), &mut delta);
+        cache.apply_run_effects_to_delta(&mk_run("s", RunStatus::Success, &["R"], 200), &mut delta);
         cache.apply_refresh_delta(delta);
 
         assert_eq!(
@@ -1175,5 +1218,39 @@ mod tests {
             "a success newer than the failure must clear the floor"
         );
         assert!(!cache.failed_assets.contains("R"));
+    }
+
+    #[test]
+    fn failure_floor_skips_assets_materialized_in_the_failed_run() {
+        // A joint run [X, Y] fails because Y's step failed, but X materialized
+        // fine. Only Y carries a failure floor — X's record
+        // points at the failing run as its latest materialization, so it must
+        // not be floored (else its dep-updated fires are wrongly suppressed).
+        let mut cache = AssetConditionCache::new("default".to_string());
+        cache
+            .records
+            .insert("X".to_string(), rec_with_run("X", Some("R"), 150));
+        cache
+            .records
+            .insert("Y".to_string(), rec_with_run("Y", Some("prev"), 50));
+
+        let mut delta = RefreshDelta::default();
+        cache.apply_run_effects_to_delta(
+            &mk_run("R", RunStatus::Failure, &["X", "Y"], 150),
+            &mut delta,
+        );
+        cache.apply_refresh_delta(delta);
+
+        assert_eq!(
+            cache.failed_asset_timestamps.get("Y"),
+            Some(&150),
+            "Y actually failed → floor at the run ts"
+        );
+        assert!(
+            !cache.failed_asset_timestamps.contains_key("X"),
+            "X materialized in the failed joint run → no failure floor"
+        );
+        assert!(!cache.failed_assets.contains("X"));
+        assert!(cache.failed_assets.contains("Y"));
     }
 }

--- a/rust/rivers-core/src/condition/cache.rs
+++ b/rust/rivers-core/src/condition/cache.rs
@@ -114,8 +114,9 @@ struct RefreshDelta {
     record_updates: Vec<AssetRecord>,
     /// In-progress changes, in apply order.
     in_progress_changes: Vec<InProgressChange>,
-    /// Asset keys to add to `failed_assets`.
-    failed_adds: HashSet<String>,
+    /// Asset keys to add to `failed_assets`, with the failing run's
+    /// end (or start) timestamp.
+    failed_adds: HashMap<String, i64>,
     /// Asset keys to remove from `failed_assets`.
     failed_removes: HashSet<String>,
     /// Tag updates: `(asset, partition_key, tags)`.
@@ -156,6 +157,8 @@ pub struct AssetConditionCache {
     pub in_progress_assets: HashMap<String, Vec<String>>,
     /// Assets whose latest run failed.
     pub failed_assets: HashSet<String>,
+    /// Latest failure timestamp per currently-failed asset.
+    pub failed_asset_timestamps: HashMap<String, i64>,
     /// Timestamp of the most recent run seen (for cursor-based queries).
     pub last_seen_run_ts: i64,
     /// Timestamp of the most recent observation event seen (cursor for external assets).
@@ -218,6 +221,7 @@ impl AssetConditionCache {
             downstream_deps: HashMap::new(),
             in_progress_assets: HashMap::new(),
             failed_assets: HashSet::new(),
+            failed_asset_timestamps: HashMap::new(),
             last_seen_run_ts: 0,
             last_observation_ts: 0,
             initialized: false,
@@ -573,9 +577,14 @@ impl AssetConditionCache {
             Some(pk) => pk.members().into_iter().map(Some).collect(),
             None => vec![None],
         };
+        let run_ts = run.end_time.unwrap_or(run.start_time);
         for asset in &run.node_names {
             if is_failure {
-                delta.failed_adds.insert(asset.clone());
+                delta
+                    .failed_adds
+                    .entry(asset.clone())
+                    .and_modify(|t| *t = (*t).max(run_ts))
+                    .or_insert(run_ts);
             } else {
                 delta.failed_removes.insert(asset.clone());
             }
@@ -768,11 +777,16 @@ impl AssetConditionCache {
             }
         }
 
-        for asset in failed_adds {
-            self.failed_assets.insert(asset);
+        for (asset, ts) in failed_adds {
+            self.failed_assets.insert(asset.clone());
+            self.failed_asset_timestamps
+                .entry(asset)
+                .and_modify(|t| *t = (*t).max(ts))
+                .or_insert(ts);
         }
         for asset in failed_removes {
             self.failed_assets.remove(asset.as_str());
+            self.failed_asset_timestamps.remove(asset.as_str());
         }
 
         for (asset, pk, tags) in run_tag_updates {
@@ -865,6 +879,7 @@ impl AssetConditionCache {
             type AssetRunRow = (
                 String,
                 RunStatus,
+                i64,
                 Option<PartitionKey>,
                 RunTags,
                 Arc<[String]>,
@@ -884,6 +899,7 @@ impl AssetConditionCache {
                             (
                                 record.asset_key.clone(),
                                 run.status.clone(),
+                                run.end_time.unwrap_or(run.start_time),
                                 pk,
                                 Arc::from(run.tags.as_slice()),
                                 Arc::from(run.node_names.as_slice()),
@@ -894,9 +910,13 @@ impl AssetConditionCache {
                 })
                 .flatten()
                 .collect();
-            for (asset_key, status, partition_key, tags, asset_names) in &asset_runs {
+            for (asset_key, status, run_ts, partition_key, tags, asset_names) in &asset_runs {
                 if *status == RunStatus::Failure {
                     self.failed_assets.insert(asset_key.clone());
+                    self.failed_asset_timestamps
+                        .entry(asset_key.clone())
+                        .and_modify(|t| *t = (*t).max(*run_ts))
+                        .or_insert(*run_ts);
                 }
                 if !tags.is_empty() {
                     self.update_run_tags(asset_key, partition_key, tags);

--- a/rust/rivers-core/src/condition/cache.rs
+++ b/rust/rivers-core/src/condition/cache.rs
@@ -97,6 +97,14 @@ enum InProgressChange {
     AssetClear(String),
 }
 
+/// A pending `failed_adds` entry: the failing run's end (or start) timestamp
+/// and id. The id lets `apply` skip an asset that actually materialized in a
+/// failed joint run (its record's `last_run_id` matches this run).
+struct FailedRun {
+    ts: i64,
+    run_id: String,
+}
+
 /// Description of every mutation a single steady-state refresh wants to make
 /// to the cache. Built fallibly by `fetch_refresh_delta` (any storage error
 /// → drop the partial delta, cache untouched). Replayed infallibly by
@@ -114,10 +122,9 @@ struct RefreshDelta {
     record_updates: Vec<AssetRecord>,
     /// In-progress changes, in apply order.
     in_progress_changes: Vec<InProgressChange>,
-    /// Asset keys to add to `failed_assets`, each with the failing run's
-    /// end (or start) timestamp and run id. The run id lets `apply` skip an
-    /// asset that actually materialized in the failed (joint) run.
-    failed_adds: HashMap<String, (i64, String)>,
+    /// Asset keys to add to `failed_assets`, each with the [`FailedRun`] that
+    /// floored them.
+    failed_adds: HashMap<String, FailedRun>,
     /// Asset keys whose success clears `failed_assets`, with the success run's
     /// timestamp — a remove only clears a failure floor older than it, so a
     /// co-batched older success can't clobber a newer failure.
@@ -587,11 +594,15 @@ impl AssetConditionCache {
                     .failed_adds
                     .entry(asset.clone())
                     .and_modify(|e| {
-                        if run_ts > e.0 {
-                            *e = (run_ts, run.run_id.clone());
+                        if run_ts > e.ts {
+                            e.run_id = run.run_id.clone();
+                            e.ts = run_ts;
                         }
                     })
-                    .or_insert_with(|| (run_ts, run.run_id.clone()));
+                    .or_insert_with(|| FailedRun {
+                        ts: run_ts,
+                        run_id: run.run_id.clone(),
+                    });
             } else {
                 delta
                     .failed_removes
@@ -792,7 +803,7 @@ impl AssetConditionCache {
         // joint run can fail one step while others materialized: an asset whose
         // latest materialization IS this run produced output, so it clears like
         // a success instead of carrying a failure floor.
-        for (asset, (ts, run_id)) in failed_adds {
+        for (asset, FailedRun { ts, run_id }) in failed_adds {
             let materialized_here = self
                 .records
                 .get(asset.as_str())

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -1341,7 +1341,14 @@ fn eval_partitioned_on_dep(
     // Staleness floor for `NewlyUpdated`, translated into the dep's key
     // space: for each dep key, the root's materialization state of the
     // downstream key(s) it maps to. Built here because the mapping and both
-    // universes are only visible at the pivot boundary.
+    // universes are only visible at the pivot boundary. Identity edges (the
+    // default) skip the per-key selection round-trip — the dep key IS the
+    // downstream key.
+    let mapping_kind = pctx.resolver.mapping_kind(dep_key, ctx.target_key);
+    let is_identity = matches!(
+        mapping_kind,
+        None | Some(crate::condition::partition::PartitionMappingKind::Identity)
+    );
     let dep_root_floor = pctx
         .all_partition_statuses
         .get(ctx.root_key)
@@ -1350,6 +1357,15 @@ fn eval_partitioned_on_dep(
                 .timestamps
                 .keys()
                 .filter_map(|uk| {
+                    if is_identity {
+                        if !pctx.all_keys.contains(uk) {
+                            return None;
+                        }
+                        return Some((
+                            uk.clone(),
+                            root_floor_over(std::iter::once(uk), root_status),
+                        ));
+                    }
                     let mapped = pctx.resolver.map_downstream(
                         dep_key,
                         ctx.target_key,

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -1242,18 +1242,27 @@ fn eval_partitioned_all_deps(
 }
 
 /// The staleness floor across the downstream keys a dep key maps to: the
-/// minimum materialization timestamp, or `None` as soon as any of them was
-/// never materialized (an unmaterialized mapped key keeps the dep "updated").
+/// minimum per-key effective timestamp, where effective = the later of the
+/// last materialization and the last (still-current) failure — a failed
+/// attempt consumes the dep update that triggered it, or the daemon would
+/// re-dispatch a failing partition every tick. `None` as soon as any mapped
+/// key was never attempted at all (that keeps the dep "updated").
 fn root_floor_over<'k>(
     keys: impl Iterator<Item = &'k PartitionKey>,
-    root_timestamps: &HashMap<PartitionKey, i64>,
+    root_status: &crate::condition::cache::PartitionStatusEntry,
 ) -> Option<i64> {
     let mut floor: Option<i64> = None;
     for k in keys {
-        match root_timestamps.get(k) {
-            None => return None,
-            Some(&ts) => floor = Some(floor.map_or(ts, |f| f.min(ts))),
-        }
+        let effective = match (
+            root_status.timestamps.get(k),
+            root_status.failed_timestamps.get(k),
+        ) {
+            (None, None) => return None,
+            (Some(&m), None) => m,
+            (None, Some(&f)) => f,
+            (Some(&m), Some(&f)) => m.max(f),
+        };
+        floor = Some(floor.map_or(effective, |fl| fl.min(effective)));
     }
     floor
 }
@@ -1330,7 +1339,7 @@ fn eval_partitioned_on_dep(
                     let floor = match &mapped {
                         PartitionSelection::Empty => return None,
                         PartitionSelection::All => {
-                            root_floor_over(pctx.all_keys.iter(), &root_status.timestamps)
+                            root_floor_over(pctx.all_keys.iter(), root_status)
                         }
                         PartitionSelection::Keys(ks) => {
                             let in_universe: Vec<&PartitionKey> =
@@ -1338,7 +1347,7 @@ fn eval_partitioned_on_dep(
                             if in_universe.is_empty() {
                                 return None;
                             }
-                            root_floor_over(in_universe.into_iter(), &root_status.timestamps)
+                            root_floor_over(in_universe.into_iter(), root_status)
                         }
                     };
                     Some((uk.clone(), floor))

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -261,12 +261,11 @@ fn eval_inner<O: EvalOutput>(
                 let expr = match ctx.target_record.last_timestamp {
                     None => false,
                     Some(dep_ts) => match ctx.root_partition_floor {
-                        // Partitioned root over an unpartitioned dep: floor
-                        // against the OLDEST partition attempt (min), so the
+                        // Partitioned root over an unpartitioned dep: the floor
+                        // is the root's OLDEST partition attempt (min), so the
                         // edge fires while ANY partition is older than the dep
                         // and self-suppresses once all partitions catch up.
-                        // Inner `None` = a partition was never attempted → fire.
-                        Some(floor) => floor.map(|f| dep_ts > f).unwrap_or(true),
+                        Some(floor) => dep_newer_than_floor(dep_ts, floor),
                         None => {
                             let root_mat = ctx
                                 .cache
@@ -928,8 +927,7 @@ fn eval_partitioned<O: PartEvalOutput>(
                 .filter(|&(pk, &ts)| match pctx.dep_root_floor {
                     Some(floor) => match floor.get(pk) {
                         None => false,
-                        Some(None) => true,
-                        Some(Some(root_ts)) => ts > *root_ts,
+                        Some(&inner) => dep_newer_than_floor(ts, inner),
                     },
                     None => match prev_timestamps.and_then(|pt| pt.get(pk)) {
                         Some(&prev) => ts > prev,
@@ -1269,6 +1267,15 @@ fn eval_partitioned_all_deps(
         }
     }
     result
+}
+
+/// Whether a dep at `dep_ts` counts as newly-updated against a downstream
+/// key's effective staleness `floor`: fire when the key was never attempted
+/// (`None`) or the dep is strictly newer than the floor. Shared by the scalar
+/// (unpartitioned-dep) and per-key (partitioned-dep) `NewlyUpdated` arms so the
+/// "never attempted ⇒ updated" rule lives in one place.
+fn dep_newer_than_floor(dep_ts: i64, floor: Option<i64>) -> bool {
+    floor.is_none_or(|f| dep_ts > f)
 }
 
 /// The staleness floor across the downstream keys a dep key maps to: the

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -260,24 +260,32 @@ fn eval_inner<O: EvalOutput>(
             if ctx.target_key != ctx.root_key {
                 let expr = match ctx.target_record.last_timestamp {
                     None => false,
-                    Some(dep_ts) => {
-                        let root_mat = ctx
-                            .cache
-                            .records
-                            .get(ctx.root_key)
-                            .and_then(|r| r.last_timestamp);
-                        let root_failed = ctx
-                            .cache
-                            .failed_asset_timestamps
-                            .get(ctx.root_key)
-                            .copied();
-                        match (root_mat, root_failed) {
-                            (None, None) => true,
-                            (Some(m), None) => dep_ts > m,
-                            (None, Some(f)) => dep_ts > f,
-                            (Some(m), Some(f)) => dep_ts > m.max(f),
+                    Some(dep_ts) => match ctx.root_partition_floor {
+                        // Partitioned root over an unpartitioned dep: floor
+                        // against the OLDEST partition attempt (min), so the
+                        // edge fires while ANY partition is older than the dep
+                        // and self-suppresses once all partitions catch up.
+                        // Inner `None` = a partition was never attempted → fire.
+                        Some(floor) => floor.map(|f| dep_ts > f).unwrap_or(true),
+                        None => {
+                            let root_mat = ctx
+                                .cache
+                                .records
+                                .get(ctx.root_key)
+                                .and_then(|r| r.last_timestamp);
+                            let root_failed = ctx
+                                .cache
+                                .failed_asset_timestamps
+                                .get(ctx.root_key)
+                                .copied();
+                            match (root_mat, root_failed) {
+                                (None, None) => true,
+                                (Some(m), None) => dep_ts > m,
+                                (None, Some(f)) => dep_ts > f,
+                                (Some(m), Some(f)) => dep_ts > m.max(f),
+                            }
                         }
-                    }
+                    },
                 };
                 return O::leaf(expr, my_idx, node);
             }
@@ -824,6 +832,7 @@ fn eval_on_dep(
         now: ctx.now,
         is_initial: ctx.is_initial,
         partitions: None,
+        root_partition_floor: None,
     };
     eval_inner(condition, &dep_ctx, counter, sub_results)
 }
@@ -1309,7 +1318,14 @@ fn eval_partitioned_on_dep(
         .unwrap_or_default();
 
     if upstream_all_keys.is_empty() {
-        // Upstream is unpartitioned — fall back to bool evaluation
+        // Upstream is unpartitioned — fall back to bool evaluation, but floor
+        // the dep against the root's OLDEST partition (min), not the asset-level
+        // max, so a `NewlyUpdated` pivot fires while any root partition is
+        // staler than the dep. `None` = some partition never attempted → fire.
+        let root_floor = pctx
+            .all_partition_statuses
+            .get(ctx.root_key)
+            .and_then(|status| root_floor_over(pctx.all_keys.iter(), status));
         let dep_state = ctx
             .all_asset_states
             .get(dep_key)
@@ -1326,6 +1342,7 @@ fn eval_partitioned_on_dep(
             now: ctx.now,
             is_initial: ctx.is_initial,
             partitions: None,
+            root_partition_floor: Some(root_floor),
         };
         let mut sub_results = HashMap::new();
         let val = eval_inner(condition, &dep_ctx, counter, &mut sub_results);
@@ -1418,6 +1435,7 @@ fn eval_partitioned_on_dep(
         now: ctx.now,
         is_initial: ctx.is_initial,
         partitions: Some(&upstream_pctx),
+        root_partition_floor: None,
     };
 
     let upstream_result: PartitionSelection =

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -294,9 +294,11 @@ fn eval_inner<O: EvalOutput>(
                 ctx.prev_state.last_materialized_timestamp,
             ) {
                 (Some(current), Some(prev)) => current > prev,
-                // No previous state: a missing prev_state means the asset
-                // appeared between ticks → treat as updated.
-                (Some(_), None) => true,
+                // No previous baseline: on the initial tick the asset was
+                // already materialized before the daemon started — not a new
+                // update, so suppress (else a bare newly_updated() re-fires on
+                // every restart). Non-initial → it appeared between ticks → fire.
+                (Some(_), None) => !ctx.is_initial,
                 _ => false,
             };
             O::leaf(expr, my_idx, node)

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -350,7 +350,7 @@ fn eval_inner<O: EvalOutput>(
             // Only meaningful inside dep pivots (eval_on_dep); at the root level
             // it's always false because the root hasn't produced a result yet.
             O::leaf(
-                ctx.requested_this_tick.contains(ctx.target_key),
+                ctx.requested_this_tick.contains_key(ctx.target_key),
                 my_idx,
                 node,
             )
@@ -1021,11 +1021,14 @@ fn eval_partitioned<O: PartEvalOutput>(
         }
 
         ConditionNode::WillBeRequested => {
-            // All-or-nothing for partitioned assets.
-            let sel = if ctx.requested_this_tick.contains(ctx.target_key) {
-                PartitionSelection::Keys(pctx.all_keys.clone())
-            } else {
-                PartitionSelection::Empty
+            // The target's fired selection from earlier this tick, in its own
+            // key space — a dep pivot maps it downstream like any other
+            // selection. Unpartitioned fires arrive as `All` and widen to the
+            // full universe.
+            let sel = match ctx.requested_this_tick.get(ctx.target_key) {
+                None | Some(PartitionSelection::Empty) => PartitionSelection::Empty,
+                Some(PartitionSelection::All) => PartitionSelection::Keys(pctx.all_keys.clone()),
+                Some(s @ PartitionSelection::Keys(_)) => s.clone(),
             };
             O::leaf(sel, my_idx, node, total)
         }

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -251,28 +251,44 @@ fn eval_inner<O: EvalOutput>(
             O::leaf(expr, my_idx, node)
         }
         ConditionNode::NewlyUpdated => {
+            // In a dep pivot, fire-time baselines are unsound (async event
+            // drains double-fire; global re-baselining loses fires) — same
+            // contract as the partitioned arm: a dep counts as updated while
+            // strictly newer than the root's last successful OR failed
+            // attempt, so the triggered run self-suppresses and a failed one
+            // consumes the update instead of retrying every tick.
+            if ctx.target_key != ctx.root_key {
+                let expr = match ctx.target_record.last_timestamp {
+                    None => false,
+                    Some(dep_ts) => {
+                        let root_mat = ctx
+                            .cache
+                            .records
+                            .get(ctx.root_key)
+                            .and_then(|r| r.last_timestamp);
+                        let root_failed = ctx
+                            .cache
+                            .failed_asset_timestamps
+                            .get(ctx.root_key)
+                            .copied();
+                        match (root_mat, root_failed) {
+                            (None, None) => true,
+                            (Some(m), None) => dep_ts > m,
+                            (None, Some(f)) => dep_ts > f,
+                            (Some(m), Some(f)) => dep_ts > m.max(f),
+                        }
+                    }
+                };
+                return O::leaf(expr, my_idx, node);
+            }
             let expr = match (
                 ctx.target_record.last_timestamp,
                 ctx.prev_state.last_materialized_timestamp,
             ) {
                 (Some(current), Some(prev)) => current > prev,
-                // No previous state: on initial tick, use heuristic — only
-                // fire if this asset was materialized AFTER the root asset
-                // (genuine new data from a racing sensor/schedule). On
-                // non-initial ticks, a missing prev_state means new dep
+                // No previous state: a missing prev_state means the asset
                 // appeared between ticks → treat as updated.
-                (Some(dep_ts), None) => {
-                    if ctx.is_initial {
-                        ctx.cache
-                            .records
-                            .get(ctx.root_key)
-                            .and_then(|r| r.last_timestamp)
-                            .map(|root_ts| dep_ts > root_ts)
-                            .unwrap_or(true)
-                    } else {
-                        true
-                    }
-                }
+                (Some(_), None) => true,
                 _ => false,
             };
             O::leaf(expr, my_idx, node)

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -1297,6 +1297,31 @@ fn root_floor_over<'k>(
     floor
 }
 
+/// Like `root_floor_over` but for fan-out (`AllPartitions`) edges: floor only
+/// over keys actually attempted, ignoring never-attempted ones instead of
+/// collapsing to `None`. A freshly-minted frontier key must not drag the floor
+/// to `None` and rebroadcast the whole universe on a stale dep. `None` only when
+/// nothing was ever attempted.
+fn root_floor_over_attempted<'k>(
+    keys: impl Iterator<Item = &'k PartitionKey>,
+    root_status: &crate::condition::cache::PartitionStatusEntry,
+) -> Option<i64> {
+    let mut floor: Option<i64> = None;
+    for k in keys {
+        let effective = match (
+            root_status.timestamps.get(k),
+            root_status.failed_timestamps.get(k),
+        ) {
+            (None, None) => continue,
+            (Some(&m), None) => m,
+            (None, Some(&f)) => f,
+            (Some(&m), Some(&f)) => m.max(f),
+        };
+        floor = Some(floor.map_or(effective, |fl| fl.min(effective)));
+    }
+    floor
+}
+
 /// Evaluate a condition on an upstream dep in partition-aware mode.
 /// Maps partitions: downstream → upstream, evaluate, upstream → downstream.
 fn eval_partitioned_on_dep(
@@ -1393,7 +1418,14 @@ fn eval_partitioned_on_dep(
                     let floor = match &mapped {
                         PartitionSelection::Empty => return None,
                         PartitionSelection::All => {
-                            root_floor_over(pctx.all_keys.iter(), root_status)
+                            // Fan-out: uk feeds the whole downstream universe.
+                            // Floor over attempted keys only; a never-attempted
+                            // key would force None (→ "updated") and rebroadcast
+                            // All. Nothing attempted → uk not due.
+                            match root_floor_over_attempted(pctx.all_keys.iter(), root_status) {
+                                Some(f) => Some(f),
+                                None => return None,
+                            }
                         }
                         PartitionSelection::Keys(ks) => {
                             let in_universe: Vec<&PartitionKey> =

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -886,23 +886,24 @@ fn eval_partitioned<O: PartEvalOutput>(
             // acted-on events (double fire), and a fire can baseline a key
             // that a sibling clause suppressed that tick (lost fire,
             // forever). Compare staleness instead: a dep key counts as
-            // updated while it is strictly newer than the root's own
-            // materialization of that key — the dispatched run advances the
-            // root past the dep so the trigger self-suppresses, and a missed
-            // tick simply retries. Keys the root never materialized pass;
-            // roots without partition status keep the baseline behavior.
-            let root_floor = if ctx.target_key != ctx.root_key {
-                pctx.all_partition_statuses
-                    .get(ctx.root_key)
-                    .map(|s| &s.timestamps)
-            } else {
-                None
-            };
+            // updated while it is strictly newer than the root's
+            // materialization of the downstream key(s) the partition mapping
+            // resolves it to — the dispatched run advances those keys past
+            // the dep so the trigger self-suppresses, and a missed tick
+            // simply retries. Mapped keys never materialized pass; dep keys
+            // with no counterpart in the downstream universe never count
+            // (nothing could ever be dispatched for them). The floor map is
+            // built per dep by `eval_partitioned_on_dep`; outside dep pivots
+            // (and for roots without partition status) baselines remain.
             let updated: HashSet<PartitionKey> = pctx
                 .timestamps
                 .iter()
-                .filter(|&(pk, &ts)| match root_floor {
-                    Some(floor) => floor.get(pk).is_none_or(|&root_ts| ts > root_ts),
+                .filter(|&(pk, &ts)| match pctx.dep_root_floor {
+                    Some(floor) => match floor.get(pk) {
+                        None => false,
+                        Some(None) => true,
+                        Some(Some(root_ts)) => ts > *root_ts,
+                    },
                     None => match prev_timestamps.and_then(|pt| pt.get(pk)) {
                         Some(&prev) => ts > prev,
                         None => true, // newly appeared partition
@@ -1240,6 +1241,23 @@ fn eval_partitioned_all_deps(
     result
 }
 
+/// The staleness floor across the downstream keys a dep key maps to: the
+/// minimum materialization timestamp, or `None` as soon as any of them was
+/// never materialized (an unmaterialized mapped key keeps the dep "updated").
+fn root_floor_over<'k>(
+    keys: impl Iterator<Item = &'k PartitionKey>,
+    root_timestamps: &HashMap<PartitionKey, i64>,
+) -> Option<i64> {
+    let mut floor: Option<i64> = None;
+    for k in keys {
+        match root_timestamps.get(k) {
+            None => return None,
+            Some(&ts) => floor = Some(floor.map_or(ts, |f| f.min(ts))),
+        }
+    }
+    floor
+}
+
 /// Evaluate a condition on an upstream dep in partition-aware mode.
 /// Maps partitions: downstream → upstream, evaluate, upstream → downstream.
 fn eval_partitioned_on_dep(
@@ -1292,6 +1310,42 @@ fn eval_partitioned_on_dep(
         .get(dep_key)
         .unwrap_or(&empty_status);
 
+    // Staleness floor for `NewlyUpdated`, translated into the dep's key
+    // space: for each dep key, the root's materialization state of the
+    // downstream key(s) it maps to. Built here because the mapping and both
+    // universes are only visible at the pivot boundary.
+    let dep_root_floor = pctx
+        .all_partition_statuses
+        .get(ctx.root_key)
+        .map(|root_status| {
+            upstream_status
+                .timestamps
+                .keys()
+                .filter_map(|uk| {
+                    let mapped = pctx.resolver.map_downstream(
+                        dep_key,
+                        ctx.target_key,
+                        &PartitionSelection::Keys(HashSet::from([uk.clone()])),
+                    );
+                    let floor = match &mapped {
+                        PartitionSelection::Empty => return None,
+                        PartitionSelection::All => {
+                            root_floor_over(pctx.all_keys.iter(), &root_status.timestamps)
+                        }
+                        PartitionSelection::Keys(ks) => {
+                            let in_universe: Vec<&PartitionKey> =
+                                ks.iter().filter(|k| pctx.all_keys.contains(*k)).collect();
+                            if in_universe.is_empty() {
+                                return None;
+                            }
+                            root_floor_over(in_universe.into_iter(), &root_status.timestamps)
+                        }
+                    };
+                    Some((uk.clone(), floor))
+                })
+                .collect::<HashMap<PartitionKey, Option<i64>>>()
+        });
+
     let upstream_pctx = PartitionEvalContext {
         all_keys: &upstream_all_keys,
         materialized: &upstream_status.materialized,
@@ -1301,6 +1355,7 @@ fn eval_partitioned_on_dep(
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: pctx.all_partition_statuses,
+        dep_root_floor: dep_root_floor.as_ref(),
     };
 
     let dep_state = ctx

--- a/rust/rivers-core/src/condition/partition.rs
+++ b/rust/rivers-core/src/condition/partition.rs
@@ -397,6 +397,16 @@ impl<'a> PartitionResolver<'a> {
         };
         mapping.map_to_downstream(upstream_keys)
     }
+
+    /// The mapping kind for an edge, if one was declared (absent = Identity).
+    pub(crate) fn mapping_kind(
+        &self,
+        upstream_asset: &str,
+        downstream_asset: &str,
+    ) -> Option<&PartitionMappingKind> {
+        self.mappings
+            .get(&(downstream_asset.to_string(), upstream_asset.to_string()))
+    }
 }
 
 /// All partition-level data needed during condition evaluation.

--- a/rust/rivers-core/src/condition/partition.rs
+++ b/rust/rivers-core/src/condition/partition.rs
@@ -421,6 +421,13 @@ pub struct PartitionEvalContext<'a> {
     /// Used by `eval_partitioned_on_dep` to look up upstream deps' actual
     /// materialized/in-progress/failed partition sets instead of heuristics.
     pub all_partition_statuses: &'a HashMap<String, crate::condition::cache::PartitionStatusEntry>,
+    /// Staleness floor for `NewlyUpdated` in a dep pivot, keyed by UPSTREAM
+    /// key: the root's materialization state of the downstream key(s) that
+    /// upstream key maps to. Absent key = no counterpart in the downstream
+    /// universe (never counts as updated); `None` = a mapped downstream key
+    /// exists but was never materialized (counts as updated). `None` for the
+    /// whole field outside dep pivots — the self path keeps baselines.
+    pub dep_root_floor: Option<&'a HashMap<PartitionKey, Option<i64>>>,
 }
 
 /// Per-partition condition evaluation state, persisted across ticks.

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -502,6 +502,7 @@ impl ConditionPass {
         let results = self.evaluate(now, selective);
         let to_materialize = self.apply_results(&results, now);
         let plan = self.classify_materializations(to_materialize);
+        self.stamp_dispatched_handled(&plan, now);
         PassOutput { results, plan }
     }
 
@@ -662,9 +663,6 @@ impl ConditionPass {
         }
 
         for tm in &to_materialize {
-            if let Some(prev) = self.eval_state.assets.get_mut(&tm.asset_key) {
-                prev.last_handled_timestamp = Some(now);
-            }
             if let Some(PartitionSelection::Keys(keys)) = &tm.selection {
                 tracing::info!(
                     target: "rivers::daemon",
@@ -813,6 +811,34 @@ impl ConditionPass {
             multi_partition_backfills,
         }
     }
+
+    /// Advance the asset-level handled cursor only for assets the plan actually
+    /// dispatched — a selection `classify` trimmed to zero must not advance it,
+    /// or `NewlyRequested` reads true next tick with nothing dispatched. Mirrors
+    /// the per-partition `handled` set classify already restricts to survivors.
+    fn stamp_dispatched_handled(&mut self, plan: &MaterializationPlan, now: i64) {
+        let dispatched: HashSet<&str> = plan
+            .unpartitioned
+            .iter()
+            .map(String::as_str)
+            .chain(
+                plan.single_partition_groups
+                    .values()
+                    .flatten()
+                    .map(String::as_str),
+            )
+            .chain(
+                plan.multi_partition_backfills
+                    .iter()
+                    .map(|(asset, _)| asset.as_str()),
+            )
+            .collect();
+        for asset_key in dispatched {
+            if let Some(prev) = self.eval_state.assets.get_mut(asset_key) {
+                prev.last_handled_timestamp = Some(now);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -832,6 +858,101 @@ mod tests {
     /// Helper: parse "YYYY-MM-DD HH:MM" as a wall-clock naive datetime.
     fn to_wall(dt_str: &str) -> NaiveDateTime {
         chrono::NaiveDateTime::parse_from_str(dt_str, "%Y-%m-%d %H:%M").unwrap()
+    }
+
+    fn test_record(key: &str) -> crate::storage::AssetRecord {
+        crate::storage::AssetRecord {
+            code_location_id: crate::storage::default_code_location_id(),
+            asset_key: key.to_string(),
+            tags: vec![],
+            kinds: vec![],
+            asset_group: None,
+            code_version: None,
+            last_event_id: None,
+            last_run_id: None,
+            last_timestamp: None,
+            last_data_version: None,
+            last_materialization_code_version: None,
+            last_input_data_versions: vec![],
+            pool: vec![],
+        }
+    }
+
+    /// Build a one-partitioned-asset pass and run a full
+    /// apply_results → classify → stamp tick with the given fired selection.
+    /// Returns the asset's handled cursor after the tick.
+    fn handled_after_fired_selection(selection: PartitionSelection) -> Option<i64> {
+        let mut cache = AssetConditionCache::default();
+        cache.records.insert("down".to_string(), test_record("down"));
+        let mut pass = ConditionPass::new(
+            cache,
+            ConditionEvalState::default(),
+            vec![AssetConditionInfo {
+                asset_key: "down".to_string(),
+                condition: ConditionNode::InProgress,
+                partition_info: Some(PartitionInfo {
+                    all_keys: make_daily_keys(&["2024-01-01"]),
+                    mappings: HashMap::new(),
+                    time_window_fmt: None,
+                    universe: PartitionUniverse::Frozen,
+                }),
+                backfill_strategy: None,
+            }],
+            HashMap::new(),
+        );
+        pass.eval_state.assets.insert(
+            "down".to_string(),
+            crate::condition::state::AssetConditionState::default(),
+        );
+        let row = EvalResultRow {
+            info_idx: 0,
+            result: EvalResult {
+                fired: true,
+                selection: Some(selection),
+                ..Default::default()
+            },
+            tree: EvalNodeResult::new(
+                &ConditionNode::InProgress,
+                0,
+                crate::condition::state::NodeStatus::True,
+                vec![],
+                None,
+            ),
+            duration_us: 0,
+        };
+        let to_mat = pass.apply_results(&[row], 5000);
+        let plan = pass.classify_materializations(to_mat);
+        pass.stamp_dispatched_handled(&plan, 5000);
+        pass.eval_state.assets["down"].last_handled_timestamp
+    }
+
+    #[test]
+    fn handled_cursor_skips_fully_dropped_selection() {
+        // An asset fires for a key outside its universe; classify trims the
+        // selection to zero, so nothing dispatches. The handled cursor must
+        // NOT advance — apply_results used to stamp it before classify ran, so
+        // NewlyRequested read true next tick with nothing dispatched.
+        let handled = handled_after_fired_selection(PartitionSelection::Keys(
+            [spk("2099-12-31")].into_iter().collect(),
+        ));
+        assert_eq!(
+            handled, None,
+            "a fully-dropped selection must not advance the handled cursor"
+        );
+    }
+
+    #[test]
+    fn handled_cursor_advances_for_surviving_selection() {
+        // The boundary: a selection with a real key DOES dispatch and so must
+        // advance the handled cursor.
+        let handled = handled_after_fired_selection(PartitionSelection::Keys(
+            [spk("2024-01-01")].into_iter().collect(),
+        ));
+        assert_eq!(
+            handled,
+            Some(5000),
+            "a dispatched selection must advance the handled cursor"
+        );
     }
 
     #[test]

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -707,10 +707,10 @@ impl ConditionPass {
         let mut partitioned_mats: Vec<(String, Vec<PartitionKey>)> = Vec::new();
 
         for tm in to_materialize {
-            self.cache
-                .in_progress_assets
-                .entry(tm.asset_key.clone())
-                .or_default();
+            // The in-progress entry gates next tick's dispatch until run ids
+            // land on it, so it may only exist for assets that actually
+            // produce a dispatch — a fully-dropped selection would leave an
+            // empty entry nothing ever clears, wedging the asset.
             match tm.selection {
                 Some(PartitionSelection::Keys(keys)) if !keys.is_empty() => {
                     // A mapped selection can name keys this asset doesn't
@@ -739,6 +739,10 @@ impl ConditionPass {
                         );
                     }
                     if !surviving.is_empty() {
+                        self.cache
+                            .in_progress_assets
+                            .entry(tm.asset_key.clone())
+                            .or_default();
                         self.mark_partitions_handled(&tm.asset_key, &surviving);
                         partitioned_mats.push((tm.asset_key, surviving));
                     }
@@ -752,14 +756,28 @@ impl ConditionPass {
                         .map(|pi| pi.all_keys.iter().cloned().collect::<Vec<_>>());
                     match resolved {
                         Some(all_keys) if !all_keys.is_empty() => {
+                            self.cache
+                                .in_progress_assets
+                                .entry(tm.asset_key.clone())
+                                .or_default();
                             self.mark_partitions_handled(&tm.asset_key, &all_keys);
                             partitioned_mats.push((tm.asset_key, all_keys));
                         }
                         Some(_) => {} // partitioned asset with zero keys — drop
-                        None => unpartitioned.push(tm.asset_key),
+                        None => {
+                            self.cache
+                                .in_progress_assets
+                                .entry(tm.asset_key.clone())
+                                .or_default();
+                            unpartitioned.push(tm.asset_key);
+                        }
                     }
                 }
                 _ => {
+                    self.cache
+                        .in_progress_assets
+                        .entry(tm.asset_key.clone())
+                        .or_default();
                     unpartitioned.push(tm.asset_key);
                 }
             }
@@ -1202,6 +1220,54 @@ mod tests {
         let mut sorted = display.clone();
         sorted.sort_unstable();
         assert_eq!(display, sorted, "dispatched keys must be display-ordered");
+    }
+
+    #[test]
+    fn classify_fully_dropped_selection_leaves_no_in_progress_entry() {
+        // A selection whose keys are all outside the asset's universe
+        // dispatches nothing — it must not pre-mark the asset in-progress.
+        // The empty entry has no clear path (no run ids ever land), so it
+        // would gate every future dispatch for the asset forever.
+        let mut pass = ConditionPass::new(
+            AssetConditionCache::default(),
+            ConditionEvalState::default(),
+            vec![AssetConditionInfo {
+                asset_key: "down".to_string(),
+                condition: ConditionNode::InProgress,
+                partition_info: Some(PartitionInfo {
+                    all_keys: make_daily_keys(&["2024-01-01", "2024-01-02"]),
+                    mappings: HashMap::new(),
+                    time_window_fmt: None,
+                    universe: PartitionUniverse::Frozen,
+                }),
+                backfill_strategy: None,
+            }],
+            HashMap::new(),
+        );
+        pass.eval_state.assets.insert(
+            "down".to_string(),
+            crate::condition::state::AssetConditionState::default(),
+        );
+        let plan = pass.classify_materializations(vec![ToMaterialize {
+            asset_key: "down".to_string(),
+            selection: Some(PartitionSelection::Keys(make_daily_keys(&["1999-01-01"]))),
+        }]);
+        assert!(plan.unpartitioned.is_empty());
+        assert!(plan.single_partition_groups.is_empty());
+        assert!(plan.multi_partition_backfills.is_empty());
+        assert!(
+            !pass.cache.in_progress_assets.contains_key("down"),
+            "a fully-dropped selection must not wedge the asset behind an \
+             in-progress entry nothing will ever clear"
+        );
+
+        // Control: a surviving selection still pre-marks the asset.
+        let plan = pass.classify_materializations(vec![ToMaterialize {
+            asset_key: "down".to_string(),
+            selection: Some(PartitionSelection::Keys(make_daily_keys(&["2024-01-01"]))),
+        }]);
+        assert_eq!(plan.single_partition_groups.len(), 1);
+        assert!(pass.cache.in_progress_assets.contains_key("down"));
     }
 
     #[test]

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -513,7 +513,7 @@ impl ConditionPass {
             self.cache.in_progress_assets.keys().cloned().collect();
 
         // WillBeRequested reads this set inside dep pivots for single-tick cascading.
-        let mut requested_this_tick: HashSet<String> = HashSet::new();
+        let mut requested_this_tick: HashMap<String, PartitionSelection> = HashMap::new();
         let mut results: Vec<EvalResultRow> = Vec::new();
 
         for (idx, info) in self.conditions.iter().enumerate() {
@@ -593,7 +593,13 @@ impl ConditionPass {
             let duration_us = start.elapsed().as_micros() as u64;
 
             if eval_result.fired {
-                requested_this_tick.insert(info.asset_key.clone());
+                requested_this_tick.insert(
+                    info.asset_key.clone(),
+                    eval_result
+                        .selection
+                        .clone()
+                        .unwrap_or(PartitionSelection::All),
+                );
             }
 
             results.push(EvalResultRow {

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -588,6 +588,7 @@ impl ConditionPass {
                 now,
                 is_initial: self.eval_state.is_initial || prev.is_initial,
                 partitions: pctx.as_ref(),
+                root_partition_floor: None,
             };
             let start = std::time::Instant::now();
             let (eval_result, tree) = evaluate_with_tree(&info.condition, &ctx);

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -556,6 +556,7 @@ impl ConditionPass {
                         ),
                         latest_time_window_keys: latest_tw_keys.as_ref(),
                         all_partition_statuses: &self.cache.partition_status,
+                        dep_root_floor: None,
                     })
             });
 

--- a/rust/rivers-core/src/condition/pass.rs
+++ b/rust/rivers-core/src/condition/pass.rs
@@ -569,6 +569,7 @@ impl ConditionPass {
                     upstream_deps: &self.cache.upstream_deps,
                     in_progress_assets: &in_progress_keys,
                     failed_assets: &self.cache.failed_assets,
+                    failed_asset_timestamps: &self.cache.failed_asset_timestamps,
                     backfill: &self.cache.backfill,
                 },
                 tags: RunTagSnapshot {

--- a/rust/rivers-core/src/condition/state.rs
+++ b/rust/rivers-core/src/condition/state.rs
@@ -75,6 +75,8 @@ pub struct CacheSnapshot<'a> {
     pub in_progress_assets: &'a HashSet<String>,
     /// Assets whose latest run failed.
     pub failed_assets: &'a HashSet<String>,
+    /// Latest failure timestamp per currently-failed asset.
+    pub failed_asset_timestamps: &'a HashMap<String, i64>,
     /// Active backfill state: asset→backfill_ids + backfill_id→partition_keys.
     pub backfill: &'a BackfillState,
 }

--- a/rust/rivers-core/src/condition/state.rs
+++ b/rust/rivers-core/src/condition/state.rs
@@ -118,9 +118,10 @@ pub struct EvalContext<'a> {
     pub prev_state: &'a AssetConditionState,
     /// All per-asset condition states (for dep lookups in AnyDepsMatch/AllDepsMatch).
     pub all_asset_states: &'a HashMap<String, AssetConditionState>,
-    /// Assets whose conditions have already fired earlier in this tick.
-    /// Populated during topological evaluation; used by `WillBeRequested`.
-    pub requested_this_tick: &'a HashSet<String>,
+    /// Fired selections of assets whose conditions already fired earlier in
+    /// this tick (own key space; `All` for unpartitioned fires). Populated
+    /// during topological evaluation; used by `WillBeRequested`.
+    pub requested_this_tick: &'a HashMap<String, PartitionSelection>,
     /// Current timestamp (nanoseconds).
     pub now: i64,
     /// Whether this is the initial evaluation (daemon just started).

--- a/rust/rivers-core/src/condition/state.rs
+++ b/rust/rivers-core/src/condition/state.rs
@@ -130,6 +130,11 @@ pub struct EvalContext<'a> {
     pub is_initial: bool,
     /// Partition-level evaluation context. None for unpartitioned assets.
     pub partitions: Option<&'a PartitionEvalContext<'a>>,
+    /// Staleness floor for a partitioned root reading an UNPARTITIONED dep (the
+    /// bool fallback in `eval_partitioned_on_dep`). `None` everywhere else (use
+    /// the asset-level records); `Some(floor)` is the root's oldest partition
+    /// attempt, inner `None` meaning some partition was never attempted → fire.
+    pub root_partition_floor: Option<Option<i64>>,
 }
 
 /// Result of evaluating a condition tree.

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -2699,6 +2699,117 @@ fn dep_updated_floor_compares_mapped_downstream_key() {
 }
 
 #[test]
+fn dep_updated_retries_once_per_dep_update_after_failure() {
+    // A failed run never advances the root's materialization floor, so
+    // without failure awareness a deterministically failing partition is
+    // re-dispatched every tick forever. The failure timestamp must raise the
+    // floor: suppressed while the failure postdates the dep update, retried
+    // exactly when the dep lands something newer.
+    let a = make_materialized_record("a", 100);
+    let b = make_materialized_record("b", 300);
+    let records = HashMap::from([("a".to_string(), a.clone()), ("b".to_string(), b.clone())]);
+    let deps = HashMap::from([("a".to_string(), vec!["b".to_string()])]);
+
+    let k = spk("2024-01-01");
+    let keys = HashSet::from([k.clone()]);
+    // Root "a" never succeeded for k; its run at 400 failed.
+    let a_timestamps: HashMap<PartitionKey, i64> = HashMap::new();
+
+    let all_states = HashMap::new();
+    let b_partition_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: keys.clone(),
+        timestamps: HashMap::from([(k.clone(), 300i64)]),
+        ..Default::default()
+    };
+    let a_partition_status = crate::condition::cache::PartitionStatusEntry {
+        failed: HashSet::from([k.clone()]),
+        failed_timestamps: HashMap::from([(k.clone(), 400i64)]),
+        ..Default::default()
+    };
+    let partition_statuses = HashMap::from([
+        ("a".to_string(), a_partition_status),
+        ("b".to_string(), b_partition_status),
+    ]);
+    let partition_asset_names = HashMap::from([(
+        "b".to_string(),
+        HashMap::from([(k.clone(), Arc::from(vec!["b".to_string()]))]),
+    )]);
+
+    let mut ctx = make_ctx("a", &a, &records, &deps);
+    ctx.tags.partition_last_run_asset_names = &partition_asset_names;
+    ctx.all_asset_states = &all_states;
+
+    let empty_mappings = HashMap::new();
+    let upstream_b = HashMap::from([("b".to_string(), keys.clone())]);
+    let pctx = PartitionEvalContext {
+        all_keys: &keys,
+        materialized: &HashSet::new(),
+        in_progress: &HashSet::new(),
+        failed: &keys,
+        timestamps: &a_timestamps,
+        resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
+        latest_time_window_keys: None,
+        all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
+    };
+    ctx.partitions = Some(&pctx);
+
+    let cond = ConditionNode::any_deps_updated();
+    let result = evaluate(&cond, &ctx);
+    assert!(
+        !result.fired,
+        "the failed attempt at 400 already consumed the dep update at 300; \
+         re-firing every tick is an unbounded retry loop; got {:?}",
+        result.selection
+    );
+
+    // Control: the dep lands NEW data (500 > failure 400) -> exactly one
+    // retry becomes due again.
+    let statuses_retry = HashMap::from([
+        (
+            "a".to_string(),
+            crate::condition::cache::PartitionStatusEntry {
+                failed: HashSet::from([k.clone()]),
+                failed_timestamps: HashMap::from([(k.clone(), 400i64)]),
+                ..Default::default()
+            },
+        ),
+        (
+            "b".to_string(),
+            crate::condition::cache::PartitionStatusEntry {
+                materialized: keys.clone(),
+                timestamps: HashMap::from([(k.clone(), 500i64)]),
+                ..Default::default()
+            },
+        ),
+    ]);
+    let pctx_retry = PartitionEvalContext {
+        all_keys: &keys,
+        materialized: &HashSet::new(),
+        in_progress: &HashSet::new(),
+        failed: &keys,
+        timestamps: &a_timestamps,
+        resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
+        latest_time_window_keys: None,
+        all_partition_statuses: &statuses_retry,
+        dep_root_floor: None,
+    };
+    let mut ctx2 = make_ctx("a", &a, &records, &deps);
+    ctx2.tags.partition_last_run_asset_names = &partition_asset_names;
+    ctx2.all_asset_states = &all_states;
+    ctx2.partitions = Some(&pctx_retry);
+    let result = evaluate(&cond, &ctx2);
+    assert!(result.fired, "a newer dep update must retry the failed key");
+    match result.selection {
+        Some(PartitionSelection::Keys(ref sel)) => {
+            assert_eq!(sel.len(), 1);
+            assert!(sel.contains(&k));
+        }
+        other => panic!("expected Keys selection, got {other:?}"),
+    }
+}
+
+#[test]
 fn dep_updated_ignores_dep_keys_outside_root_universe() {
     // Identity dep whose upstream range is a superset of the root's
     // (upstream daily since 2020, downstream added with start=2024): the
@@ -6953,6 +7064,7 @@ fn test_partitioned_any_deps_missing_with_identity() {
             materialized: HashSet::from([spk("p1"), spk("p2"), spk("p3")]),
             in_progress: HashSet::new(),
             failed: HashSet::new(),
+            failed_timestamps: HashMap::new(),
             timestamps: HashMap::from([(spk("p1"), 100), (spk("p2"), 100), (spk("p3"), 100)]),
         },
     )]);
@@ -7035,6 +7147,7 @@ fn test_partitioned_all_deps_match_not_missing() {
             materialized: HashSet::from([spk("p1"), spk("p2")]),
             in_progress: HashSet::new(),
             failed: HashSet::new(),
+            failed_timestamps: HashMap::new(),
             timestamps: HashMap::from([(spk("p1"), 100), (spk("p2"), 100)]),
         },
     )]);
@@ -7196,6 +7309,7 @@ fn test_partitioned_eager_selects_new_partition() {
             materialized: HashSet::from([spk("p1"), spk("p2"), spk("p3")]),
             in_progress: HashSet::new(),
             failed: HashSet::new(),
+            failed_timestamps: HashMap::new(),
             timestamps: HashMap::from([(spk("p1"), 200), (spk("p2"), 200), (spk("p3"), 200)]),
         },
     )]);
@@ -7551,6 +7665,7 @@ fn test_partitioned_eager_partial_upstream_update() {
             materialized: HashSet::from([spk("p1"), spk("p2"), spk("p3")]),
             in_progress: HashSet::new(),
             failed: HashSet::new(),
+            failed_timestamps: HashMap::new(),
             timestamps: HashMap::from([(spk("p1"), 200), (spk("p2"), 200), (spk("p3"), 200)]),
         },
     )]);
@@ -7638,6 +7753,7 @@ fn test_partitioned_eager_only_fires_for_partitions_with_upstream_data() {
             materialized: HashSet::from([spk("p1"), spk("p2"), spk("p3")]),
             in_progress: HashSet::new(),
             failed: HashSet::new(),
+            failed_timestamps: HashMap::new(),
             timestamps: HashMap::from([(spk("p1"), 200), (spk("p2"), 200), (spk("p3"), 200)]),
         },
     )]);
@@ -7743,6 +7859,7 @@ fn test_partitioned_on_missing_only_missing_partitions() {
             materialized: HashSet::from([spk("p1"), spk("p2"), spk("p3")]),
             in_progress: HashSet::new(),
             failed: HashSet::new(),
+            failed_timestamps: HashMap::new(),
             timestamps: HashMap::from([(spk("p1"), 100), (spk("p2"), 100), (spk("p3"), 100)]),
         },
     )]);
@@ -9543,6 +9660,7 @@ fn test_partitioned_on_cron_waits_for_dep_update() {
             materialized: HashSet::from([spk("p1"), spk("p2")]),
             in_progress: HashSet::new(),
             failed: HashSet::new(),
+            failed_timestamps: HashMap::new(),
             timestamps: HashMap::from([(spk("p1"), 100), (spk("p2"), 100)]),
         },
     )]);
@@ -9631,6 +9749,7 @@ fn test_partitioned_on_cron_fires_after_dep_update() {
             materialized: HashSet::from([spk("p1"), spk("p2")]),
             in_progress: HashSet::new(),
             failed: HashSet::new(),
+            failed_timestamps: HashMap::new(),
             timestamps: HashMap::from([(spk("p1"), 200), (spk("p2"), 200)]),
         },
     )]);
@@ -9723,6 +9842,7 @@ fn test_partitioned_on_cron_partial_dep_update() {
             materialized: HashSet::from([spk("p1"), spk("p2")]),
             in_progress: HashSet::new(),
             failed: HashSet::new(),
+            failed_timestamps: HashMap::new(),
             timestamps: HashMap::from([(spk("p1"), 200), (spk("p2"), 100)]),
         },
     )]);

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -440,6 +440,94 @@ fn test_newly_updated_no_change() {
 }
 
 #[test]
+fn test_newly_updated_self_suppressed_on_initial_tick() {
+    // A bare newly_updated() self-condition must NOT fire for an
+    // already-materialized asset on the daemon's first/restart tick, where
+    // prev_state is empty (no baseline). Pre-fix the (Some, None) self arm
+    // returned true unconditionally and re-materialized up-to-date data once
+    // per (re)start.
+    let record = make_materialized_record("a", 200);
+    let records = HashMap::from([("a".to_string(), record.clone())]);
+    let deps = HashMap::new();
+    // Empty prev state: the daemon just (re)started — no last-tick baseline.
+    let prev = AssetConditionState::default();
+    let ctx = EvalContext {
+        target_key: "a",
+        root_key: "a",
+        target_record: &record,
+        cache: CacheSnapshot {
+            records: &records,
+            upstream_deps: &deps,
+            in_progress_assets: &HashSet::new(),
+            failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
+            backfill: &EMPTY_BACKFILL,
+        },
+        tags: RunTagSnapshot {
+            last_run_tags: &EMPTY_RUN_TAGS,
+            partition_last_run_tags: &EMPTY_PARTITION_RUN_TAGS,
+            tick_materialization_tags: &EMPTY_TICK_MAT_TAGS,
+            tick_partition_materialization_tags: &EMPTY_TICK_PART_MAT_TAGS,
+            last_run_asset_names: &EMPTY_RUN_ASSET_NAMES,
+            partition_last_run_asset_names: &EMPTY_PARTITION_RUN_ASSET_NAMES,
+        },
+        prev_state: &prev,
+        all_asset_states: &EMPTY_ASSET_STATES,
+        requested_this_tick: &EMPTY_REQUESTED,
+        now: 1000,
+        is_initial: true,
+        partitions: None,
+        root_partition_floor: None,
+    };
+    assert!(
+        !evaluate(&ConditionNode::NewlyUpdated, &ctx).fired,
+        "already-materialized asset must not re-fire newly_updated() on the initial tick"
+    );
+}
+
+#[test]
+fn test_newly_updated_self_fires_when_appears_between_ticks() {
+    // The boundary the is_initial guard must preserve: on a NON-initial tick a
+    // missing baseline means the asset genuinely appeared between ticks → fire.
+    let record = make_materialized_record("a", 200);
+    let records = HashMap::from([("a".to_string(), record.clone())]);
+    let deps = HashMap::new();
+    let prev = AssetConditionState::default();
+    let ctx = EvalContext {
+        target_key: "a",
+        root_key: "a",
+        target_record: &record,
+        cache: CacheSnapshot {
+            records: &records,
+            upstream_deps: &deps,
+            in_progress_assets: &HashSet::new(),
+            failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
+            backfill: &EMPTY_BACKFILL,
+        },
+        tags: RunTagSnapshot {
+            last_run_tags: &EMPTY_RUN_TAGS,
+            partition_last_run_tags: &EMPTY_PARTITION_RUN_TAGS,
+            tick_materialization_tags: &EMPTY_TICK_MAT_TAGS,
+            tick_partition_materialization_tags: &EMPTY_TICK_PART_MAT_TAGS,
+            last_run_asset_names: &EMPTY_RUN_ASSET_NAMES,
+            partition_last_run_asset_names: &EMPTY_PARTITION_RUN_ASSET_NAMES,
+        },
+        prev_state: &prev,
+        all_asset_states: &EMPTY_ASSET_STATES,
+        requested_this_tick: &EMPTY_REQUESTED,
+        now: 1000,
+        is_initial: false,
+        partitions: None,
+        root_partition_floor: None,
+    };
+    assert!(
+        evaluate(&ConditionNode::NewlyUpdated, &ctx).fired,
+        "an asset appearing between non-initial ticks must fire newly_updated()"
+    );
+}
+
+#[test]
 fn test_initial_evaluation_true_on_first_tick() {
     let record = make_record("a");
     let records = HashMap::from([("a".to_string(), record.clone())]);

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -2780,6 +2780,133 @@ fn partitioned_root_unpartitioned_dep_refires_stale_older_partitions() {
 }
 
 #[test]
+fn all_partitions_dep_frontier_key_does_not_refire_whole_universe() {
+    // AllPartitions floors the dep against the MIN effective ts over the whole
+    // downstream universe. A freshly-minted, never-attempted frontier key made
+    // root_floor_over return None → the dep counted as "updated" with no
+    // upstream change and re-dispatched the entire universe. The floor must
+    // ignore never-attempted keys.
+    let d1 = spk("d1");
+    let d2 = spk("d2");
+    let d3 = spk("d3"); // freshly minted, never attempted
+    let all_keys = HashSet::from([d1.clone(), d2.clone(), d3.clone()]);
+    let u1 = spk("u1");
+    let up_keys = HashSet::from([u1.clone()]);
+
+    let a = make_materialized_record("a", 100);
+    let b = make_materialized_record("b", 90);
+    let records = HashMap::from([("a".to_string(), a.clone()), ("b".to_string(), b.clone())]);
+    let deps = HashMap::from([("a".to_string(), vec!["b".to_string()])]);
+
+    // Root "a": d1/d2 materialized at 100, d3 never attempted. Dep "b": u1 at
+    // 90 — older than every attempted downstream key, already consumed.
+    let a_timestamps = HashMap::from([(d1.clone(), 100i64), (d2.clone(), 100)]);
+    let a_mat = HashSet::from([d1.clone(), d2.clone()]);
+    let a_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: a_mat.clone(),
+        timestamps: a_timestamps.clone(),
+        ..Default::default()
+    };
+    let b_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: up_keys.clone(),
+        timestamps: HashMap::from([(u1.clone(), 90i64)]),
+        ..Default::default()
+    };
+    let partition_statuses =
+        HashMap::from([("a".to_string(), a_status), ("b".to_string(), b_status)]);
+
+    let all_states = HashMap::new();
+    let mut ctx = make_ctx("a", &a, &records, &deps);
+    ctx.all_asset_states = &all_states;
+
+    let mappings =
+        HashMap::from([(("a".into(), "b".into()), PartitionMappingKind::AllPartitions)]);
+    let upstream_b = HashMap::from([("b".to_string(), up_keys.clone())]);
+    let pctx = PartitionEvalContext {
+        all_keys: &all_keys,
+        materialized: &a_mat,
+        in_progress: &HashSet::new(),
+        failed: &HashSet::new(),
+        timestamps: &a_timestamps,
+        resolver: PartitionResolver::new(&mappings, &upstream_b),
+        latest_time_window_keys: None,
+        all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
+    };
+    ctx.partitions = Some(&pctx);
+
+    let result = evaluate(&ConditionNode::any_deps_updated(), &ctx);
+
+    // Dep u1@90 is older than every attempted downstream key (100); the new
+    // frontier key d3 must not drag the floor to None and broadcast All.
+    assert!(
+        !result.fired,
+        "a never-attempted frontier key must not refire the universe with no \
+         upstream change, got {:?}",
+        result.selection
+    );
+}
+
+#[test]
+fn all_partitions_dep_genuine_update_still_fires() {
+    // The boundary the floor must preserve: when an upstream key IS newer than
+    // an attempted downstream key, the AllPartitions edge must still fire.
+    let d1 = spk("d1");
+    let d2 = spk("d2");
+    let d3 = spk("d3"); // never attempted
+    let all_keys = HashSet::from([d1.clone(), d2.clone(), d3.clone()]);
+    let u1 = spk("u1");
+    let up_keys = HashSet::from([u1.clone()]);
+
+    let a = make_materialized_record("a", 100);
+    let b = make_materialized_record("b", 150);
+    let records = HashMap::from([("a".to_string(), a.clone()), ("b".to_string(), b.clone())]);
+    let deps = HashMap::from([("a".to_string(), vec!["b".to_string()])]);
+
+    let a_timestamps = HashMap::from([(d1.clone(), 100i64), (d2.clone(), 100)]);
+    let a_mat = HashSet::from([d1.clone(), d2.clone()]);
+    let a_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: a_mat.clone(),
+        timestamps: a_timestamps.clone(),
+        ..Default::default()
+    };
+    let b_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: up_keys.clone(),
+        timestamps: HashMap::from([(u1.clone(), 150i64)]),
+        ..Default::default()
+    };
+    let partition_statuses =
+        HashMap::from([("a".to_string(), a_status), ("b".to_string(), b_status)]);
+
+    let all_states = HashMap::new();
+    let mut ctx = make_ctx("a", &a, &records, &deps);
+    ctx.all_asset_states = &all_states;
+
+    let mappings =
+        HashMap::from([(("a".into(), "b".into()), PartitionMappingKind::AllPartitions)]);
+    let upstream_b = HashMap::from([("b".to_string(), up_keys.clone())]);
+    let pctx = PartitionEvalContext {
+        all_keys: &all_keys,
+        materialized: &a_mat,
+        in_progress: &HashSet::new(),
+        failed: &HashSet::new(),
+        timestamps: &a_timestamps,
+        resolver: PartitionResolver::new(&mappings, &upstream_b),
+        latest_time_window_keys: None,
+        all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
+    };
+    ctx.partitions = Some(&pctx);
+
+    let result = evaluate(&ConditionNode::any_deps_updated(), &ctx);
+    assert!(
+        result.fired,
+        "upstream u1@150 newer than attempted downstream (100) must fire, got {:?}",
+        result.selection
+    );
+}
+
+#[test]
 fn dep_updated_floor_compares_mapped_downstream_key() {
     // The staleness floor must compare a dep key against the root's
     // materialization of the DOWNSTREAM key the mapping resolves it to —

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -86,8 +86,8 @@ fn mpk(dims: &[(&str, &str)]) -> PartitionKey {
     }
 }
 
-static EMPTY_REQUESTED: std::sync::LazyLock<HashSet<String>> =
-    std::sync::LazyLock::new(HashSet::new);
+static EMPTY_REQUESTED: std::sync::LazyLock<HashMap<String, PartitionSelection>> =
+    std::sync::LazyLock::new(HashMap::new);
 
 fn make_ctx<'a>(
     target_key: &'a str,
@@ -2692,6 +2692,97 @@ fn dep_updated_floor_compares_mapped_downstream_key() {
             assert!(
                 keys.contains(&spk("2024-01-06")),
                 "the fire must target the mapped downstream key"
+            );
+        }
+        other => panic!("expected Keys selection, got {other:?}"),
+    }
+}
+
+#[test]
+fn will_be_requested_carries_the_upstream_fired_selection() {
+    // A partitioned upstream whose own condition fired for ONE key this tick
+    // must make only the mapped downstream key eligible — the old arm
+    // broadcast the whole universe (`requested_this_tick` carried bare asset
+    // names), re-introducing the per-partition-contract violation through
+    // any_deps_updated's WillBeRequested branch.
+    let down = make_materialized_record("down", 100);
+    let up = make_materialized_record("up", 100);
+    let records = HashMap::from([
+        ("down".to_string(), down.clone()),
+        ("up".to_string(), up.clone()),
+    ]);
+    let deps = HashMap::from([("down".to_string(), vec!["up".to_string()])]);
+
+    let pa = spk("a");
+    let pb = spk("b");
+    let pc = spk("c");
+    let keys = HashSet::from([pa.clone(), pb.clone(), pc.clone()]);
+    // Equal timestamps on both sides: the NewlyUpdated branch stays quiet,
+    // isolating WillBeRequested.
+    let ts: HashMap<PartitionKey, i64> =
+        keys.iter().map(|k| (k.clone(), 100i64)).collect();
+
+    let all_states = HashMap::new();
+    let partition_statuses = HashMap::from([
+        (
+            "down".to_string(),
+            crate::condition::cache::PartitionStatusEntry {
+                materialized: keys.clone(),
+                timestamps: ts.clone(),
+                ..Default::default()
+            },
+        ),
+        (
+            "up".to_string(),
+            crate::condition::cache::PartitionStatusEntry {
+                materialized: keys.clone(),
+                timestamps: ts.clone(),
+                ..Default::default()
+            },
+        ),
+    ]);
+    let partition_asset_names = HashMap::from([(
+        "up".to_string(),
+        keys.iter()
+            .map(|k| (k.clone(), Arc::from(vec!["up".to_string()])))
+            .collect::<HashMap<_, _>>(),
+    )]);
+
+    // Upstream's own condition fired for 'a' only, earlier this tick.
+    let requested = HashMap::from([(
+        "up".to_string(),
+        PartitionSelection::Keys(HashSet::from([pa.clone()])),
+    )]);
+
+    let mut ctx = make_ctx("down", &down, &records, &deps);
+    ctx.tags.partition_last_run_asset_names = &partition_asset_names;
+    ctx.all_asset_states = &all_states;
+    ctx.requested_this_tick = &requested;
+
+    let empty_mappings = HashMap::new();
+    let upstream_up = HashMap::from([("up".to_string(), keys.clone())]);
+    let pctx = PartitionEvalContext {
+        all_keys: &keys,
+        materialized: &keys,
+        in_progress: &HashSet::new(),
+        failed: &HashSet::new(),
+        timestamps: &ts,
+        resolver: PartitionResolver::new(&empty_mappings, &upstream_up),
+        latest_time_window_keys: None,
+        all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
+    };
+    ctx.partitions = Some(&pctx);
+
+    let cond = ConditionNode::any_deps_updated();
+    let result = evaluate(&cond, &ctx);
+    assert!(result.fired);
+    match result.selection {
+        Some(PartitionSelection::Keys(ref sel)) => {
+            assert_eq!(
+                sel,
+                &HashSet::from([pa.clone()]),
+                "only the upstream's fired key may cascade, not the universe"
             );
         }
         other => panic!("expected Keys selection, got {other:?}"),
@@ -9269,7 +9360,7 @@ fn test_will_be_requested_true_when_in_set() {
     let record = make_materialized_record("a", 100);
     let records = HashMap::from([("a".to_string(), record.clone())]);
     let deps = HashMap::new();
-    let requested = HashSet::from(["a".to_string()]);
+    let requested = HashMap::from([("a".to_string(), PartitionSelection::All)]);
     let ctx = EvalContext {
         target_key: "a",
         root_key: "a",
@@ -9304,7 +9395,7 @@ fn test_will_be_requested_in_dep_pivot() {
         ("downstream".to_string(), down_record.clone()),
     ]);
     let deps = HashMap::from([("downstream".to_string(), vec!["upstream".to_string()])]);
-    let requested = HashSet::from(["upstream".to_string()]);
+    let requested = HashMap::from([("upstream".to_string(), PartitionSelection::All)]);
     let ctx = EvalContext {
         target_key: "downstream",
         root_key: "downstream",
@@ -9373,7 +9464,7 @@ fn test_any_deps_updated_fires_via_will_be_requested() {
         ("downstream".to_string(), down_record.clone()),
     ]);
     let deps = HashMap::from([("downstream".to_string(), vec!["upstream".to_string()])]);
-    let requested = HashSet::from(["upstream".to_string()]);
+    let requested = HashMap::from([("upstream".to_string(), PartitionSelection::All)]);
     // upstream has prev_state with same timestamp → NewlyUpdated is false
     let up_state = AssetConditionState {
         last_materialized_timestamp: Some(100),
@@ -9417,7 +9508,7 @@ fn test_any_deps_missing_suppressed_by_will_be_requested() {
         ("downstream".to_string(), down_record.clone()),
     ]);
     let deps = HashMap::from([("downstream".to_string(), vec!["upstream".to_string()])]);
-    let requested = HashSet::from(["upstream".to_string()]);
+    let requested = HashMap::from([("upstream".to_string(), PartitionSelection::All)]);
     let ctx = EvalContext {
         target_key: "downstream",
         root_key: "downstream",
@@ -9478,7 +9569,7 @@ fn test_will_be_requested_tree_output() {
     let record = make_materialized_record("a", 100);
     let records = HashMap::from([("a".to_string(), record.clone())]);
     let deps = HashMap::new();
-    let requested = HashSet::from(["a".to_string()]);
+    let requested = HashMap::from([("a".to_string(), PartitionSelection::All)]);
     let ctx = EvalContext {
         target_key: "a",
         root_key: "a",

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -117,6 +117,7 @@ fn make_ctx<'a>(
         now: 1_000_000_000_000, // 1000s in nanos
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     }
 }
 
@@ -172,6 +173,7 @@ fn test_in_progress() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::InProgress, &ctx).fired);
 }
@@ -208,6 +210,7 @@ fn test_execution_failed() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::ExecutionFailed, &ctx).fired);
 }
@@ -270,6 +273,7 @@ fn test_newly_requested_after_firing() {
         now: 2000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::NewlyRequested, &ctx).fired);
 }
@@ -310,6 +314,7 @@ fn test_newly_requested_not_fired_last_tick() {
         now: 2000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(!evaluate(&ConditionNode::NewlyRequested, &ctx).fired);
 }
@@ -349,6 +354,7 @@ fn test_newly_requested_never_handled() {
         now: 2000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(!evaluate(&ConditionNode::NewlyRequested, &ctx).fired);
 }
@@ -388,6 +394,7 @@ fn test_newly_updated() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::NewlyUpdated, &ctx).fired);
 }
@@ -427,6 +434,7 @@ fn test_newly_updated_no_change() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(!evaluate(&ConditionNode::NewlyUpdated, &ctx).fired);
 }
@@ -572,6 +580,7 @@ fn test_newly_true_does_not_refire_with_previous_true() {
         now: 1000,
         is_initial: true,
         partitions: None,
+        root_partition_floor: None,
     };
     let cond = ConditionNode::NewlyTrue(Box::new(ConditionNode::Missing));
     assert!(
@@ -685,6 +694,7 @@ fn test_data_version_changed_true_when_version_differs() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::DataVersionChanged, &ctx).fired);
 }
@@ -725,6 +735,7 @@ fn test_data_version_changed_false_when_same() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(!evaluate(&ConditionNode::DataVersionChanged, &ctx).fired);
 }
@@ -785,6 +796,7 @@ fn test_data_version_changed_false_version_disappeared() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(!evaluate(&ConditionNode::DataVersionChanged, &ctx).fired);
 }
@@ -825,6 +837,7 @@ fn test_data_version_changed_with_tree() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let (result, tree) = evaluate_with_tree(&ConditionNode::DataVersionChanged, &ctx);
     assert!(result.fired);
@@ -878,6 +891,7 @@ fn test_data_version_changed_state_tracking() {
         now: 3_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let result2 = evaluate(&ConditionNode::DataVersionChanged, &ctx2);
     assert!(!result2.fired);
@@ -912,6 +926,7 @@ fn test_data_version_changed_state_tracking() {
         now: 4_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let result3 = evaluate(&ConditionNode::DataVersionChanged, &ctx3);
     assert!(result3.fired);
@@ -952,6 +967,7 @@ fn test_backfill_in_progress_true_when_in_backfill() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::BackfillInProgress, &ctx).fired);
 }
@@ -1002,6 +1018,7 @@ fn test_backfill_in_progress_only_matches_selected_assets() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let ctx_b = EvalContext {
         target_key: "b",
@@ -1029,6 +1046,7 @@ fn test_backfill_in_progress_only_matches_selected_assets() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::BackfillInProgress, &ctx_a).fired);
     assert!(!evaluate(&ConditionNode::BackfillInProgress, &ctx_b).fired);
@@ -1069,6 +1087,7 @@ fn test_backfill_in_progress_with_tree() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let (result, tree) = evaluate_with_tree(&ConditionNode::BackfillInProgress, &ctx);
     assert!(result.fired);
@@ -1112,6 +1131,7 @@ fn test_backfill_in_progress_composition_with_in_progress() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let cond = ConditionNode::InProgress | ConditionNode::BackfillInProgress;
     assert!(evaluate(&cond, &ctx).fired);
@@ -1156,6 +1176,7 @@ fn test_backfill_in_progress_dep_aggregate() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let cond = ConditionNode::any_deps_match(ConditionNode::BackfillInProgress);
     assert!(evaluate(&cond, &ctx).fired);
@@ -1203,6 +1224,7 @@ fn test_backfill_in_progress_partitioned_targets_subset() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
     let result = evaluate(&ConditionNode::BackfillInProgress, &ctx);
     assert!(result.fired);
@@ -1261,6 +1283,7 @@ fn test_backfill_in_progress_partitioned_empty_keys_selects_all() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
     let result = evaluate(&ConditionNode::BackfillInProgress, &ctx);
     assert!(result.fired);
@@ -1313,6 +1336,7 @@ fn test_backfill_in_progress_partitioned_disjoint_keys() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
     let result = evaluate(&ConditionNode::BackfillInProgress, &ctx);
     assert!(!result.fired);
@@ -1368,6 +1392,7 @@ fn test_backfill_in_progress_multiple_backfills_union_partitions() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
     let result = evaluate(&ConditionNode::BackfillInProgress, &ctx);
     assert!(result.fired);
@@ -1431,6 +1456,7 @@ fn test_backfill_in_progress_one_backfill_empty_keys_short_circuits() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
     let result = evaluate(&ConditionNode::BackfillInProgress, &ctx);
     assert!(result.fired);
@@ -2586,6 +2612,86 @@ fn dep_updated_requires_dep_newer_than_target_key() {
 }
 
 #[test]
+fn partitioned_root_unpartitioned_dep_refires_stale_older_partitions() {
+    // A partitioned root reading an UNPARTITIONED dep takes the bool fallback
+    // in eval_partitioned_on_dep. The staleness floor there must be the root's
+    // OLDEST partition attempt (min across partitions), not the asset-level max
+    // — otherwise a dep update older than the newest partition floors against
+    // that newest ts and the genuinely-stale older partitions never re-fire.
+    let pk_old = spk("2024-01-01");
+    let pk_mid = spk("2024-01-02");
+    let pk_new = spk("2024-01-03");
+    let all_keys = HashSet::from([pk_old.clone(), pk_mid.clone(), pk_new.clone()]);
+
+    // Root "a": partitions materialized at 10 / 30 / 50; the asset-level record
+    // carries the MAX (50) — exactly the value the buggy floor compared against.
+    let a = make_materialized_record("a", 50);
+    // Dep "b": UNPARTITIONED, updated at 35 — newer than pk_old/pk_mid, older
+    // than pk_new.
+    let b = make_materialized_record("b", 35);
+    let records = HashMap::from([("a".to_string(), a.clone()), ("b".to_string(), b.clone())]);
+    let deps = HashMap::from([("a".to_string(), vec!["b".to_string()])]);
+
+    let a_timestamps = HashMap::from([
+        (pk_old.clone(), 10i64),
+        (pk_mid.clone(), 30),
+        (pk_new.clone(), 50),
+    ]);
+    let a_partition_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: all_keys.clone(),
+        timestamps: a_timestamps.clone(),
+        ..Default::default()
+    };
+    let partition_statuses = HashMap::from([("a".to_string(), a_partition_status)]);
+
+    let all_states = HashMap::new();
+    let mut ctx = make_ctx("a", &a, &records, &deps);
+    ctx.all_asset_states = &all_states;
+
+    let empty_mappings = HashMap::new();
+    // "b" absent from upstream_partition_keys → unpartitioned dep → bool fallback.
+    let no_upstream_keys = HashMap::new();
+    let pctx = PartitionEvalContext {
+        all_keys: &all_keys,
+        materialized: &all_keys,
+        in_progress: &HashSet::new(),
+        failed: &HashSet::new(),
+        timestamps: &a_timestamps,
+        resolver: PartitionResolver::new(&empty_mappings, &no_upstream_keys),
+        latest_time_window_keys: None,
+        all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
+    };
+    ctx.partitions = Some(&pctx);
+
+    let result = evaluate(&ConditionNode::any_deps_updated(), &ctx);
+
+    let covers = |sel: &Option<PartitionSelection>, k: &PartitionKey| match sel {
+        Some(PartitionSelection::All) => true,
+        Some(PartitionSelection::Keys(ks)) => ks.contains(k),
+        _ => false,
+    };
+    // dep@35 is newer than the older partition attempts (10, 30), so the edge
+    // must fire and re-materialize those stale partitions. Pre-fix it floored
+    // against the asset-level max (50), got 35 > 50 = false, and starved them.
+    assert!(
+        result.fired,
+        "dep@35 newer than older partitions (10/30) → must re-fire, got {:?}",
+        result.selection
+    );
+    assert!(
+        covers(&result.selection, &pk_old),
+        "stale pk_old (mat@10 < dep@35) must be selected, got {:?}",
+        result.selection
+    );
+    assert!(
+        covers(&result.selection, &pk_mid),
+        "stale pk_mid (mat@30 < dep@35) must be selected, got {:?}",
+        result.selection
+    );
+}
+
+#[test]
 fn dep_updated_floor_compares_mapped_downstream_key() {
     // The staleness floor must compare a dep key against the root's
     // materialization of the DOWNSTREAM key the mapping resolves it to —
@@ -3501,6 +3607,7 @@ fn test_any_deps_in_progress() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::any_deps_in_progress(), &ctx).fired);
 }
@@ -3538,6 +3645,7 @@ fn test_any_deps_in_progress_none() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(!evaluate(&ConditionNode::any_deps_in_progress(), &ctx).fired);
 }
@@ -3577,6 +3685,7 @@ fn test_any_deps_updated() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::any_deps_updated(), &ctx).fired);
 }
@@ -3688,6 +3797,7 @@ fn test_any_deps_updated_no_change() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(!evaluate(&ConditionNode::any_deps_updated(), &ctx).fired);
 }
@@ -3776,6 +3886,7 @@ fn test_newly_true_transition() {
         now: 1000,
         is_initial: true,
         partitions: None,
+        root_partition_floor: None,
     };
     let cond = ConditionNode::NewlyTrue(Box::new(ConditionNode::Missing));
     assert!(evaluate(&cond, &ctx).fired);
@@ -3809,6 +3920,7 @@ fn test_newly_true_transition() {
         now: 2000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(!evaluate(&cond, &ctx2).fired);
 
@@ -3843,6 +3955,7 @@ fn test_newly_true_transition() {
         now: 3000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(!evaluate(&cond, &ctx3).fired);
 }
@@ -3901,6 +4014,7 @@ fn test_counter_stability_and_short_circuit() {
         now: 2000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let r2 = evaluate(&cond, &ctx2);
     // And(InProgress=true, NewlyTrue(Missing=true, prev=false)=true) → true
@@ -3936,6 +4050,7 @@ fn test_counter_stability_and_short_circuit() {
         now: 3000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let r3 = evaluate(&cond, &ctx3);
     // NewlyTrue(Missing=true, prev=true) → false, so And → false
@@ -3996,6 +4111,7 @@ fn test_on_missing_does_not_fire_when_in_progress() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::on_missing(), &ctx).fired);
 }
@@ -4051,6 +4167,7 @@ fn test_eager_fires_on_deps_updated() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::eager(), &ctx).fired);
 }
@@ -4097,6 +4214,7 @@ fn test_eager_does_not_fire_when_up_to_date() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(!evaluate(&ConditionNode::eager(), &ctx).fired);
 }
@@ -4163,6 +4281,7 @@ fn test_bug_cron_tick_always_fires_on_first_eval() {
         now: now_nanos,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
 
     assert!(
@@ -4216,6 +4335,7 @@ fn test_cron_tick_fires_when_tick_passes_between_evals() {
         now: now_nanos,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
 
     assert!(
@@ -4337,6 +4457,7 @@ fn test_bug_since_last_handled_refires_after_own_materialization() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&cond, &ctx1).fired, "Tick 1 should fire");
 
@@ -4378,6 +4499,7 @@ fn test_bug_since_last_handled_refires_after_own_materialization() {
         now: 2000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(
         !evaluate(&cond, &ctx2).fired,
@@ -4433,6 +4555,7 @@ fn test_newly_requested_any_deps_match_cross_asset_signaling() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(
         !evaluate(&cond, &ctx1).fired,
@@ -4486,6 +4609,7 @@ fn test_newly_requested_any_deps_match_cross_asset_signaling() {
         now: 2000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(
         evaluate(&cond, &ctx2).fired,
@@ -4532,6 +4656,7 @@ fn test_newly_requested_any_deps_match_cross_asset_signaling() {
         now: 3000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(
         !evaluate(&cond, &ctx3).fired,
@@ -4587,6 +4712,7 @@ fn test_newly_requested_as_since_reset() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let r1 = evaluate(&cond, &ctx1);
     assert!(r1.fired, "Tick 1: code changed → fires");
@@ -4630,6 +4756,7 @@ fn test_newly_requested_as_since_reset() {
         now: 2000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let r2 = evaluate(&cond, &ctx2);
     assert!(
@@ -4687,6 +4814,7 @@ fn test_newly_requested_as_since_reset_fast_ticks() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let r1 = evaluate(&cond, &ctx1);
     assert!(r1.fired, "Tick 1: code changed → fires");
@@ -4724,6 +4852,7 @@ fn test_newly_requested_as_since_reset_fast_ticks() {
         now: 2000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let r2 = evaluate(&cond, &ctx2);
     assert!(
@@ -4765,6 +4894,7 @@ fn test_newly_requested_as_since_reset_fast_ticks() {
         now: 3000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let r3 = evaluate(&cond, &ctx3);
     assert!(
@@ -4819,6 +4949,7 @@ fn test_newly_requested_in_since_last_handled() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&cond, &ctx1).fired, "Tick 1: should fire");
 
@@ -4854,6 +4985,7 @@ fn test_newly_requested_in_since_last_handled() {
         now: 2000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(
         !evaluate(&cond, &ctx2).fired,
@@ -4892,6 +5024,7 @@ fn test_newly_requested_in_since_last_handled() {
         now: 3000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(
         evaluate(&cond, &ctx3).fired,
@@ -5085,6 +5218,7 @@ fn bench_eval(
                 now: 999_999_999_999,
                 is_initial: false,
                 partitions: None,
+                root_partition_floor: None,
             };
             std::hint::black_box(evaluate(cond, &ctx));
         }
@@ -5121,6 +5255,7 @@ fn bench_eval(
                 now: 999_999_999_999,
                 is_initial: false,
                 partitions: None,
+                root_partition_floor: None,
             };
             std::hint::black_box(evaluate(cond, &ctx));
         }
@@ -5447,6 +5582,7 @@ fn bench_selective_vs_full_eval() {
                     now: 999_999_999_999,
                     is_initial: false,
                     partitions: None,
+                    root_partition_floor: None,
                 };
                 std::hint::black_box(evaluate(cond, &ctx));
             }
@@ -5488,6 +5624,7 @@ fn bench_selective_vs_full_eval() {
                     now: 999_999_999_999,
                     is_initial: false,
                     partitions: None,
+                    root_partition_floor: None,
                 };
                 std::hint::black_box(evaluate(cond, &ctx));
             }
@@ -5714,6 +5851,7 @@ async fn bench_cache_tick<S: StorageBackend>(
                     now: 100_000_000_000,
                     is_initial: false,
                     partitions: None,
+                    root_partition_floor: None,
                 };
                 std::hint::black_box(evaluate(cond, &ctx));
             }
@@ -6658,6 +6796,7 @@ fn make_partitioned_ctx<'a>(
         now: 1_000_000_000_000,
         is_initial: false,
         partitions: Some(pctx),
+        root_partition_floor: None,
     }
 }
 
@@ -7065,6 +7204,7 @@ fn test_partitioned_newly_updated() {
         now: 1_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
     let result = evaluate(&ConditionNode::NewlyUpdated, &ctx);
     assert!(result.fired);
@@ -7181,6 +7321,7 @@ fn test_partitioned_newly_true() {
         now: 1_000_000_000_000,
         is_initial: true,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
     let cond = ConditionNode::NewlyTrue(Box::new(ConditionNode::Missing));
     let result = evaluate(&cond, &ctx);
@@ -7230,6 +7371,7 @@ fn test_partitioned_newly_true() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx2),
+        root_partition_floor: None,
     };
     let result2 = evaluate(&cond, &ctx2);
     assert!(!result2.fired);
@@ -7334,6 +7476,7 @@ fn test_partitioned_any_deps_missing_with_identity() {
         now: 1_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     // AnyDepsMissing evaluates Missing on upstream "a" which has
@@ -7418,6 +7561,7 @@ fn test_partitioned_all_deps_match_not_missing() {
         now: 1_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     let cond = ConditionNode::all_deps_match(!ConditionNode::Missing);
@@ -7581,6 +7725,7 @@ fn test_partitioned_eager_selects_new_partition() {
         now: 1_000_000_000_000,
         is_initial: true, // first tick,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     let result = evaluate(&ConditionNode::eager(), &ctx);
@@ -7938,6 +8083,7 @@ fn test_partitioned_eager_partial_upstream_update() {
         now: 1_000_000_000_000,
         is_initial: true,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     let result = evaluate(&ConditionNode::eager(), &ctx);
@@ -8027,6 +8173,7 @@ fn test_partitioned_eager_only_fires_for_partitions_with_upstream_data() {
         now: 1_000_000_000_000,
         is_initial: true,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     // evaluate() should use partition-aware path
@@ -8135,6 +8282,7 @@ fn test_partitioned_on_missing_only_missing_partitions() {
         now: 1_000_000_000_000,
         is_initial: true,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     let result = evaluate(&ConditionNode::on_missing(), &ctx);
@@ -8202,6 +8350,7 @@ fn test_partitioned_in_progress_excludes_from_and() {
         now: 1_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     let cond = ConditionNode::And(vec![
@@ -8308,6 +8457,7 @@ fn test_partitioned_since_latch_per_partition() {
         now: 1_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx1),
+        root_partition_floor: None,
     };
     let cond = ConditionNode::Since {
         trigger: Box::new(ConditionNode::Missing),
@@ -8368,6 +8518,7 @@ fn test_partitioned_since_latch_per_partition() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx2),
+        root_partition_floor: None,
     };
     let r2 = evaluate(&cond, &ctx2);
     // p2 was reset (NewlyUpdated), p3 still latched
@@ -8418,6 +8569,7 @@ fn test_partitioned_newly_true_only_new_partitions() {
         now: 1_000_000_000_000,
         is_initial: true,
         partitions: Some(&pctx1),
+        root_partition_floor: None,
     };
     let r1 = evaluate(&cond, &ctx1);
     assert_eq!(
@@ -8460,6 +8612,7 @@ fn test_partitioned_newly_true_only_new_partitions() {
         now: 2_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx2),
+        root_partition_floor: None,
     };
     let r2 = evaluate(&cond, &ctx2);
     assert_eq!(r2.selection.unwrap(), PartitionSelection::Empty);
@@ -8500,6 +8653,7 @@ fn test_partitioned_newly_true_only_new_partitions() {
         now: 3_000_000_000_000,
         is_initial: false,
         partitions: Some(&pctx3),
+        root_partition_floor: None,
     };
     let r3 = evaluate(&cond, &ctx3);
     // Only p4 is newly missing (p2,p3 were already missing last tick)
@@ -8682,6 +8836,7 @@ fn test_eager_does_not_fire_when_all_up_to_date_first_tick() {
         now: tick2_now,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
 
     let (result_b2, tree_b2) = evaluate_with_tree(&cond, &ctx_b2);
@@ -8811,6 +8966,7 @@ fn test_eager_fires_after_upstream_observed_on_second_tick() {
         now: now2,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
 
     let (result_agg2, tree_agg2) = evaluate_with_tree(&cond, &ctx_agg2);
@@ -8883,6 +9039,7 @@ fn test_eager_fires_after_upstream_observed_on_second_tick() {
         now: now2,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let (result_rep2, _) = evaluate_with_tree(&cond, &ctx_rep2);
     update_condition_state(
@@ -8918,6 +9075,7 @@ fn test_eager_fires_after_upstream_observed_on_second_tick() {
         now: now3,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
 
     let (result_rep3, tree_rep3) = evaluate_with_tree(&cond, &ctx_rep3);
@@ -9035,6 +9193,7 @@ fn test_eager_fires_after_dep_in_progress_clears() {
         now: now2,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
 
     let (result2, tree2) = evaluate_with_tree(&cond, &ctx2);
@@ -9084,6 +9243,7 @@ fn test_eager_fires_after_dep_in_progress_clears() {
         now: now3,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
 
     let (result3, tree3) = evaluate_with_tree(&cond, &ctx3);
@@ -9529,6 +9689,7 @@ fn test_will_be_requested_true_when_in_set() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::WillBeRequested, &ctx).fired);
 }
@@ -9565,6 +9726,7 @@ fn test_will_be_requested_in_dep_pivot() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let cond = ConditionNode::any_deps_match(ConditionNode::WillBeRequested);
     assert!(evaluate(&cond, &ctx).fired);
@@ -9599,6 +9761,7 @@ fn test_will_be_requested_not_in_dep_pivot_when_dep_not_requested() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let cond = ConditionNode::any_deps_match(ConditionNode::WillBeRequested);
     assert!(!evaluate(&cond, &ctx).fired);
@@ -9645,6 +9808,7 @@ fn test_any_deps_updated_fires_via_will_be_requested() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::any_deps_updated(), &ctx).fired);
 }
@@ -9681,6 +9845,7 @@ fn test_any_deps_missing_suppressed_by_will_be_requested() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     // Missing dep, but will be requested → should be false
     assert!(!evaluate(&ConditionNode::any_deps_missing(), &ctx).fired);
@@ -9715,6 +9880,7 @@ fn test_any_deps_missing_fires_when_dep_not_requested() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     assert!(evaluate(&ConditionNode::any_deps_missing(), &ctx).fired);
 }
@@ -9744,6 +9910,7 @@ fn test_will_be_requested_tree_output() {
         now: 1000,
         is_initial: false,
         partitions: None,
+        root_partition_floor: None,
     };
     let (result, tree) = evaluate_with_tree(&ConditionNode::WillBeRequested, &ctx);
     assert!(result.fired);
@@ -9806,6 +9973,7 @@ fn test_partitioned_on_cron_no_deps_fires_all_partitions() {
         now: now_nanos,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     let result = evaluate(&cond, &ctx);
@@ -9874,6 +10042,7 @@ fn test_partitioned_on_cron_does_not_fire_without_tick() {
         now: now_nanos,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     let result = evaluate(&cond, &ctx);
@@ -9964,6 +10133,7 @@ fn test_partitioned_on_cron_waits_for_dep_update() {
         now: now_nanos,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     let result = evaluate(&cond, &ctx);
@@ -10054,6 +10224,7 @@ fn test_partitioned_on_cron_fires_after_dep_update() {
         now: now_nanos,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     let result = evaluate(&cond, &ctx);
@@ -10148,6 +10319,7 @@ fn test_partitioned_on_cron_partial_dep_update() {
         now: now_nanos,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
 
     let result = evaluate(&cond, &ctx);
@@ -10301,6 +10473,7 @@ fn test_update_dep_baselines_prevents_newly_updated_false_positive() {
         now: 1000,
         is_initial: false,
         partitions: Some(&pctx),
+        root_partition_floor: None,
     };
     let cond = ConditionNode::any_deps_updated();
     let result = evaluate(&cond, &ctx);
@@ -10351,6 +10524,7 @@ fn test_update_dep_baselines_prevents_newly_updated_false_positive() {
         now: 1000,
         is_initial: false,
         partitions: Some(&pctx2),
+        root_partition_floor: None,
     };
     let result2 = evaluate(&cond, &ctx2);
     assert!(

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -2341,6 +2341,7 @@ fn test_last_run_includes_target_partitioned() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &partition_status,
+        dep_root_floor: None,
     };
     ctx.partitions = Some(&pctx);
 
@@ -2452,6 +2453,7 @@ fn test_last_run_includes_target_partitioned_joint_run_suppresses_newly_updated(
         resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
     ctx.partitions = Some(&pctx);
 
@@ -2533,6 +2535,7 @@ fn dep_updated_requires_dep_newer_than_target_key() {
         resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
     ctx.partitions = Some(&pctx);
 
@@ -2548,6 +2551,265 @@ fn dep_updated_requires_dep_newer_than_target_key() {
                 "a dep key no newer than the root's must not count as updated"
             );
             assert_eq!(keys.len(), 1);
+        }
+        other => panic!("expected Keys selection, got {other:?}"),
+    }
+}
+
+#[test]
+fn dep_updated_floor_compares_mapped_downstream_key() {
+    // The staleness floor must compare a dep key against the root's
+    // materialization of the DOWNSTREAM key the mapping resolves it to —
+    // not the root's unrelated same-named key. With time_window(offset=-1)
+    // ("read yesterday's partition"), b@D drives a@(D+1): once a@(D+1) has
+    // landed newer than b@D, the trigger must self-suppress.
+    let a = make_materialized_record("a", 400);
+    let b = make_materialized_record("b", 300);
+    let records = HashMap::from([("a".to_string(), a.clone()), ("b".to_string(), b.clone())]);
+    let deps = HashMap::from([("a".to_string(), vec!["b".to_string()])]);
+
+    let grid = crate::timegrid::TimeGrid {
+        cron_schedule: None,
+        interval_seconds: Some(86400.0),
+        start: chrono::NaiveDate::from_ymd_opt(2024, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        end: Some(
+            chrono::NaiveDate::from_ymd_opt(2024, 2, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+        ),
+        fmt: "%Y-%m-%d".to_string(),
+    };
+
+    let b_keys = HashSet::from([spk("2024-01-04"), spk("2024-01-05")]);
+    let a_keys = HashSet::from([spk("2024-01-05"), spk("2024-01-06")]);
+    // Root already consumed both dep updates: a@05 (from b@04) and a@06
+    // (from b@05) are newer than their driving dep keys.
+    let a_timestamps = HashMap::from([(spk("2024-01-05"), 100i64), (spk("2024-01-06"), 400)]);
+
+    let all_states = HashMap::new();
+    let b_partition_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: b_keys.clone(),
+        timestamps: HashMap::from([(spk("2024-01-04"), 50i64), (spk("2024-01-05"), 300)]),
+        ..Default::default()
+    };
+    let a_partition_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: a_keys.clone(),
+        timestamps: a_timestamps.clone(),
+        ..Default::default()
+    };
+    let partition_statuses = HashMap::from([
+        ("a".to_string(), a_partition_status),
+        ("b".to_string(), b_partition_status),
+    ]);
+    // Solo runs: no joint-run suppression in play.
+    let partition_asset_names = HashMap::from([(
+        "b".to_string(),
+        HashMap::from([
+            (spk("2024-01-04"), Arc::from(vec!["b".to_string()])),
+            (spk("2024-01-05"), Arc::from(vec!["b".to_string()])),
+        ]),
+    )]);
+
+    let mut ctx = make_ctx("a", &a, &records, &deps);
+    ctx.tags.partition_last_run_asset_names = &partition_asset_names;
+    ctx.all_asset_states = &all_states;
+
+    let mappings = HashMap::from([(
+        ("a".to_string(), "b".to_string()),
+        PartitionMappingKind::TimeWindow {
+            offset: -1,
+            grid: Some(grid),
+        },
+    )]);
+    let upstream_b = HashMap::from([("b".to_string(), b_keys.clone())]);
+    let pctx = PartitionEvalContext {
+        all_keys: &a_keys,
+        materialized: &a_keys,
+        in_progress: &HashSet::new(),
+        failed: &HashSet::new(),
+        timestamps: &a_timestamps,
+        resolver: PartitionResolver::new(&mappings, &upstream_b),
+        latest_time_window_keys: None,
+        all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
+    };
+    ctx.partitions = Some(&pctx);
+
+    let cond = ConditionNode::any_deps_updated();
+    let result = evaluate(&cond, &ctx);
+    assert!(
+        !result.fired,
+        "every dep key's mapped downstream key is already newer; got {:?}",
+        result.selection
+    );
+
+    // Control: the root's mapped key a@06 older than b@05 -> exactly that
+    // downstream key fires.
+    let a_timestamps_stale =
+        HashMap::from([(spk("2024-01-05"), 100i64), (spk("2024-01-06"), 200)]);
+    let statuses_stale = HashMap::from([
+        (
+            "a".to_string(),
+            crate::condition::cache::PartitionStatusEntry {
+                materialized: a_keys.clone(),
+                timestamps: a_timestamps_stale.clone(),
+                ..Default::default()
+            },
+        ),
+        (
+            "b".to_string(),
+            crate::condition::cache::PartitionStatusEntry {
+                materialized: b_keys.clone(),
+                timestamps: HashMap::from([(spk("2024-01-04"), 50i64), (spk("2024-01-05"), 300)]),
+                ..Default::default()
+            },
+        ),
+    ]);
+    let pctx_stale = PartitionEvalContext {
+        all_keys: &a_keys,
+        materialized: &a_keys,
+        in_progress: &HashSet::new(),
+        failed: &HashSet::new(),
+        timestamps: &a_timestamps_stale,
+        resolver: PartitionResolver::new(&mappings, &upstream_b),
+        latest_time_window_keys: None,
+        all_partition_statuses: &statuses_stale,
+        dep_root_floor: None,
+    };
+    let mut ctx2 = make_ctx("a", &a, &records, &deps);
+    ctx2.tags.partition_last_run_asset_names = &partition_asset_names;
+    ctx2.all_asset_states = &all_states;
+    ctx2.partitions = Some(&pctx_stale);
+    let result = evaluate(&cond, &ctx2);
+    assert!(result.fired, "a@06 is older than b@05 now");
+    match result.selection {
+        Some(PartitionSelection::Keys(ref keys)) => {
+            assert_eq!(keys.len(), 1);
+            assert!(
+                keys.contains(&spk("2024-01-06")),
+                "the fire must target the mapped downstream key"
+            );
+        }
+        other => panic!("expected Keys selection, got {other:?}"),
+    }
+}
+
+#[test]
+fn dep_updated_ignores_dep_keys_outside_root_universe() {
+    // Identity dep whose upstream range is a superset of the root's
+    // (upstream daily since 2020, downstream added with start=2024): the
+    // upstream-only keys can never be dispatched downstream, so they must
+    // not count as updated — pre-fix they kept the condition permanently
+    // firing phantom selections.
+    let a = make_materialized_record("a", 100);
+    let b = make_materialized_record("b", 500);
+    let records = HashMap::from([("a".to_string(), a.clone()), ("b".to_string(), b.clone())]);
+    let deps = HashMap::from([("a".to_string(), vec!["b".to_string()])]);
+
+    let old = spk("2020-01-01");
+    let shared = spk("2024-06-01");
+    let b_keys = HashSet::from([old.clone(), shared.clone()]);
+    let a_keys = HashSet::from([shared.clone()]);
+    let a_timestamps = HashMap::from([(shared.clone(), 100i64)]);
+
+    let all_states = HashMap::new();
+    let b_partition_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: b_keys.clone(),
+        timestamps: HashMap::from([(old.clone(), 500i64), (shared.clone(), 100)]),
+        ..Default::default()
+    };
+    let a_partition_status = crate::condition::cache::PartitionStatusEntry {
+        materialized: a_keys.clone(),
+        timestamps: a_timestamps.clone(),
+        ..Default::default()
+    };
+    let partition_statuses = HashMap::from([
+        ("a".to_string(), a_partition_status),
+        ("b".to_string(), b_partition_status),
+    ]);
+    let partition_asset_names = HashMap::from([(
+        "b".to_string(),
+        HashMap::from([
+            (old.clone(), Arc::from(vec!["b".to_string()])),
+            (shared.clone(), Arc::from(vec!["b".to_string()])),
+        ]),
+    )]);
+
+    let mut ctx = make_ctx("a", &a, &records, &deps);
+    ctx.tags.partition_last_run_asset_names = &partition_asset_names;
+    ctx.all_asset_states = &all_states;
+
+    let empty_mappings = HashMap::new();
+    let upstream_b = HashMap::from([("b".to_string(), b_keys.clone())]);
+    let pctx = PartitionEvalContext {
+        all_keys: &a_keys,
+        materialized: &a_keys,
+        in_progress: &HashSet::new(),
+        failed: &HashSet::new(),
+        timestamps: &a_timestamps,
+        resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
+        latest_time_window_keys: None,
+        all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
+    };
+    ctx.partitions = Some(&pctx);
+
+    let cond = ConditionNode::any_deps_updated();
+    let result = evaluate(&cond, &ctx);
+    assert!(
+        !result.fired,
+        "an upstream-only key must not fire the condition; got {:?}",
+        result.selection
+    );
+
+    // Control: a genuine update of the shared key still fires it alone.
+    let statuses_new = HashMap::from([
+        (
+            "a".to_string(),
+            crate::condition::cache::PartitionStatusEntry {
+                materialized: a_keys.clone(),
+                timestamps: a_timestamps.clone(),
+                ..Default::default()
+            },
+        ),
+        (
+            "b".to_string(),
+            crate::condition::cache::PartitionStatusEntry {
+                materialized: b_keys.clone(),
+                timestamps: HashMap::from([(old.clone(), 500i64), (shared.clone(), 150)]),
+                ..Default::default()
+            },
+        ),
+    ]);
+    let pctx_new = PartitionEvalContext {
+        all_keys: &a_keys,
+        materialized: &a_keys,
+        in_progress: &HashSet::new(),
+        failed: &HashSet::new(),
+        timestamps: &a_timestamps,
+        resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
+        latest_time_window_keys: None,
+        all_partition_statuses: &statuses_new,
+        dep_root_floor: None,
+    };
+    let mut ctx2 = make_ctx("a", &a, &records, &deps);
+    ctx2.tags.partition_last_run_asset_names = &partition_asset_names;
+    ctx2.all_asset_states = &all_states;
+    ctx2.partitions = Some(&pctx_new);
+    let result = evaluate(&cond, &ctx2);
+    assert!(result.fired);
+    match result.selection {
+        Some(PartitionSelection::Keys(ref keys)) => {
+            assert_eq!(
+                keys.len(),
+                1,
+                "only the shared key may fire, never the phantom: {keys:?}"
+            );
+            assert!(keys.contains(&shared));
         }
         other => panic!("expected Keys selection, got {other:?}"),
     }
@@ -2605,6 +2867,7 @@ fn test_last_run_includes_target_partitioned_solo_run_allows_newly_updated() {
         resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
     ctx.partitions = Some(&pctx);
 
@@ -2681,6 +2944,7 @@ fn test_last_run_includes_target_partitioned_mixed_joint_and_solo() {
         resolver: PartitionResolver::new(&empty_mappings, &upstream_b),
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
     ctx.partitions = Some(&pctx);
 
@@ -6034,6 +6298,7 @@ impl OwnedPartitionData {
             resolver: PartitionResolver::empty(),
             latest_time_window_keys: None,
             all_partition_statuses: &self.all_partition_statuses,
+            dep_root_floor: None,
         }
     }
 }
@@ -6260,6 +6525,7 @@ fn test_partitioned_in_latest_time_window_selects_recent_keys() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: Some(&latest),
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
     let ctx = make_partitioned_ctx("a", &record, &records, &deps, &pctx);
     let cond = ConditionNode::InLatestTimeWindow {
@@ -6292,6 +6558,7 @@ fn test_partitioned_in_latest_time_window_empty_when_no_recent() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: Some(&latest),
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
     let ctx = make_partitioned_ctx("a", &record, &records, &deps, &pctx);
     let cond = ConditionNode::InLatestTimeWindow {
@@ -6343,6 +6610,7 @@ fn test_partitioned_in_latest_time_window_combined_with_missing() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: Some(&latest),
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
     let ctx = make_partitioned_ctx("a", &record, &records, &deps, &pctx);
     // InLatestTimeWindow & Missing — only the latest missing partitions
@@ -6703,6 +6971,7 @@ fn test_partitioned_any_deps_missing_with_identity() {
         resolver,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
 
     let ctx = EvalContext {
@@ -6784,6 +7053,7 @@ fn test_partitioned_all_deps_match_not_missing() {
         resolver,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
 
     let ctx = EvalContext {
@@ -6944,6 +7214,7 @@ fn test_partitioned_eager_selects_new_partition() {
         resolver,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
 
     let ctx = EvalContext {
@@ -7298,6 +7569,7 @@ fn test_partitioned_eager_partial_upstream_update() {
         resolver,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
 
     let ctx = EvalContext {
@@ -7384,6 +7656,7 @@ fn test_partitioned_eager_only_fires_for_partitions_with_upstream_data() {
         resolver,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
 
     let ctx = EvalContext {
@@ -7489,6 +7762,7 @@ fn test_partitioned_on_missing_only_missing_partitions() {
         resolver,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
 
     let ctx = EvalContext {
@@ -7554,6 +7828,7 @@ fn test_partitioned_in_progress_excludes_from_and() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
 
     let ctx = EvalContext {
@@ -7619,6 +7894,7 @@ fn test_partitioned_code_version_changed_all_partitions() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
 
     let pctx_ref = &pctx;
@@ -7657,6 +7933,7 @@ fn test_partitioned_since_latch_per_partition() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
 
     let ctx1 = EvalContext {
@@ -7707,6 +7984,7 @@ fn test_partitioned_since_latch_per_partition() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
 
     let prev2 = AssetConditionState {
@@ -7902,6 +8180,7 @@ fn test_partitioned_execution_failed_subset() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
 
     let ctx = make_partitioned_ctx("a", &record, &records, &deps, &pctx);
@@ -7936,6 +8215,7 @@ fn test_partitioned_complex_or_and_not() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
 
     let ctx = make_partitioned_ctx("a", &record, &records, &deps, &pctx);
@@ -9136,6 +9416,7 @@ fn test_partitioned_on_cron_no_deps_fires_all_partitions() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
 
     let prev = AssetConditionState {
@@ -9202,6 +9483,7 @@ fn test_partitioned_on_cron_does_not_fire_without_tick() {
         resolver: PartitionResolver::empty(),
         latest_time_window_keys: None,
         all_partition_statuses: &empty_partition_statuses,
+        dep_root_floor: None,
     };
 
     let prev = AssetConditionState {
@@ -9289,6 +9571,7 @@ fn test_partitioned_on_cron_waits_for_dep_update() {
         resolver,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
 
     let prev = AssetConditionState {
@@ -9376,6 +9659,7 @@ fn test_partitioned_on_cron_fires_after_dep_update() {
         resolver,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
 
     let prev = AssetConditionState {
@@ -9467,6 +9751,7 @@ fn test_partitioned_on_cron_partial_dep_update() {
         resolver,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
 
     let prev = AssetConditionState {
@@ -9623,6 +9908,7 @@ fn test_update_dep_baselines_prevents_newly_updated_false_positive() {
         resolver,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
     let ctx = EvalContext {
         target_key: "a",
@@ -9671,6 +9957,7 @@ fn test_update_dep_baselines_prevents_newly_updated_false_positive() {
         resolver: resolver2,
         latest_time_window_keys: None,
         all_partition_statuses: &partition_statuses,
+        dep_root_floor: None,
     };
     let ctx2 = EvalContext {
         target_key: "a",

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -89,6 +89,9 @@ fn mpk(dims: &[(&str, &str)]) -> PartitionKey {
 static EMPTY_REQUESTED: std::sync::LazyLock<HashMap<String, PartitionSelection>> =
     std::sync::LazyLock::new(HashMap::new);
 
+static EMPTY_FAILED_TS: std::sync::LazyLock<HashMap<String, i64>> =
+    std::sync::LazyLock::new(HashMap::new);
+
 fn make_ctx<'a>(
     target_key: &'a str,
     target_record: &'a AssetRecord,
@@ -104,6 +107,7 @@ fn make_ctx<'a>(
             upstream_deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -151,6 +155,7 @@ fn test_in_progress() {
             upstream_deps: &deps,
             in_progress_assets: &in_progress,
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -186,6 +191,7 @@ fn test_execution_failed() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &failed,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -247,6 +253,7 @@ fn test_newly_requested_after_firing() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -286,6 +293,7 @@ fn test_newly_requested_not_fired_last_tick() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -324,6 +332,7 @@ fn test_newly_requested_never_handled() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -362,6 +371,7 @@ fn test_newly_updated() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -400,6 +410,7 @@ fn test_newly_updated_no_change() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -544,6 +555,7 @@ fn test_newly_true_does_not_refire_with_previous_true() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -656,6 +668,7 @@ fn test_data_version_changed_true_when_version_differs() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -695,6 +708,7 @@ fn test_data_version_changed_false_when_same() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -754,6 +768,7 @@ fn test_data_version_changed_false_version_disappeared() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -793,6 +808,7 @@ fn test_data_version_changed_with_tree() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -845,6 +861,7 @@ fn test_data_version_changed_state_tracking() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -878,6 +895,7 @@ fn test_data_version_changed_state_tracking() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -917,6 +935,7 @@ fn test_backfill_in_progress_true_when_in_backfill() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -966,6 +985,7 @@ fn test_backfill_in_progress_only_matches_selected_assets() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -992,6 +1012,7 @@ fn test_backfill_in_progress_only_matches_selected_assets() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -1031,6 +1052,7 @@ fn test_backfill_in_progress_with_tree() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -1073,6 +1095,7 @@ fn test_backfill_in_progress_composition_with_in_progress() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -1116,6 +1139,7 @@ fn test_backfill_in_progress_dep_aggregate() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -1162,6 +1186,7 @@ fn test_backfill_in_progress_partitioned_targets_subset() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -1219,6 +1244,7 @@ fn test_backfill_in_progress_partitioned_empty_keys_selects_all() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -1270,6 +1296,7 @@ fn test_backfill_in_progress_partitioned_disjoint_keys() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -1324,6 +1351,7 @@ fn test_backfill_in_progress_multiple_backfills_union_partitions() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -1386,6 +1414,7 @@ fn test_backfill_in_progress_one_backfill_empty_keys_short_circuits() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &bf,
         },
         tags: RunTagSnapshot {
@@ -3455,6 +3484,7 @@ fn test_any_deps_in_progress() {
             upstream_deps: &deps,
             in_progress_assets: &in_progress,
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3491,6 +3521,7 @@ fn test_any_deps_in_progress_none() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3529,6 +3560,7 @@ fn test_any_deps_updated() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3547,6 +3579,72 @@ fn test_any_deps_updated() {
         partitions: None,
     };
     assert!(evaluate(&ConditionNode::any_deps_updated(), &ctx).fired);
+}
+
+#[test]
+fn unpartitioned_dep_updated_compares_against_root_record() {
+    // Drain-lag double fire: the root already ran at 110 reading b@99's
+    // durably-written data; b's completion drains into the cache a tick
+    // later with a stale fire-time baseline (50). Baselines re-fire; the
+    // staleness floor must see the root is already newer and suppress.
+    let r = make_materialized_record("R", 110);
+    let b = make_materialized_record("b", 99);
+    let records = HashMap::from([("R".to_string(), r.clone()), ("b".to_string(), b.clone())]);
+    let deps = HashMap::from([("R".to_string(), vec!["b".to_string()])]);
+    let b_state = AssetConditionState {
+        last_materialized_timestamp: Some(50),
+        ..Default::default()
+    };
+    let all_states = HashMap::from([("b".to_string(), b_state)]);
+
+    let mut ctx = make_ctx("R", &r, &records, &deps);
+    ctx.all_asset_states = &all_states;
+    assert!(
+        !evaluate(&ConditionNode::any_deps_updated(), &ctx).fired,
+        "the root's run at 110 already consumed b@99"
+    );
+
+    // Control: b lands genuinely newer than the root -> fires.
+    let b_new = make_materialized_record("b", 120);
+    let records_new = HashMap::from([
+        ("R".to_string(), r.clone()),
+        ("b".to_string(), b_new.clone()),
+    ]);
+    let mut ctx2 = make_ctx("R", &r, &records_new, &deps);
+    ctx2.all_asset_states = &all_states;
+    assert!(evaluate(&ConditionNode::any_deps_updated(), &ctx2).fired);
+}
+
+#[test]
+fn unpartitioned_dep_updated_failed_root_retries_once() {
+    // A failed root run consumes the dep update that triggered it: while the
+    // failure postdates the dep, re-firing every tick is an unbounded retry
+    // loop. A newer dep update retries exactly once more.
+    let r = make_materialized_record("R", 100);
+    let b = make_materialized_record("b", 120);
+    let records = HashMap::from([("R".to_string(), r.clone()), ("b".to_string(), b.clone())]);
+    let deps = HashMap::from([("R".to_string(), vec!["b".to_string()])]);
+    let failed_ts = HashMap::from([("R".to_string(), 130i64)]);
+    let all_states = HashMap::new();
+
+    let mut ctx = make_ctx("R", &r, &records, &deps);
+    ctx.all_asset_states = &all_states;
+    ctx.cache.failed_asset_timestamps = &failed_ts;
+    assert!(
+        !evaluate(&ConditionNode::any_deps_updated(), &ctx).fired,
+        "the failed attempt at 130 already consumed b@120"
+    );
+
+    // Control: b lands after the failure -> one retry becomes due.
+    let b_new = make_materialized_record("b", 140);
+    let records_new = HashMap::from([
+        ("R".to_string(), r.clone()),
+        ("b".to_string(), b_new.clone()),
+    ]);
+    let mut ctx2 = make_ctx("R", &r, &records_new, &deps);
+    ctx2.all_asset_states = &all_states;
+    ctx2.cache.failed_asset_timestamps = &failed_ts;
+    assert!(evaluate(&ConditionNode::any_deps_updated(), &ctx2).fired);
 }
 
 #[test]
@@ -3573,6 +3671,7 @@ fn test_any_deps_updated_no_change() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3660,6 +3759,7 @@ fn test_newly_true_transition() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3692,6 +3792,7 @@ fn test_newly_true_transition() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3725,6 +3826,7 @@ fn test_newly_true_transition() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3782,6 +3884,7 @@ fn test_counter_stability_and_short_circuit() {
             upstream_deps: &deps,
             in_progress_assets: &in_progress,
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3816,6 +3919,7 @@ fn test_counter_stability_and_short_circuit() {
             upstream_deps: &deps,
             in_progress_assets: &in_progress,
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3875,6 +3979,7 @@ fn test_on_missing_does_not_fire_when_in_progress() {
             upstream_deps: &deps,
             in_progress_assets: &in_progress,
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3929,6 +4034,7 @@ fn test_eager_fires_on_deps_updated() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -3974,6 +4080,7 @@ fn test_eager_does_not_fire_when_up_to_date() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4039,6 +4146,7 @@ fn test_bug_cron_tick_always_fires_on_first_eval() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4091,6 +4199,7 @@ fn test_cron_tick_fires_when_tick_passes_between_evals() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4211,6 +4320,7 @@ fn test_bug_since_last_handled_refires_after_own_materialization() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4251,6 +4361,7 @@ fn test_bug_since_last_handled_refires_after_own_materialization() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4305,6 +4416,7 @@ fn test_newly_requested_any_deps_match_cross_asset_signaling() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4357,6 +4469,7 @@ fn test_newly_requested_any_deps_match_cross_asset_signaling() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4402,6 +4515,7 @@ fn test_newly_requested_any_deps_match_cross_asset_signaling() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4456,6 +4570,7 @@ fn test_newly_requested_as_since_reset() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4498,6 +4613,7 @@ fn test_newly_requested_as_since_reset() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4554,6 +4670,7 @@ fn test_newly_requested_as_since_reset_fast_ticks() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4590,6 +4707,7 @@ fn test_newly_requested_as_since_reset_fast_ticks() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4630,6 +4748,7 @@ fn test_newly_requested_as_since_reset_fast_ticks() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4683,6 +4802,7 @@ fn test_newly_requested_in_since_last_handled() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4717,6 +4837,7 @@ fn test_newly_requested_in_since_last_handled() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4754,6 +4875,7 @@ fn test_newly_requested_in_since_last_handled() {
             upstream_deps: &deps,
             in_progress_assets: &HashSet::new(),
             failed_assets: &HashSet::new(),
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -4946,6 +5068,7 @@ fn bench_eval(
                     upstream_deps,
                     in_progress_assets: &in_progress,
                     failed_assets: &failed,
+                    failed_asset_timestamps: &EMPTY_FAILED_TS,
                     backfill: &EMPTY_BACKFILL,
                 },
                 tags: RunTagSnapshot {
@@ -4981,6 +5104,7 @@ fn bench_eval(
                     upstream_deps,
                     in_progress_assets: &in_progress,
                     failed_assets: &failed,
+                    failed_asset_timestamps: &EMPTY_FAILED_TS,
                     backfill: &EMPTY_BACKFILL,
                 },
                 tags: RunTagSnapshot {
@@ -5306,6 +5430,7 @@ fn bench_selective_vs_full_eval() {
                         upstream_deps: &cache.upstream_deps,
                         in_progress_assets: &in_progress,
                         failed_assets: &failed,
+                        failed_asset_timestamps: &EMPTY_FAILED_TS,
                         backfill: &EMPTY_BACKFILL,
                     },
                     tags: RunTagSnapshot {
@@ -5346,6 +5471,7 @@ fn bench_selective_vs_full_eval() {
                         upstream_deps: &cache.upstream_deps,
                         in_progress_assets: &in_progress,
                         failed_assets: &failed,
+                        failed_asset_timestamps: &EMPTY_FAILED_TS,
                         backfill: &EMPTY_BACKFILL,
                     },
                     tags: RunTagSnapshot {
@@ -5571,6 +5697,7 @@ async fn bench_cache_tick<S: StorageBackend>(
                         upstream_deps: &cache.upstream_deps,
                         in_progress_assets: &in_progress,
                         failed_assets: &failed,
+                        failed_asset_timestamps: &EMPTY_FAILED_TS,
                         backfill: &EMPTY_BACKFILL,
                     },
                     tags: RunTagSnapshot {
@@ -6521,6 +6648,7 @@ fn make_partitioned_ctx<'a>(
             upstream_deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -6920,6 +7048,7 @@ fn test_partitioned_newly_updated() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -7035,6 +7164,7 @@ fn test_partitioned_newly_true() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -7083,6 +7213,7 @@ fn test_partitioned_newly_true() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -7186,6 +7317,7 @@ fn test_partitioned_any_deps_missing_with_identity() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -7269,6 +7401,7 @@ fn test_partitioned_all_deps_match_not_missing() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -7431,6 +7564,7 @@ fn test_partitioned_eager_selects_new_partition() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -7787,6 +7921,7 @@ fn test_partitioned_eager_partial_upstream_update() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -7875,6 +8010,7 @@ fn test_partitioned_eager_only_fires_for_partitions_with_upstream_data() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -7982,6 +8118,7 @@ fn test_partitioned_on_missing_only_missing_partitions() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8048,6 +8185,7 @@ fn test_partitioned_in_progress_excludes_from_and() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8153,6 +8291,7 @@ fn test_partitioned_since_latch_per_partition() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8212,6 +8351,7 @@ fn test_partitioned_since_latch_per_partition() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8261,6 +8401,7 @@ fn test_partitioned_newly_true_only_new_partitions() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8302,6 +8443,7 @@ fn test_partitioned_newly_true_only_new_partitions() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8341,6 +8483,7 @@ fn test_partitioned_newly_true_only_new_partitions() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8522,6 +8665,7 @@ fn test_eager_does_not_fire_when_all_up_to_date_first_tick() {
             upstream_deps: &upstream_deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8650,6 +8794,7 @@ fn test_eager_fires_after_upstream_observed_on_second_tick() {
             upstream_deps: &upstream_deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8721,6 +8866,7 @@ fn test_eager_fires_after_upstream_observed_on_second_tick() {
             upstream_deps: &upstream_deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8755,6 +8901,7 @@ fn test_eager_fires_after_upstream_observed_on_second_tick() {
             upstream_deps: &upstream_deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8871,6 +9018,7 @@ fn test_eager_fires_after_dep_in_progress_clears() {
             upstream_deps: &upstream_deps,
             in_progress_assets: &in_progress,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -8919,6 +9067,7 @@ fn test_eager_fires_after_dep_in_progress_clears() {
             upstream_deps: &upstream_deps,
             in_progress_assets: &empty_in_progress,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: RunTagSnapshot {
@@ -9370,6 +9519,7 @@ fn test_will_be_requested_true_when_in_set() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9405,6 +9555,7 @@ fn test_will_be_requested_in_dep_pivot() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9438,6 +9589,7 @@ fn test_will_be_requested_not_in_dep_pivot_when_dep_not_requested() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9483,6 +9635,7 @@ fn test_any_deps_updated_fires_via_will_be_requested() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9518,6 +9671,7 @@ fn test_any_deps_missing_suppressed_by_will_be_requested() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9551,6 +9705,7 @@ fn test_any_deps_missing_fires_when_dep_not_requested() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9579,6 +9734,7 @@ fn test_will_be_requested_tree_output() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9640,6 +9796,7 @@ fn test_partitioned_on_cron_no_deps_fires_all_partitions() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9707,6 +9864,7 @@ fn test_partitioned_on_cron_does_not_fire_without_tick() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9796,6 +9954,7 @@ fn test_partitioned_on_cron_waits_for_dep_update() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9885,6 +10044,7 @@ fn test_partitioned_on_cron_fires_after_dep_update() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -9978,6 +10138,7 @@ fn test_partitioned_on_cron_partial_dep_update() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -10130,6 +10291,7 @@ fn test_update_dep_baselines_prevents_newly_updated_false_positive() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),
@@ -10179,6 +10341,7 @@ fn test_update_dep_baselines_prevents_newly_updated_false_positive() {
             upstream_deps: &deps,
             in_progress_assets: &EMPTY_SET,
             failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
             backfill: &EMPTY_BACKFILL,
         },
         tags: empty_tag_snapshot(),

--- a/rust/rivers-core/src/storage/mod.rs
+++ b/rust/rivers-core/src/storage/mod.rs
@@ -1500,14 +1500,15 @@ pub(crate) trait PerCodeLocationStorage: Send + Sync {
     ) -> impl Future<Output = Result<Vec<PartitionKey>>> + Send;
 
     /// Partitions whose latest `StepFailure` isn't superseded by a later
-    /// materialization. `materialized` is the caller's per-partition timestamps
-    /// (from `get_partition_timestamps`), so we don't re-read `asset_partitions`.
+    /// materialization, with that failure's timestamp. `materialized` is the
+    /// caller's per-partition timestamps (from `get_partition_timestamps`),
+    /// so we don't re-read `asset_partitions`.
     fn get_failed_partitions(
         &self,
         code_location_id: &str,
         asset_key: &str,
         materialized: &HashMap<PartitionKey, i64>,
-    ) -> impl Future<Output = Result<Vec<PartitionKey>>> + Send;
+    ) -> impl Future<Output = Result<HashMap<PartitionKey, i64>>> + Send;
 
     fn get_backfills(
         &self,
@@ -1880,7 +1881,7 @@ impl<'a, S: PerCodeLocationStorage + ?Sized> ScopedStorage<'a, S> {
         &self,
         asset_key: &str,
         materialized: &HashMap<PartitionKey, i64>,
-    ) -> Result<Vec<PartitionKey>> {
+    ) -> Result<HashMap<PartitionKey, i64>> {
         self.backend
             .get_failed_partitions(self.code_location_id, asset_key, materialized)
             .await

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -402,7 +402,13 @@ async fn refresh_reserved_dynamic_keys_warning(
     let recorded: Vec<ReservedDynamicKey> = match serde_json::from_slice(&row.value) {
         Ok(v) => v,
         Err(e) => {
-            tracing::warn!(error = %e, "unreadable reserved_dynamic_keys record; ignoring");
+            // An unreadable record would re-fail to parse on every open
+            // forever; delete it so the DB reaches a clean state.
+            tracing::warn!(error = %e, "unreadable reserved_dynamic_keys record; deleting");
+            db.query("DELETE FROM kv WHERE key = $key")
+                .bind(("key", RESERVED_DYNAMIC_KEYS_KEY.to_string()))
+                .await?
+                .check()?;
             return Ok(Vec::new());
         }
     };
@@ -4451,6 +4457,47 @@ mod tests {
             .unwrap();
         let rows: Vec<DbKv> = res.take(0).unwrap();
         assert!(rows.is_empty(), "an emptied record must be deleted");
+    }
+
+    /// A reserved_dynamic_keys record left in an older (Vec<String>)
+    /// format can't deserialize into the current struct. The Err arm must
+    /// DELETE it so it stops re-failing to parse on every open instead of
+    /// lingering corrupt forever.
+    #[tokio::test]
+    async fn unreadable_reserved_dynamic_keys_record_is_deleted() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+
+        // Old human-string format the current struct schema cannot read.
+        let legacy = vec!["default/colors: 'us|eu'".to_string()];
+        storage
+            .db
+            .query("INSERT INTO kv { key: $key, value: $value }")
+            .bind(("key", RESERVED_DYNAMIC_KEYS_KEY.to_string()))
+            .bind(("value", Bytes::from(serde_json::to_vec(&legacy).unwrap())))
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+
+        let remaining = refresh_reserved_dynamic_keys_warning(&storage.db)
+            .await
+            .unwrap();
+        assert!(remaining.is_empty());
+
+        let mut res = storage
+            .db
+            .query("SELECT * FROM kv WHERE key = $key")
+            .bind(("key", RESERVED_DYNAMIC_KEYS_KEY.to_string()))
+            .await
+            .unwrap();
+        let rows: Vec<DbKv> = res.take(0).unwrap();
+        assert!(
+            rows.is_empty(),
+            "an unreadable reserved_dynamic_keys record must be deleted"
+        );
     }
 
     /// The heal's values come from a snapshot taken before its write loop, so

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -340,10 +340,18 @@ async fn set_schema_version(db: &Surreal<Any>, version: u32) -> anyhow::Result<(
 /// remediation: delete each and re-register it under a clean name.
 const RESERVED_DYNAMIC_KEYS_KEY: &str = "reserved_dynamic_keys";
 
+/// One recorded reserved-char dynamic key, kept in `kv` until remediated.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct ReservedDynamicKey {
+    code_location_id: String,
+    partitions_def_name: String,
+    partition_key: String,
+}
+
 /// v2 → v3 scan: stored reserved-char dynamic keys still classify (matching
 /// is structural) but cannot round-trip any display-string path (UI, gRPC).
-/// Renaming them silently would change user-visible keys, so warn and record
-/// them in `kv` instead.
+/// Renaming them silently would change user-visible keys, so record them in
+/// `kv`; every open re-checks the record and warns until they're gone.
 async fn scan_reserved_char_dynamic_keys(db: &Surreal<Any>) -> anyhow::Result<()> {
     let mut result = db
         .query(
@@ -352,27 +360,19 @@ async fn scan_reserved_char_dynamic_keys(db: &Surreal<Any>) -> anyhow::Result<()
         )
         .await?;
     let rows: Vec<DbDynamicPartition> = result.take(0)?;
-    let offenders: Vec<String> = rows
-        .iter()
+    let offenders: Vec<ReservedDynamicKey> = rows
+        .into_iter()
         .filter(|r| PartitionKey::reserved_display_char(&r.partition_key).is_some())
-        .map(|r| {
-            format!(
-                "{}/{}: '{}'",
-                r.code_location_id, r.partitions_def_name, r.partition_key
-            )
+        .map(|r| ReservedDynamicKey {
+            code_location_id: r.code_location_id,
+            partitions_def_name: r.partitions_def_name,
+            partition_key: r.partition_key,
         })
         .collect();
     if offenders.is_empty() {
         return Ok(());
     }
-    for o in offenders.iter().take(20) {
-        tracing::warn!(
-            key = %o,
-            "dynamic partition key contains display-reserved characters; \
-             delete it and re-register under a clean name"
-        );
-    }
-    let body = serde_json::to_vec(&offenders[..offenders.len().min(100)])?;
+    let body = serde_json::to_vec(&offenders)?;
     db.query(
         "INSERT INTO kv { key: $key, value: $value } \
          ON DUPLICATE KEY UPDATE value = $value",
@@ -382,6 +382,87 @@ async fn scan_reserved_char_dynamic_keys(db: &Surreal<Any>) -> anyhow::Result<()
     .await?
     .check()?;
     Ok(())
+}
+
+/// Re-check the recorded reserved-char dynamic keys at every open: entries
+/// the operator has remediated drop out (the record rewrites itself, and
+/// disappears once empty); the rest are warned about. Cost is proportional
+/// to the recorded list, not the table.
+async fn refresh_reserved_dynamic_keys_warning(
+    db: &Surreal<Any>,
+) -> anyhow::Result<Vec<ReservedDynamicKey>> {
+    let mut res = db
+        .query("SELECT * FROM kv WHERE key = $key")
+        .bind(("key", RESERVED_DYNAMIC_KEYS_KEY.to_string()))
+        .await?;
+    let rows: Vec<DbKv> = res.take(0)?;
+    let Some(row) = rows.into_iter().next() else {
+        return Ok(Vec::new());
+    };
+    let recorded: Vec<ReservedDynamicKey> = match serde_json::from_slice(&row.value) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "unreadable reserved_dynamic_keys record; ignoring");
+            return Ok(Vec::new());
+        }
+    };
+    let recorded_len = recorded.len();
+    #[derive(Debug, SurrealValue)]
+    struct KeyRow {
+        partition_key: String,
+    }
+    let mut remaining: Vec<ReservedDynamicKey> = Vec::new();
+    for entry in recorded {
+        let mut res = db
+            .query(
+                "SELECT partition_key FROM dynamic_partitions \
+                 WHERE code_location_id = $cl AND partitions_def_name = $def \
+                 AND partition_key = $pk LIMIT 1",
+            )
+            .bind(("cl", entry.code_location_id.clone()))
+            .bind(("def", entry.partitions_def_name.clone()))
+            .bind(("pk", entry.partition_key.clone()))
+            .await?;
+        let hits: Vec<KeyRow> = res.take(0)?;
+        if !hits.is_empty() {
+            remaining.push(entry);
+        }
+    }
+    if remaining.is_empty() {
+        db.query("DELETE FROM kv WHERE key = $key")
+            .bind(("key", RESERVED_DYNAMIC_KEYS_KEY.to_string()))
+            .await?
+            .check()?;
+        return Ok(remaining);
+    }
+    if remaining.len() != recorded_len {
+        let body = serde_json::to_vec(&remaining)?;
+        db.query(
+            "INSERT INTO kv { key: $key, value: $value } \
+             ON DUPLICATE KEY UPDATE value = $value",
+        )
+        .bind(("key", RESERVED_DYNAMIC_KEYS_KEY.to_string()))
+        .bind(("value", Bytes::from(body)))
+        .await?
+        .check()?;
+    }
+    for e in remaining.iter().take(20) {
+        tracing::warn!(
+            code_location = %e.code_location_id,
+            partitions_def = %e.partitions_def_name,
+            key = %e.partition_key,
+            "dynamic partition key contains display-reserved characters; \
+             delete it and re-register under a clean name"
+        );
+    }
+    if remaining.len() > 20 {
+        tracing::warn!(
+            more = remaining.len() - 20,
+            "additional reserved-character dynamic keys recorded in kv \
+             'reserved_dynamic_keys'"
+        );
+    }
+    Ok(remaining)
 }
 
 /// Versioned in-place migrations, run once at every constructor. Steps
@@ -899,6 +980,7 @@ impl SurrealStorage {
             tracing::debug!("applying schema");
             db.query(SCHEMA).await?.check()?;
             run_migrations(&db).await?;
+            refresh_reserved_dynamic_keys_warning(&db).await?;
             Ok(db)
         })
         .await?;
@@ -950,6 +1032,7 @@ impl SurrealStorage {
             tracing::debug!("applying schema");
             db.query(SCHEMA).await?.check()?;
             run_migrations(&db).await?;
+            refresh_reserved_dynamic_keys_warning(&db).await?;
             Ok(db)
         })
         .await?;
@@ -1031,6 +1114,7 @@ impl SurrealStorage {
             tracing::debug!("applying schema");
             db.query(SCHEMA).await?.check()?;
             run_migrations(&db).await?;
+            refresh_reserved_dynamic_keys_warning(&db).await?;
             Ok(db)
         })
         .await?;
@@ -4313,6 +4397,60 @@ mod tests {
         assert_eq!(rows.len(), 1, "offending keys must be recorded in kv");
         let body = String::from_utf8(rows[0].value.to_vec()).unwrap();
         assert!(body.contains("colors") && body.contains("us|eu"), "{body}");
+    }
+
+    /// Every open re-checks the recorded offenders (the docs promise a
+    /// startup warning, not a one-shot migration log) and the record heals
+    /// itself once the operator deletes the offending keys.
+    #[tokio::test]
+    async fn test_reserved_dynamic_keys_record_warns_until_remediated() {
+        let temp_dir = test_temp_dir::test_temp_dir!();
+        let storage = SurrealStorage::new_embedded(temp_dir.as_path_untracked().to_str().unwrap())
+            .await
+            .expect("failed to create rocksdb storage");
+        set_schema_version(&storage.db, 2).await.unwrap();
+        storage
+            .db
+            .query(
+                "CREATE dynamic_partitions CONTENT { code_location_id: 'default', \
+                 partitions_def_name: 'colors', partition_key: 'us|eu', \
+                 create_timestamp: 1 }",
+            )
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+        run_migrations(&storage.db).await.unwrap();
+
+        // A later open (any constructor) re-surfaces the recorded offender.
+        let remaining = refresh_reserved_dynamic_keys_warning(&storage.db)
+            .await
+            .unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].partition_key, "us|eu");
+
+        // Remediation: the operator deletes the offending key; the next open
+        // drops it from the record and removes the empty record entirely.
+        storage
+            .db
+            .query("DELETE FROM dynamic_partitions WHERE partition_key = $pk")
+            .bind(("pk", "us|eu".to_string()))
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+        let remaining = refresh_reserved_dynamic_keys_warning(&storage.db)
+            .await
+            .unwrap();
+        assert!(remaining.is_empty(), "remediated keys must drop out");
+        let mut res = storage
+            .db
+            .query("SELECT * FROM kv WHERE key = $key")
+            .bind(("key", RESERVED_DYNAMIC_KEYS_KEY.to_string()))
+            .await
+            .unwrap();
+        let rows: Vec<DbKv> = res.take(0).unwrap();
+        assert!(rows.is_empty(), "an emptied record must be deleted");
     }
 
     /// The heal's values come from a snapshot taken before its write loop, so

--- a/rust/rivers-core/src/storage/surrealdb_backend.rs
+++ b/rust/rivers-core/src/storage/surrealdb_backend.rs
@@ -3484,7 +3484,7 @@ impl PerCodeLocationStorage for SurrealStorage {
         code_location_id: &str,
         asset_key: &str,
         materialized: &std::collections::HashMap<PartitionKey, i64>,
-    ) -> Result<Vec<PartitionKey>> {
+    ) -> Result<std::collections::HashMap<PartitionKey, i64>> {
         // No run-status filter: mark_partition_failed lands in a Success run (review #1).
         let mut result = self
             .db
@@ -3520,7 +3520,6 @@ impl PerCodeLocationStorage for SurrealStorage {
         Ok(latest_failure
             .into_iter()
             .filter(|(pk, ts)| materialized.get(pk).is_none_or(|&mat_ts| mat_ts < *ts))
-            .map(|(pk, _)| pk)
             .collect())
     }
 
@@ -8478,7 +8477,7 @@ mod tests {
             .unwrap();
         assert_eq!(failed.len(), 2);
         let mut pk_strs: Vec<String> = failed
-            .iter()
+            .keys()
             .map(|pk| match pk {
                 PartitionKey::Single { keys } => keys[0].clone(),
                 _ => panic!("expected Single partition key"),
@@ -8547,12 +8546,10 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(
-            failed,
-            vec![PartitionKey::Single {
-                keys: vec!["b".to_string()]
-            }],
-        );
+        assert_eq!(failed.len(), 1);
+        assert!(failed.contains_key(&PartitionKey::Single {
+            keys: vec!["b".to_string()]
+        }));
     }
 
     #[tokio::test]
@@ -8618,7 +8615,8 @@ mod tests {
             .get_failed_partitions(DEFAULT_CODE_LOCATION_ID, "asset", &materialized)
             .await
             .unwrap();
-        assert_eq!(failed, vec![single("c")], "only c (latest event = failure)");
+        assert_eq!(failed.len(), 1, "only c (latest event = failure)");
+        assert!(failed.contains_key(&single("c")));
     }
 
     #[tokio::test]
@@ -8684,12 +8682,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            failed,
-            vec![PartitionKey::Single {
-                keys: vec!["b".to_string()]
-            }],
+            failed.len(),
+            1,
             "only the per-partition failure; None-keyed step-level failure must be excluded"
         );
+        assert!(failed.contains_key(&PartitionKey::Single {
+            keys: vec!["b".to_string()]
+        }));
     }
 
     #[tokio::test]
@@ -8742,7 +8741,7 @@ mod tests {
             .await
             .unwrap();
         let mut keys: Vec<String> = failed
-            .iter()
+            .keys()
             .map(|pk| match pk {
                 PartitionKey::Single { keys } => keys[0].clone(),
                 _ => panic!("expected Single after expansion"),


### PR DESCRIPTION
# Description
**Dep-updated staleness floor**
- Compare each dep key against its **mapped downstream** key, not a same-named one
- A failed attempt raises the floor, so a failing partition stops re-dispatching every tick
- Compare staleness instead of fire-time baselines (immune to async event-drain double-fires)
- Partitioned root over an **unpartitioned** dep floors on the oldest partition, not the across-partition max
- `AllPartitions` ignores never-built frontier keys instead of rebroadcasting the whole universe
- A bare `newly_updated()` no longer re-fires an up-to-date asset on daemon restart

**Partition-mapping validation** (downstream grid must be a subgrid of upstream)
- Subgrid probe stops at the downstream's explicit end and always checks the first two ticks, even for sparse grids
- Reject sub-second cron probe times
- route `dynamic()` and duplicate `Multi` dimension names through one validator

**Failure-floor bookkeeping**
- A co-batched older success can't clobber a newer failure.
- A failed joint run only floors the steps that actually failed, not every asset it named.

**Classify / dispatch**
- Only assets that actually dispatch get pre-marked in-progress / advance their handled cursor (no _phantom_ selections wedging an asset).