### PR TITLE
fix: write RunLaunchFailed event before flipping run status

### DIFF
--- a/python/src/daemon/subdaemons.rs
+++ b/python/src/daemon/subdaemons.rs
@@ -295,18 +295,8 @@ pub(crate) async fn fail_unlaunched_run(
     run_id: &str,
     error: &str,
 ) {
-    if let Err(e) = storage
-        .update_run_status(run_id, RunStatus::Failure, Some(now_ts()))
-        .await
-    {
-        tracing::error!(
-            target: "rivers::coordinator",
-            run_id = %run_id,
-            error = %e,
-            "failed to fail-out an unlaunched run; it will read as in-flight until the next sweep"
-        );
-        return;
-    }
+    // Event first: the terminal status is what readers poll on, so writing it
+    // last means anyone who sees `Failure` already sees the reason.
     if let Err(e) = storage
         .store_event(&EventRecord {
             code_location_id: code_location_id.to_string(),
@@ -325,6 +315,17 @@ pub(crate) async fn fail_unlaunched_run(
             run_id = %run_id,
             error = %e,
             "failed to persist RunLaunchFailed event"
+        );
+    }
+    if let Err(e) = storage
+        .update_run_status(run_id, RunStatus::Failure, Some(now_ts()))
+        .await
+    {
+        tracing::error!(
+            target: "rivers::coordinator",
+            run_id = %run_id,
+            error = %e,
+            "failed to fail-out an unlaunched run; it will read as in-flight until the next sweep"
         );
     }
 }

--- a/python/tests/grpc_api/test_grpc_server.py
+++ b/python/tests/grpc_api/test_grpc_server.py
@@ -217,7 +217,8 @@ def test_materialize_launch_failure_records_reason(no_handler_grpc_channel):
 
     The run status alone tells the UI "failed" but not why — without an event
     the run detail renders an empty timeline and the error only ever reaches
-    the terminal (issue #52).
+    the terminal (issue #52). The reason has to be committed *before* the
+    status flips, or a reader polling on status sees an empty timeline.
     """
     channel, pb2, pb2_grpc, _repo, storage = no_handler_grpc_channel
     stub = pb2_grpc.CodeLocationServiceStub(channel)
@@ -237,6 +238,8 @@ def test_materialize_launch_failure_records_reason(no_handler_grpc_channel):
     events = storage.get_events_for_run(run_id)
     launch_failed = [e for e in events if e.event_type == "RunLaunchFailed"]
     assert len(launch_failed) == 1, f"expected a RunLaunchFailed event, got {events}"
+
+    assert launch_failed[0].timestamp <= run.end_time
 
     error = dict(launch_failed[0].metadata).get("error", "")
     # The reason the terminal printed has to be the reason the UI can read.


### PR DESCRIPTION
Changes the order of event submission