### PR TITLE
fix(conditions): clear in-progress per run, not per asset

### DIFF
--- a/python/tests/backfill/test_daemon_backfill.py
+++ b/python/tests/backfill/test_daemon_backfill.py
@@ -454,9 +454,16 @@ class TestDaemonConditionBackfill:
             dst_runs = [r for r in storage.get_runs(limit=100) if "dst" in r.node_names]
             successful = [r for r in dst_runs if r.status == "Success"]
 
-            # Should be exactly 3, not 5
+            # Exactly partitions a, b, c materialize downstream, once each:
+            # !AnyDepsMissing excludes d/e (no upstream `src`), and a finished
+            # backfill partition must not re-fire its still-running siblings.
+            assert len(dst_runs) == 3, (
+                f"expected exactly 3 downstream runs (one per upstream partition), "
+                f"got {len(dst_runs)}: "
+                f"{[(r.partition_key.key[0], r.status) for r in dst_runs]}"
+            )
             assert len(successful) == 3, (
-                f"Expected 3 successful downstream runs (matching upstream), "
+                f"expected 3 successful downstream runs (matching upstream), "
                 f"got {len(successful)} successful out of {len(dst_runs)} total"
             )
         finally:

--- a/rust/rivers-core/src/condition/cache.rs
+++ b/rust/rivers-core/src/condition/cache.rs
@@ -85,15 +85,18 @@ pub struct PendingRun {
 /// minutes.
 pub const DEFAULT_PENDING_GRACE_NANOS: i64 = 60 * 1_000_000_000;
 
-/// One mutation to `in_progress_assets`. Stored in order so the apply phase
-/// can replay e.g. "push run R1 to asset A, then clear A entirely" exactly
-/// the way the in-place refresh did before the Plan/Apply split.
+/// One mutation to `in_progress_assets`, applied in order.
 enum InProgressChange {
     Push {
         asset_key: String,
         run_id: String,
     },
-    /// Remove all run_ids for this asset.
+    /// Drop one completed run, removing the asset entry when its last run
+    /// clears. Run completions use this so a backfill's still-running
+    /// partitions stay gated when a sibling finishes.
+    ClearRun { asset_key: String, run_id: String },
+    /// Drop all of an asset's runs. Only the external-observation path
+    /// (no owning run_id) uses this.
     AssetClear(String),
 }
 
@@ -413,10 +416,35 @@ impl AssetConditionCache {
                 }
             }
             for key in &completed_keys {
-                delta
-                    .in_progress_changes
-                    .push(InProgressChange::AssetClear(key.clone()));
                 invalidated_keys.push(key.clone());
+            }
+
+            // Clear per run, not per asset. A backfill registers one run per
+            // partition; evicting the whole asset when the first finishes
+            // reopens the dispatch gate for its still-running siblings and
+            // re-fires them as duplicate runs. Re-read the completed assets'
+            // runs and clear only the terminal ones — in-flight runs stay.
+            let clearable: Vec<String> = completed_keys
+                .iter()
+                .filter_map(|k| self.in_progress_assets.get(k))
+                .flatten()
+                .cloned()
+                .collect();
+            if !clearable.is_empty() {
+                let tracked_runs = storage.get_runs_by_ids(&clearable, None).await?;
+                for run in &tracked_runs {
+                    if matches!(run.status, RunStatus::Started | RunStatus::NotStarted) {
+                        continue;
+                    }
+                    for asset in &run.node_names {
+                        if self.in_progress_assets.contains_key(asset) {
+                            delta.in_progress_changes.push(InProgressChange::ClearRun {
+                                asset_key: asset.clone(),
+                                run_id: run.run_id.clone(),
+                            });
+                        }
+                    }
+                }
             }
 
             // `get_runs_since` uses `>`, so a run only ever seen as Started
@@ -460,17 +488,19 @@ impl AssetConditionCache {
                     }
                     RunStatus::Success | RunStatus::Failure => {
                         for asset in &run.node_names {
-                            delta
-                                .in_progress_changes
-                                .push(InProgressChange::AssetClear(asset.clone()));
+                            delta.in_progress_changes.push(InProgressChange::ClearRun {
+                                asset_key: asset.clone(),
+                                run_id: run.run_id.clone(),
+                            });
                         }
                         self.apply_run_effects_to_delta(run, &mut delta);
                     }
                     RunStatus::Canceled => {
                         for asset in &run.node_names {
-                            delta
-                                .in_progress_changes
-                                .push(InProgressChange::AssetClear(asset.clone()));
+                            delta.in_progress_changes.push(InProgressChange::ClearRun {
+                                asset_key: asset.clone(),
+                                run_id: run.run_id.clone(),
+                            });
                         }
                     }
                     RunStatus::Queued => {
@@ -577,8 +607,8 @@ impl AssetConditionCache {
 
     /// Plan-phase helper: append the run-derived mutations (failure flag,
     /// run/tick tag updates, asset_names updates) for a completed
-    /// Success/Failure run into `delta`. Caller is responsible for emitting
-    /// any `InProgressChange::AssetClear` separately.
+    /// Success/Failure run into `delta`. Caller is responsible for emitting the
+    /// matching `InProgressChange::ClearRun` separately.
     fn apply_run_effects_to_delta(&self, run: &RunRecord, delta: &mut RefreshDelta) {
         let run_asset_names: Arc<[String]> = Arc::from(run.node_names.as_slice());
         let run_tags: Arc<[(String, String)]> = Arc::from(run.tags.as_slice());
@@ -781,10 +811,8 @@ impl AssetConditionCache {
             self.records.insert(record.asset_key.clone(), record);
         }
 
-        // Apply in-progress changes IN ORDER — the per-run loop in fetch
-        // emits e.g. Push then AssetClear when the same asset has both a
-        // newly-Started run and a freshly-completed older run; iterating in
-        // order preserves the pre-refactor semantics.
+        // Apply in order: fetch can emit Push then ClearRun for one asset (a
+        // newly-Started run alongside a freshly-completed one); order keeps both.
         for change in in_progress_changes {
             match change {
                 InProgressChange::Push { asset_key, run_id } => {
@@ -792,6 +820,14 @@ impl AssetConditionCache {
                         .entry(asset_key)
                         .or_default()
                         .push(run_id);
+                }
+                InProgressChange::ClearRun { asset_key, run_id } => {
+                    if let Some(run_ids) = self.in_progress_assets.get_mut(&asset_key) {
+                        run_ids.retain(|id| id != &run_id);
+                        if run_ids.is_empty() {
+                            self.in_progress_assets.remove(&asset_key);
+                        }
+                    }
                 }
                 InProgressChange::AssetClear(asset_key) => {
                     self.in_progress_assets.remove(asset_key.as_str());

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -6474,6 +6474,111 @@ async fn test_cache_detects_in_progress_completion_as_change() {
 }
 
 #[tokio::test]
+async fn test_cache_keeps_sibling_backfill_runs_in_progress_on_partial_completion() {
+    // Regression: a backfill registers one run per partition, all on the same
+    // asset. When the first run completes, refresh must clear only that run —
+    // wiping the whole asset reopens the dispatch gate for the still-running
+    // siblings, re-firing them as duplicate runs (the flaky "expected 3, got 4
+    // successful runs").
+
+    use crate::storage::surrealdb_backend::SurrealStorage;
+    use crate::storage::{
+        DEFAULT_CODE_LOCATION_ID, EventRecord, EventType, PartitionKey, RunRecord, RunStatus,
+        StorageBackend,
+    };
+
+    let storage = SurrealStorage::new_memory().await.unwrap();
+    let ctx = crate::storage::CodeLocationContext::new(DEFAULT_CODE_LOCATION_ID);
+
+    // Downstream asset with a baseline materialization.
+    storage
+        .for_code_location(&ctx)
+        .register_assets(&[make_materialized_record("dst", 1000)])
+        .await
+        .unwrap();
+
+    let mut cache = AssetConditionCache::new(DEFAULT_CODE_LOCATION_ID.to_string());
+    cache.refresh(&storage, 0).await.unwrap();
+    assert!(
+        cache.in_progress_assets.is_empty(),
+        "baseline: nothing in flight"
+    );
+
+    // Backfill dispatch: one Started run per partition (a, b, c), all on `dst`.
+    let part = |k: &str| PartitionKey::Single {
+        keys: vec![k.to_string()],
+    };
+    let mk_run = |id: &str, k: &str| RunRecord {
+        run_id: id.to_string(),
+        code_location_id: DEFAULT_CODE_LOCATION_ID.to_string(),
+        job_name: Some("backfill".to_string()),
+        status: RunStatus::Started,
+        start_time: 2000,
+        end_time: None,
+        tags: vec![],
+        node_names: vec!["dst".to_string()],
+        priority: 0,
+        partition_key: Some(part(k)),
+        block_reason: None,
+        launched_by: LaunchedBy::Manual,
+    };
+    storage
+        .create_runs(&[mk_run("run_a", "a"), mk_run("run_b", "b"), mk_run("run_c", "c")])
+        .await
+        .unwrap();
+
+    // Tick 1: all three observed Started → tracked under `dst`.
+    cache.refresh(&storage, 0).await.unwrap();
+    let tracked = cache
+        .in_progress_assets
+        .get("dst")
+        .expect("dst should be in-progress after dispatch");
+    assert_eq!(tracked.len(), 3, "all three backfill runs are tracked");
+
+    // Partition a finishes: its run flips to Success and its materialization
+    // lands (advancing `dst`'s asset-record timestamp).
+    storage
+        .update_run_status("run_a", RunStatus::Success, Some(3000))
+        .await
+        .unwrap();
+    storage
+        .store_events(&[EventRecord {
+            code_location_id: DEFAULT_CODE_LOCATION_ID.to_string(),
+            event_type: EventType::Materialization {
+                data_version: Some("dv_a".to_string()),
+            },
+            asset_key: Some("dst".to_string()),
+            run_id: "run_a".to_string(),
+            partition_key: Some(part("a")),
+            timestamp: 3000,
+            metadata: vec![],
+            input_data_versions: vec![],
+        }])
+        .await
+        .unwrap();
+
+    // Tick 2: a's completion is detected. Only run_a may clear — b and c are
+    // still running, so `dst` must stay gated against re-dispatch.
+    cache.refresh(&storage, 0).await.unwrap();
+    let tracked = cache
+        .in_progress_assets
+        .get("dst")
+        .expect("dst must stay in-progress while runs b and c are still running");
+    assert!(
+        !tracked.contains(&"run_a".to_string()),
+        "the completed run a should be cleared"
+    );
+    assert!(
+        tracked.contains(&"run_b".to_string()),
+        "still-running run b must stay tracked"
+    );
+    assert!(
+        tracked.contains(&"run_c".to_string()),
+        "still-running run c must stay tracked"
+    );
+}
+
+#[tokio::test]
 async fn test_cache_clears_in_progress_when_run_succeeds_but_timestamp_unchanged() {
     // Root cause of flaky test_schedule_chain_three_layers.
     //


### PR DESCRIPTION
A completed backfill partition cleared the whole asset from in_progress_assets, reopening the dispatch gate and re-firing its still-running siblings as duplicate runs

# Description

The description of the main changes of your pull request

## Related Issue(s)
<!---
For example:

- closes #106
--->

## Documentation

<!---
Share links to useful documentation
--->
