### PR TITLE
chore: Add pyright warn for unused functions and variables

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -48,6 +48,8 @@ markers = [
 
 [tool.pyright]
 exclude = ["**/tests"]
+reportUnusedFunction = "warning"
+reportUnusedVariable = "warning"
 
 [build-system]
 requires = ["maturin>=1,<2"]


### PR DESCRIPTION
# Description

This PR adds pyright warnings for unused functions and variables, so devs are able to take action accordingly while making code changes on local.

## Related Issue(s)
<!---
For example:

- closes #106
--->
- closes #88

## Documentation

<!---
Share links to useful documentation
--->
Context for this is in #88 and [PR #87 comments](https://github.com/ion-elgreco/rivers/pull/87#issuecomment-4709584778).