### PR TITLE
fix(conditions): guard partitioned newly_updated self re-fire on daemon restart

### DIFF
--- a/python/tests/daemon/test_condition_eval_integration.py
+++ b/python/tests/daemon/test_condition_eval_integration.py
@@ -1292,3 +1292,66 @@ class TestSameTickCascading:
                 )
         finally:
             daemon.stop()
+
+
+class TestPartitionedNewlyUpdatedRefire:
+    def test_no_refire_of_preexisting_partition_on_fresh_start(self, storage):
+        """A partitioned ``newly_updated()`` condition must not re-dispatch a
+        partition that was already materialized before the condition daemon's
+        evaluation state existed.
+
+        A prior run (backfill/manual) materializes the partition, then the daemon
+        starts with a fresh evaluation state — a restart or redeploy. On that
+        initial tick the partition has a materialization timestamp but no
+        previous baseline; without the ``is_initial`` guard it is misread as
+        "newly updated" and re-dispatched every tick.
+        """
+        pd = rs.PartitionsDefinition.static_(["p1", "p2"])
+
+        @rs.Asset(
+            name="a",
+            io_handler=rs.InMemoryIOHandler(),
+            partitions_def=pd,
+            automation_condition=rs.AutomationCondition.newly_updated(),
+        )
+        def a() -> str:
+            return "x"
+
+        repo = rs.CodeRepository(
+            assets=[a],
+            default_executor=rs.Executor.in_process(),
+        )
+        repo.resolve(storage=storage)
+
+        pk = rs.PartitionKey.single("p1")
+
+        # A prior run materialized p1 before the condition daemon ever evaluated.
+        repo.materialize(selection=["a"], partition_key=pk)
+        assert storage.get_latest_materialization("a", "p1") is not None, (
+            "precondition: p1 must be materialized before the daemon starts"
+        )
+
+        def _p1_runs():
+            return [r for r in storage.get_runs(limit=500) if r.partition_key == pk]
+
+        baseline = len(_p1_runs())
+
+        # Start the condition daemon with a fresh evaluation state (the restart).
+        daemon = AutomationDaemon(
+            repo=repo,
+            storage=storage,
+            condition_eval_interval="300ms",
+        )
+        daemon.start()
+        try:
+            # Several initial ticks — long enough for the buggy path to
+            # re-dispatch (and the in-process run to land).
+            time.sleep(4.0)
+        finally:
+            daemon.stop()
+
+        after = len(_p1_runs())
+        assert after == baseline, (
+            "condition daemon re-dispatched an already-materialized partition on "
+            f"a fresh start: {baseline} -> {after} runs for p1"
+        )

--- a/rust/rivers-core/src/condition/eval.rs
+++ b/rust/rivers-core/src/condition/eval.rs
@@ -928,7 +928,10 @@ fn eval_partitioned<O: PartEvalOutput>(
                     },
                     None => match prev_timestamps.and_then(|pt| pt.get(pk)) {
                         Some(&prev) => ts > prev,
-                        None => true, // newly appeared partition
+                        // No baseline on the initial tick = materialized before
+                        // startup, not new (suppress); later = appeared between
+                        // ticks (fire). Mirrors the unpartitioned arm.
+                        None => !ctx.is_initial,
                     },
                 })
                 .map(|(pk, _)| pk.clone())

--- a/rust/rivers-core/src/condition/tests.rs
+++ b/rust/rivers-core/src/condition/tests.rs
@@ -7556,6 +7556,57 @@ fn test_partitioned_newly_updated() {
 }
 
 #[test]
+fn test_partitioned_newly_updated_suppressed_on_initial_tick() {
+    // On the very first tick (is_initial=true), partitions already materialized
+    // before the daemon started have no previous baseline and must NOT count as
+    // newly updated — mirror of the unpartitioned guard. Otherwise a bare
+    // newly_updated() re-fires every materialized partition on every restart.
+    let record = make_materialized_record("a", 200);
+    let records = HashMap::from([("a".into(), record.clone())]);
+    let deps = HashMap::new();
+    let pdata = OwnedPartitionData::new(&["p1", "p2"], &["p1", "p2"], &[("p1", 100), ("p2", 200)]);
+    let prev = AssetConditionState::default(); // no partition_state → no baselines
+    let pctx = pdata.as_eval_ctx();
+    let mut ctx = EvalContext {
+        target_key: "a",
+        root_key: "a",
+        target_record: &record,
+        cache: CacheSnapshot {
+            records: &records,
+            upstream_deps: &deps,
+            in_progress_assets: &EMPTY_SET,
+            failed_assets: &EMPTY_SET,
+            failed_asset_timestamps: &EMPTY_FAILED_TS,
+            backfill: &EMPTY_BACKFILL,
+        },
+        tags: empty_tag_snapshot(),
+        prev_state: &prev,
+        all_asset_states: &EMPTY_ASSET_STATES,
+        requested_this_tick: &EMPTY_REQUESTED,
+        now: 1_000_000_000_000,
+        is_initial: true,
+        partitions: Some(&pctx),
+        root_partition_floor: None,
+    };
+
+    let result = evaluate(&ConditionNode::NewlyUpdated, &ctx);
+    assert!(
+        !result.fired,
+        "initial tick: pre-existing partitions must not be newly updated, got {:?}",
+        result.selection
+    );
+
+    // Boundary: on a non-initial tick the same baseline-less partitions are
+    // genuinely new (appeared between ticks) and DO fire.
+    ctx.is_initial = false;
+    let result2 = evaluate(&ConditionNode::NewlyUpdated, &ctx);
+    assert!(
+        result2.fired,
+        "non-initial tick: baseline-less partitions appeared between ticks and should fire"
+    );
+}
+
+#[test]
 fn test_partitioned_and() {
     // And(Missing, Not(InProgress))
     // 3 partitions: p1 materialized, p2 missing, p3 missing+in_progress


### PR DESCRIPTION
Mirrors the unpartitioned is_initial guard so partitions materialized before daemon start aren't re-materialized on every restart