### PR TITLE
fix(conditions): validate cron schedules at construction

### DIFF
--- a/python/rivers/_core/automation/__init__.pyi
+++ b/python/rivers/_core/automation/__init__.pyi
@@ -50,6 +50,9 @@ class AutomationCondition:
         Args:
             cron_schedule: Cron expression (e.g. ``"0 * * * *"``).
             timezone: Optional timezone name (e.g. ``"US/Eastern"``).
+
+        Raises:
+            ValueError: If ``cron_schedule`` is not a valid cron expression.
         """
         ...
     @staticmethod
@@ -96,6 +99,9 @@ class AutomationCondition:
         Args:
             cron_schedule: Cron expression.
             timezone: Optional timezone name.
+
+        Raises:
+            ValueError: If ``cron_schedule`` is not a valid cron expression.
         """
         ...
     @staticmethod
@@ -239,6 +245,9 @@ class AutomationCondition:
         Args:
             cron_schedule: Cron expression.
             timezone: Optional timezone name.
+
+        Raises:
+            ValueError: If ``cron_schedule`` is not a valid cron expression.
         """
         ...
     def on_selected(

--- a/python/src/automation/condition.rs
+++ b/python/src/automation/condition.rs
@@ -3,6 +3,13 @@ use pyo3::prelude::*;
 
 pub use rivers_core::condition::ConditionNode;
 
+/// Reject an invalid cron schedule at construction, not at eval time.
+fn validate_cron_schedule(schedule: &str) -> PyResult<()> {
+    rivers_core::condition::validate_cron(schedule).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("invalid cron schedule {schedule:?}: {e}"))
+    })
+}
+
 /// Human-readable description of a condition node (for Python display).
 pub(crate) fn description(node: &ConditionNode) -> String {
     match node {
@@ -147,16 +154,17 @@ impl PyAutomationCondition {
     /// Cron-based automation: run on cron ticks.
     #[staticmethod]
     #[pyo3(signature = (cron_schedule, timezone=None))]
-    fn on_cron(cron_schedule: String, timezone: Option<String>) -> Self {
+    fn on_cron(cron_schedule: String, timezone: Option<String>) -> PyResult<Self> {
+        validate_cron_schedule(&cron_schedule)?;
         let label = if let Some(ref tz) = timezone {
             format!("on_cron('{}', tz='{}')", cron_schedule, tz)
         } else {
             format!("on_cron('{}')", cron_schedule)
         };
-        Self {
+        Ok(Self {
             node: ConditionNode::on_cron(cron_schedule, timezone),
             label: Some(label),
-        }
+        })
     }
 
     /// Only run when asset becomes missing; skips failed partitions.
@@ -207,11 +215,12 @@ impl PyAutomationCondition {
     /// True when a cron tick just passed.
     #[staticmethod]
     #[pyo3(signature = (cron_schedule, timezone=None))]
-    fn cron_tick_passed(cron_schedule: String, timezone: Option<String>) -> Self {
-        Self::new_node(ConditionNode::CronTickPassed {
+    fn cron_tick_passed(cron_schedule: String, timezone: Option<String>) -> PyResult<Self> {
+        validate_cron_schedule(&cron_schedule)?;
+        Ok(Self::new_node(ConditionNode::CronTickPassed {
             cron_schedule,
             timezone,
-        })
+        }))
     }
 
     /// True when the partition is in the latest time window.
@@ -348,11 +357,15 @@ impl PyAutomationCondition {
     /// True when all deps have been updated since the last tick of the given cron schedule.
     #[staticmethod]
     #[pyo3(signature = (cron_schedule, timezone=None))]
-    fn all_deps_updated_since_cron(cron_schedule: String, timezone: Option<String>) -> Self {
-        Self::new_node(ConditionNode::all_deps_updated_since_cron(
+    fn all_deps_updated_since_cron(
+        cron_schedule: String,
+        timezone: Option<String>,
+    ) -> PyResult<Self> {
+        validate_cron_schedule(&cron_schedule)?;
+        Ok(Self::new_node(ConditionNode::all_deps_updated_since_cron(
             cron_schedule,
             timezone,
-        ))
+        )))
     }
 
     /// Evaluate this condition on specific named assets (true if any match).

--- a/python/tests/daemon/test_automation.py
+++ b/python/tests/daemon/test_automation.py
@@ -270,6 +270,27 @@ class TestRepr:
 
 
 # ---------------------------------------------------------------------------
+# Cron validation
+# ---------------------------------------------------------------------------
+
+
+class TestCronValidation:
+    def test_cron_tick_passed_rejects_invalid_schedule(self):
+        with pytest.raises(ValueError):
+            rs.AutomationCondition.cron_tick_passed("this is not a cron")
+
+    def test_on_cron_rejects_invalid_schedule(self):
+        with pytest.raises(ValueError):
+            rs.AutomationCondition.on_cron("totally bogus")
+
+    def test_valid_schedules_accepted(self):
+        # Standard 5-field and 6-field (optional seconds) both parse.
+        rs.AutomationCondition.cron_tick_passed("0 0 * * *")
+        rs.AutomationCondition.on_cron("*/15 * * * *")
+        rs.AutomationCondition.on_cron("0 0 0 * * *")
+
+
+# ---------------------------------------------------------------------------
 # Asset integration
 # ---------------------------------------------------------------------------
 

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -754,6 +754,20 @@ fn eval_new_update_tags_partitioned(
 /// Check if a cron tick occurred between `prev_nanos` and `now_nanos`.
 /// Caches parsed cron expressions in a thread-local to avoid re-parsing
 /// the same schedule string on every eval.
+/// Parse a cron schedule (seconds optional) — the one place the syntax is defined.
+fn build_cron(schedule: &str) -> Result<croner::Cron, String> {
+    croner::parser::CronParser::builder()
+        .seconds(croner::parser::Seconds::Optional)
+        .build()
+        .parse(schedule)
+        .map_err(|e| e.to_string())
+}
+
+/// Validate a cron schedule at construction so bad input is rejected up front.
+pub fn validate_cron(schedule: &str) -> Result<(), String> {
+    build_cron(schedule).map(|_| ())
+}
+
 fn cron_tick_between(cron_schedule: &str, prev_nanos: i64, now_nanos: i64) -> bool {
     use std::cell::RefCell;
 
@@ -767,11 +781,8 @@ fn cron_tick_between(cron_schedule: &str, prev_nanos: i64, now_nanos: i64) -> bo
     CRON_CACHE.with(|cache| {
         let mut cache = cache.borrow_mut();
         let cron = cache.entry(cron_schedule.to_string()).or_insert_with(|| {
-            croner::parser::CronParser::builder()
-                .seconds(croner::parser::Seconds::Optional)
-                .build()
-                .parse(cron_schedule)
-                .expect("invalid cron schedule")
+            // Validated at construction, so a parse error here is a bug.
+            build_cron(cron_schedule).expect("cron schedule validated at construction")
         });
         let prev_dt = chrono::DateTime::from_timestamp(prev_secs, 0);
         let now_dt = chrono::DateTime::from_timestamp(now_secs, 0);


### PR DESCRIPTION
The cron constructors now raise ValueError on an un-parseable schedule instead of letting it panic the daemon tick at evaluation time